### PR TITLE
Prevent service does not exist error

### DIFF
--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -261,7 +261,7 @@ module NetworkGui = struct
   let merge_services old_services new_services =
     old_services
     |> List.filter
-      (fun (o:Service.t) -> List.exists (fun (n:Service.t) -> o.id == n.id) new_services)
+      (fun (o:Service.t) -> not (List.exists (fun (n:Service.t) -> o.id = n.id) new_services))
     |> List.append new_services
 
   (** Find a service by id.*)


### PR DESCRIPTION
The proposed solution store all fetched services in a variable.

Previously:

1. When the user asked for the network page, the server fetched services
and returned those inside the page.
2. Then, the user selected one service and tried to connect to it by
sending its id to the server.
3. Finally, the server re-fetched services and tried to find the service
the user wants to connect to by using its id.

The service can not be found in the newly fetched services.

With the proposed modification:

1. When the user ask for the network page, the server fetches services,
store the new ones with the old ones in a mutable list, and return the
new services inside the page.
2. Then, the user select one service and tries to connect to it by
sending its id to the server.
3. Then, the server tries to find the service in the list of stored
services.

Because every all the previous services have been stored, the server
should always find back the service the user wants to connect to.

### Checks

- [ ] Add changelog