### PR TITLE
Add full support for semver versioning in updater

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# [Unreleased]
+
+## Changed
+
+- updater: Support SemVer 2.0 versioning, respecting pre-release identifiers
+
 # [2019.4.0] - 2019-04-03
 
 First stable release on master channel.

--- a/controller/nix/ocaml-modules/obus/default.nix
+++ b/controller/nix/ocaml-modules/obus/default.nix
@@ -20,7 +20,7 @@ buildDunePackage rec {
     [ camlp4 ocaml-migrate-parsetree ppx_metaquot ppx_tools_versioned ocaml_lwt lwt_react lwt_ppx lwt_log react type_conv xmlm ];
 
   meta = {
-    homepage = https://github.com/pukkamustard/obus;
+    homepage = https://github.com/dividat/obus;
     description = "Pure OCaml implementation of the D-Bus protocol";
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ ];

--- a/controller/nix/ocaml-modules/semver/default.nix
+++ b/controller/nix/ocaml-modules/semver/default.nix
@@ -1,16 +1,26 @@
-{buildOcaml, fetchFromGitHub}:
-buildOcaml rec {
-  name= "semver";
+{buildDunePackage, fetchFromGitHub, angstrom, ppxlib, ppx_inline_test, ocaml, stdenv}:
+buildDunePackage rec {
+  pname= "semver";
   version = "0.1.0";
 
-  minimumOCamlVersion = "4.02";
+  minimumOCamlVersion = "4.04";
 
   src = fetchFromGitHub {
-    owner = "rgrinberg";
+    owner = "dividat";
     repo = "ocaml-semver";
-    rev = "905c063a84935765f21fcc632c28a35dbc3b3e3d";
-    sha256 = "0f8id2pxn2k6bfnnp5w2s9k37wsf457q6im7il815fg9ajwxw76h";
+    rev = "ea51d2f6a60a6203978f9b10ffb3acf7a4178ef1";
+    sha256 = "0i3k1m7cr8gzajwvi7yaikdfzwl122wgqy2wic9404dwffppxaqz";
   };
 
+  buildInputs = [ ];
+  propagatedBuildInputs = [ angstrom ppxlib ppx_inline_test ];
+
+  meta = {
+    description = " Semantic version handling for OCaml.";
+    license = stdenv.lib.licenses.mit;
+    homepage = "https://github.com/dividat/ocaml-semver";
+    maintainers = [ ];
+    inherit (ocaml.meta) platforms;
+  };
 
 }

--- a/controller/server/update.ml
+++ b/controller/server/update.ml
@@ -1,36 +1,37 @@
 open Lwt
 open Sexplib.Std
+open Sexplib.Conv
 
 let log_src = Logs.Src.create "update"
 
 
 (* Version handling *)
 
-(* Compatible with Semver.t but also deriving sexp *)
-type semver = int * int * int [@@deriving sexp]
 
 (** Type containing version information *)
 type version_info =
   {(* the latest available version *)
-    latest : semver * string
+    latest : Semver.t sexp_opaque * string
 
   (* version of currently booted system *)
-  ; booted : semver * string
+  ; booted : Semver.t sexp_opaque * string
 
   (* version of inactive system *)
-  ; inactive : semver * string
+  ; inactive : Semver.t sexp_opaque * string
   }
 [@@deriving sexp]
 
 
 (** Helper to parse semver from string or fail *)
 let semver_of_string string =
-  match Semver.of_string string with
+  let trimmed_string = String.trim string
+  in
+  match Semver.of_string trimmed_string with
   | None ->
     failwith
       (Format.sprintf "could not parse version (version string: %s)" string)
   | Some version ->
-    version, string |> String.trim
+    version, trimmed_string
 
 (** Get latest version available at [url] *)
 let get_latest_version url =

--- a/controller/server/update.mli
+++ b/controller/server/update.mli
@@ -1,21 +1,14 @@
-(* Compatible with Semver.t but also deriving sexp *)
-type semver = int * int * int [@@deriving sexp]
-
 (** Type containing version information.
-
-    Versions are encoded with Semver decoding and a string representation. This is because the Semver library ignores pre-release and build meta-data.
-    TODO: improve Semver library (see https://github.com/rgrinberg/ocaml-semver/issues/1)
-
 *)
 type version_info =
   {(* the latest available version *)
-    latest : semver * string
+    latest : Semver.t * string
 
   (* version of currently booted system *)
-  ; booted : semver * string
+  ; booted : Semver.t * string
 
   (* version of inactive system *)
-  ; inactive : semver * string
+  ; inactive : Semver.t * string
   }
 [@@deriving sexp]
 


### PR DESCRIPTION
Switch to dividat/ocaml-semver which provides proper support for pre-release and build identifiers.

This means no more bumping of patch level version for release candidates.

- [x] Test full update flow on `develop` channel