### PR TITLE
Show service strength alongside its name in networks

### DIFF
--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -328,6 +328,9 @@ struct
     ; "name", s.name |> Ezjsonm.string
     ; "favorite", s.favorite |> Ezjsonm.bool
     ; "connected", s |> is_connected |> Ezjsonm.bool
+    ; "strength", (match s.strength with
+      | Some s -> string_of_int s ^ "%"
+      | None -> "") |> Ezjsonm.string
     ; "properties", s |> sexp_of_t |> Sexplib.Sexp.to_string_hum |> Ezjsonm.string
     ]
 

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -58,10 +58,6 @@ dl > dt {
     margin: 10px;
 }
 
-.service-detail {
-    margin-left: 10px;
-}
-
 .info-icon {
     width: 200px;
 }
@@ -84,4 +80,15 @@ dl > dt {
     align-items: stretch;
 
     height: 90vh;
+}
+
+/* Network */
+
+.d-Network__ServiceDetail {
+    margin-left: 10px;
+}
+
+.d-Network__ServiceStrength {
+  color: #777777;
+  font-size: 80%;
 }

--- a/controller/gui/template/network.mustache
+++ b/controller/gui/template/network.mustache
@@ -11,8 +11,14 @@
 <h2>Services</h2>
 
 {{#services}}
-    <details class="service-details">
-        <summary>{{name}}</summary>
+    <details class="d-Network__ServiceDetail">
+        <summary>
+            {{name}}
+
+            <span class="d-Network__ServiceStrength">
+                {{strength}}
+            </span>
+        </summary>
 
         <pre>{{properties}}</pre>
 
@@ -34,4 +40,3 @@
 {{^services}}
     No services available.
 {{/services}}
-


### PR DESCRIPTION
The strength was already accessible in each service detail, but it was
too hidden to get this information at a glance.

When the strength of a network is too low, the user knows he will have
difficulties connecting to it. It can be a trigger for him to take
action to get a better strength if possible.

![2019-11-11_10-56-05](https://user-images.githubusercontent.com/6768842/68578395-34fcff80-0472-11ea-8f2c-3452f5bf5b4c.png)