### PR TITLE
Enable connman online check for service selection

### DIFF
--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -23,8 +23,8 @@
         # Allow simultaneous connection to ethernet and wifi
         SingleConnectedTechnology=false
 
-        # Disable calling home
-        EnableOnlineCheck=false
+        # Enable online check to favour connected services
+        EnableOnlineCheck=true
       '';
     };
     # Issue 1: Add a dummy network to make sure wpa_supplicant.conf


### PR DESCRIPTION
Enabling connman's online check much improves connman's ability to select the service to use for the default route (Internet access).

This is important for selecting the right service within the same technology (double Ethernet), where otherwise no natural hierarchy exists.

Compare the outcome of the following scenario with online check off vs on:

**Scenario:** PlayOS starts while only connected to the Senso, other Ethernet interface is unplugged or otherwise physically down. After startup, the Senso-bound interface is assigned a link-local address and assumes READY state in connman.

**Connecting Internet-bound interface WITH online check:** The second Ethernet interface comes up and is tested for online access. The test succeeds and the service assumes ONLINE state, causing it to be prioritized over the existing service in READY state.

**Connecting Internet-bound interface WITHOUT online check:** The second Ethernet interface comes up and assumes READY state. There is no reason to prioritize it over the existing service, which is also READY, and the default route is not changed.

We initially disabled the online check, seeing no concrete benefit and preferring to do an application-level online check instead. Clearly, there IS a concrete payoff to performing the check in the network
management level, as seen from the above.

Marcel Holtmann of Intel makes the following, sensible, argument as to why the online check is reasonably designed for privacy:

    If everybody uses the same service then it is fully anonymous since
    nobody can tell you apart from the other ConnMan on your network. If
    we start fragmenting, then this looses its anonymous status where
    everybody is equal.

https://lists.01.org/pipermail/connman/2015-July/020255.html
https://lists.01.org/pipermail/connman/2015-July/020254.html