### PR TITLE
Update rauc to 1.2

### DIFF
--- a/pkgs/rauc/default.nix
+++ b/pkgs/rauc/default.nix
@@ -1,20 +1,22 @@
-{stdenv, fetchurl, glib, curl, json-glib, pkgconfig, makeWrapper, grub2, utillinux, squashfsTools, e2fsprogs, gnutar, xz, ...}:
+{stdenv, fetchurl, autoreconfHook, dbus, glib, curl, json-glib, pkgconfig, makeWrapper, grub2, utillinux, squashfsTools, e2fsprogs, gnutar, xz, ...}:
 stdenv.mkDerivation rec {
   name = "rauc-${version}";
-  version = "1.0.rc1";
+  version = "1.2";
 
-  buildInputs = [ glib curl json-glib pkgconfig makeWrapper ];
+  buildInputs = [ autoreconfHook glib curl json-glib pkgconfig makeWrapper dbus ];
 
   src = fetchurl {
-    url = "https://github.com/rauc/rauc/releases/download/v1.0-rc1/rauc-${version}.tar.xz";
-    sha256 = "0c4p1c1ghlcfzv8x7qncgmxgj9gdra4dmfwznyashihrr47m780d";
+    url = "https://github.com/rauc/rauc/releases/download/v${version}/rauc-${version}.tar.xz";
+    sha256 = "sha256:0qg6frrih1q81r0x9byy4nxjd3nd8mj7iai8j6wcql5c3zy86ii2";
   };
 
-  postInstall = ''
-    # Move dbus configuration to right place so that it is picked up by NixOS machinery
-    mkdir -p $out/etc/dbus-1
-    mv $out/share/dbus-1/system.d $out/etc/dbus-1/
+  configureFlags = [
+    "--with-dbuspolicydir=${placeholder "out"}/etc/dbus-1/system.d"
+    "--with-dbussystemservicedir=${placeholder "out"}/etc/dbus-1/system-services"
+    "--with-dbusinterfacesdir=${placeholder "out"}/etc/dbus-1/system.d"
+  ];
 
+  postInstall = ''
     # Add required tools to path
     wrapProgram $out/bin/rauc \
       --prefix PATH ":" ${utillinux}/bin \


### PR DESCRIPTION
This updates rauc to `1.2`. There are no documented breaking changes since `1.0-rc1`: https://rauc.readthedocs.io/en/v1.2/changes.html

A first test was done, verifying that PlayOS can still perform a self-upgrade using rauc `1.2`.

After merge, a complete test of the self-upgrade flow should be done on `develop` channel.