### PR TITLE
Reload network page with a button

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # [UNRELEASED]
 
+## Added
+
+- controller: Add a refresh button in the network page
+- controller: Show network strengths in the network page
+
+## Fixed
+
+- controller: Allow subsequent connections after a connection error
+
 # [2019.9.0] - 2019-10-15
 
 # [2019.9.0-VALIDATION] - 2019-09-28

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -89,11 +89,11 @@ dl > dt {
 }
 
 .d-Network__ServiceStrength {
-  color: #777777;
-  font-size: 80%;
+    color: #777777;
+    font-size: 80%;
 }
 
-.d-Network__Reload {
+.d-Network__Refresh {
     display: inline-block;
     font-size: 1rem;
     text-decoration: none;
@@ -104,6 +104,6 @@ dl > dt {
     border: 0.15rem solid #DDDDDD;
 }
 
-.d-Network__Reload:hover {
+.d-Network__Refresh:hover {
     border-color: #888888;
 }

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -92,3 +92,18 @@ dl > dt {
   color: #777777;
   font-size: 80%;
 }
+
+.d-Network__Reload {
+    display: inline-block;
+    font-size: 1rem;
+    text-decoration: none;
+    padding: 0.4rem 0.8rem;
+    margin-bottom: 1rem;
+    color: black;
+    background-color: #DDDDDD;
+    border: 0.15rem solid #DDDDDD;
+}
+
+.d-Network__Reload:hover {
+    border-color: #888888;
+}

--- a/controller/gui/template/network.mustache
+++ b/controller/gui/template/network.mustache
@@ -1,6 +1,6 @@
 <h1>Network</h1>
 
-<a href="/network" class="d-Network__Reload">Reload</a>
+<a href="/network" class="d-Network__Refresh">Refresh</a>
 
 <dl>
     <dt>Internet</dt>

--- a/controller/gui/template/network.mustache
+++ b/controller/gui/template/network.mustache
@@ -1,5 +1,7 @@
 <h1>Network</h1>
 
+<a href="/network" class="d-Network__Reload">Reload</a>
+
 <dl>
     <dt>Internet</dt>
     <dd>


### PR DESCRIPTION
This allows the user to get a fresh network list when he clicks on the
reload button.

![2019-11-11_11-30-18](https://user-images.githubusercontent.com/6768842/68580459-b6569100-0476-11ea-8340-7ce3257ad9cc.gif)
