### PR TITLE
Fix WebGL support in kiosk

### DIFF
--- a/kiosk/default.nix
+++ b/kiosk/default.nix
@@ -34,5 +34,6 @@ python3Packages.buildPythonApplication rec {
 
   makeWrapperArgs = [
       "--set QT_QPA_PLATFORM_PLUGIN_PATH ${qtbase.bin}/lib/qt-*/plugins/platforms"
+      "--set QT_PLUGIN_PATH ${qtbase.bin}/lib/qt-*/plugins"
   ];
 }


### PR DESCRIPTION
Setting only the platform plugin path leads to all plugins being looked up in the `platforms/` subfolder, breaking WebGL support.