### PR TITLE
Add wpa_supplicant restart hook on rfkill unblock

### DIFF
--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -62,6 +62,7 @@
   environment.etc = [
     { source = pkgs.writeScript "rfkill.hook" ''
       #!${pkgs.runtimeShell}
+      # States: 1 - normal, 0 - soft-blocked, 2 - hardware-blocked
       if [ "$RFKILL_STATE" == 1 ]; then
         # Wait an instant. Immediate restart gets wpa_supplicant stuck in the same way.
         sleep 5

--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -55,19 +55,22 @@
   };
   # Issue 2: Make sure connman starts after wpa_supplicant
   systemd.services."connman".after = [ "wpa_supplicant.service" ];
-  # Issue 3: Leave time for rfkill to unblock WLAN and restart wpa_supplicant & connman (https://01.org/jira/browse/CM-670)
-  systemd.timers."restart-wpa" = {
-    timerConfig = {
-      OnBootSec = 20;
-      RemainAfterElapse = false;
-    };
-    wantedBy = [ "timers.target" ];
-  };
-  systemd.services."restart-wpa" = {
-    description = "Restart wpa to enable WLAN";
-    serviceConfig.Type = "oneshot";
-    serviceConfig.ExecStart = "/run/current-system/sw/bin/systemctl try-restart wpa_supplicant.service";
-  };
+  # Issue 3: Restart wpa_supplicant (and thereby connman) after rfkill unblock of wlan
+  #          This addresses the problem of wpa_supplicant with connman not seeing any
+  #          networks if wlan was initially soft blocked. (https://01.org/jira/browse/CM-670)
+  services.udev.packages = [ pkgs.rfkill_udev ];
+  environment.etc = [
+    { source = pkgs.writeScript "rfkill.hook" ''
+      #!${pkgs.runtimeShell}
+      if [ "$RFKILL_STATE" == 1 ]; then
+        # Wait an instant. Immediate restart gets wpa_supplicant stuck in the same way.
+        sleep 3
+        ${config.systemd.package}/bin/systemctl try-restart wpa_supplicant.service
+      fi
+      '';
+      target = "rfkill.hook";
+    }
+  ];
 
   # Make connman folder persistent
   volatileRoot.persistentFolders."/var/lib/connman" = {

--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -64,7 +64,7 @@
       #!${pkgs.runtimeShell}
       if [ "$RFKILL_STATE" == 1 ]; then
         # Wait an instant. Immediate restart gets wpa_supplicant stuck in the same way.
-        sleep 3
+        sleep 5
         ${config.systemd.package}/bin/systemctl try-restart wpa_supplicant.service
       fi
       '';


### PR DESCRIPTION
This uses udev to restart wpa_supplicant whenever a rfkill block of wifi is removed ("unblock"). This seems a bit trigger happy, but is probably the most direct solution as long as the underlying problem in wpa_supplicant/connman's interaction with rfkill is not known. Our machines are also unlikely to toggle rfkill during operation, so the practical downsides should be low.

While the heuristic timer-based restarting of wpa_supplicant mostly works in regular setups, picking a timer duration is difficult: Longer durations are more likely to work (coming after the unblock), but overly long durations are bad for the user and may even lead to mistaken conclusions of there being no connectivity at all.

Point in case, the duration was just about too short for live systems ("lab key"), so they would frequently boot into a state where wifi connectivity could not be restored without a system reboot.