### PR TITLE
Add proof of concept for always-on Play kiosk

### DIFF
--- a/system/modules/play/default.nix
+++ b/system/modules/play/default.nix
@@ -38,10 +38,15 @@
     };
 
     displayManager = {
-      # Automatically log in play user
-      auto = {
+      # Always automatically log in play user
+      lightdm = {
         enable = true;
-        user = "play";
+        greeter.enable = false;
+        autoLogin = {
+          enable = true;
+          user = "play";
+          timeout = 0;
+        };
       };
     };
   };


### PR DESCRIPTION
- Fix `play` user
- Implement two alternative options for kiosk
  - Launched and kept running on top of a basic user session by systemd user service
  - Launched directly in place of desktop manager and causing a logout when closed