### PR TITLE
Clean connection state after a connection failure

### DIFF
--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -95,7 +95,7 @@ struct
     match input with
     | Passphrase p ->
       (match List.assoc_opt "Passphrase" fields with
-       | Some _ -> 
+       | Some _ ->
          return [ "Passphrase", p |> OBus_value.C.(make_single basic_string)]
        | None ->
          let%lwt () = Logs_lwt.err ~src:log_src
@@ -340,20 +340,21 @@ struct
     let%lwt () = Logs_lwt.debug ~src:log_src
         (fun m -> m "connect to service %s" service.id)
     in
+
     (* Create and register an agent that will pass input to ConnMan *)
     let%lwt agent_path, agent = Agent.create input in
     let%lwt () = register_agent service._manager agent_path in
 
-    (* Connect to service *)
-    let%lwt () =
+    begin
+      (* Connect to service *)
       OBus_method.call
         Connman_interfaces.Net_connman_Service.m_Connect
         service._proxy ()
-    in
-
-    (* Cleanup and destroy agent *)
-    let%lwt () = unregister_agent service._manager agent_path in
-    Agent.destroy agent
+    end
+    [%lwt.finally
+      (* Cleanup and destroy agent *)
+      let%lwt () = unregister_agent service._manager agent_path in
+      Agent.destroy agent]
 
   let disconnect service =
     let%lwt () = Logs_lwt.debug ~src:log_src


### PR DESCRIPTION
Previously, when an error happened during a connection, the agent was
not cleaned up. At the next connection attempt, an Already Existed error
was returned. A reboot of PlayOS was required to be able to connect to a
wifi network.

![2019-11-08_14-47-28](https://user-images.githubusercontent.com/6768842/68481295-1bbc3f00-0237-11ea-98c9-6188fe7cafec.gif)

The proposed change clean up the agent, no matters if the connection
succeeds or fail. It allows to reconnect without restarting PlayOS.

![2019-11-08_14-49-25](https://user-images.githubusercontent.com/6768842/68481304-2080f300-0237-11ea-9c23-5cc8ab289b9c.gif)