### PR TITLE
Add persistence of preferred boot order

### DIFF
--- a/bootloader/grub.cfg
+++ b/bootloader/grub.cfg
@@ -67,11 +67,15 @@ search --label system.b --set b_DISK
 set common_kernel_args="$machine_id_arg quiet panic=3 boot.panic_on_fail"
 
 menuentry "system.a (try=$a_TRY, ok=$a_OK)" --id system.a {
+  set ORDER="a b"
+  save_env ORDER
   linux ($a_DISK)/kernel root=/dev/disk/by-label/system.a rauc.slot=a $common_kernel_args
   initrd ($a_DISK)/initrd
 }
 
 menuentry "system.b (try=$b_TRY, ok=$b_OK)" --id system.b {
+  set ORDER="b a"
+  save_env ORDER
   linux ($b_DISK)/kernel root=/dev/disk/by-label/system.b rauc.slot=b $common_kernel_args
   initrd ($b_DISK)/initrd
 }


### PR DESCRIPTION
The preferred boot order is persisted to preserve the boot choice after manual selection from the GRUB menu. By relying on the boot order, the manual choice will automatically be overridden following a successful update of the inactive partition, and fallback booting continues to work if the favoured choice fails repeatedly.

Fulfills two criteria:

- When manually selecting a system in the GRUB menu, the choice should be preserved.
- The manual boot choice should be overridden when a new update is found and installed.