### PR TITLE
Drop high dpi support

### DIFF
--- a/kiosk/kiosk_browser/__init__.py
+++ b/kiosk/kiosk_browser/__init__.py
@@ -6,10 +6,6 @@ from PyQt5.QtWidgets import QApplication
 
 from kiosk_browser import main_widget
 
-# Enable high dpi scaling, must be activated before the app is created.
-# https://doc.qt.io/qt-5/highdpi.html#high-dpi-support-in-qt
-QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
-
 def start(primary_url, secondary_url, toggle_sequence, fullscreen = True):
 
     app = QApplication(sys.argv)


### PR DESCRIPTION
Screens can be considered to be 160mm x 90mm as a default in case there
is something wrong. This is very small, and it then wrongly activates
scaling introduced by Qt high dpi scaling mode.

See https://bbs.archlinux.org/viewtopic.php?pid=1338379#p1338379