### PR TITLE
Increase BBS scans expiration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 ## Fixed
 
 - controller: Allow subsequent connections after a connection error
+- controller: Stabilize WIFI connection scanning
 
 # [2019.9.0] - 2019-10-15
 

--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -33,12 +33,12 @@
       extraConfig = ''
         # BSS expiration age in seconds. A BSS will be removed from the local cache
         # if it is not in use and has not been seen for this time. Default is 180.
-        bss_expiration_age=180
+        bss_expiration_age=60
 
         # BSS expiration after number of scans. A BSS will be removed from the local
         # cache if it is not seen in this number of scans.
         # Default is 2.
-        bss_expiration_scan_count=16
+        bss_expiration_scan_count=1000
       '';
 
       # Issue 1: Add a dummy network to make sure wpa_supplicant.conf

--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -27,10 +27,22 @@
         EnableOnlineCheck=true
       '';
     };
-    # Issue 1: Add a dummy network to make sure wpa_supplicant.conf
-    # is created (see https://github.com/NixOS/nixpkgs/issues/23196)
     wireless = {
       enable = true;
+
+      extraConfig = ''
+        # BSS expiration age in seconds. A BSS will be removed from the local cache
+        # if it is not in use and has not been seen for this time. Default is 180.
+        bss_expiration_age=180
+
+        # BSS expiration after number of scans. A BSS will be removed from the local
+        # cache if it is not seen in this number of scans.
+        # Default is 2.
+        bss_expiration_scan_count=16
+      '';
+
+      # Issue 1: Add a dummy network to make sure wpa_supplicant.conf
+      # is created (see https://github.com/NixOS/nixpkgs/issues/23196)
       networks."12345-i-do-not-exist"= {
         extraConfig = ''
           disabled=1

--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -30,6 +30,9 @@
     wireless = {
       enable = true;
 
+      # Stabilize WIFI connection scanning by keeping any scanned WIFI for at
+      # least 1 minute. This intends to fix “Service not found” error when
+      # connecting to a network by id.
       extraConfig = ''
         # BSS expiration age in seconds. A BSS will be removed from the local cache
         # if it is not in use and has not been seen for this time. Default is 180.


### PR DESCRIPTION
This change aims to fix WIFI connection when there are lot of available
WIFI networks.

When loading the network page, the list of WIFI networks are sent to the
user. When he wants to connect to one of them, he sends the id of the
WIFI network he wants to connect to, then, the server fetchs the list of
WIFI networks again and tries to find the user one. But when there are
lot of WIFI networks available, only a subset of available WIFI networks
are returned at each scan. It’s possible that the network the user wants
to connect to is not returned this time.

By default, WIFI networks are discarded if they don’t appear in 2
consecutive scans, see [wpa_supplicant configuration documentation](
https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf). We
could increase the number of required succesive scan before abandoning a
network.

After shutting down a WIFI network, I measured the time it was displayed
in cmst, according to various count of BBS expirations.

- 2 [default]: 25 seconds
- 4: 34 seconds
- 8: 52 seconds
- 16: 1 minute 30 seconds

By requiring 16 consecutive scans before droppinga network, that could
be enough to keep networks in a crowded WIFI place. The drawback is that
if a WIFI network is off, the user will know it 1mn30s after, instead of
25s after.

### Checklist

- [x] Add changelog
- [x] Test on PlayOS