### PR TITLE
Improve update status

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,5 +1,9 @@
 # [UNRELEASED]
 
+## Added
+
+- controller: Add update status types for manually pinned systems and dual-slot system failure
+
 ## Changed
 
 - system: Update rauc to 1.2

--- a/controller/bindings/rauc/rauc.ml
+++ b/controller/bindings/rauc/rauc.ml
@@ -100,6 +100,14 @@ let get_status daemon =
   }
   |> return
 
+let get_primary daemon =
+  try%lwt
+  (OBus_method.call De_pengutronix_rauc_Installer.m_GetPrimary (proxy daemon) ()
+  >|= Slot.of_string
+  >>= Lwt.return_some
+  )
+  with _ -> Lwt.return_none
+
 let install daemon source =
   let proxy = proxy daemon in
   let%lwt completed_e =

--- a/controller/bindings/rauc/rauc.mli
+++ b/controller/bindings/rauc/rauc.mli
@@ -24,7 +24,7 @@ end
 (** [get_booted_slot rauc] returns the currently booted slot *)
 val get_booted_slot : t -> Slot.t Lwt.t
 
-(** [mark_good rauc slot] marks the slot [slot] as good*)
+(** [mark_good rauc slot] marks the slot [slot] as good *)
 val mark_good : t -> Slot.t -> unit Lwt.t
 
 (** Rauc status *)
@@ -39,6 +39,9 @@ val json_of_status : status -> Ezjsonm.t
 
 (** [get_status rauc] returns current RAUC status *)
 val get_status : t -> status Lwt.t
+
+(** [get_primary rauc] returns current primary slot, if any *)
+val get_primary : t -> Slot.t option Lwt.t
 
 (** [install rauc source] install the bundle at path [source] *)
 val install : t -> string -> unit Lwt.t

--- a/controller/server/update.ml
+++ b/controller/server/update.ml
@@ -166,7 +166,7 @@ let rec run ~update_url ~rauc ~set_state =
                 (* Inactive is up to date while booted is out of date, but booted was specifically selected for boot *)
                 OutOfDateVersionSelected |> set
               else
-                (* If booted is not up to date but inactive is up to date, we probably should reboot *)
+                (* If booted is not up to date but inactive is both up to date and primary, we should reboot into the primary *)
                 RebootRequired |> set
           | None ->
             (* All systems bad; suggest reinstallation *)

--- a/controller/server/update.ml
+++ b/controller/server/update.ml
@@ -142,10 +142,10 @@ let rec run ~update_url ~rauc ~set_state =
       | Ok version_info ->
 
         (* Compare latest available version to version booted. *)
-        let booted_version_comparae = Semver.compare
+        let booted_version_compare = Semver.compare
             (fst version_info.latest)
             (fst version_info.booted) in
-        let booted_up_to_date = booted_version_comparae == 0 in
+        let booted_up_to_date = booted_version_compare == 0 in
 
         (* Compare latest available version to version on inactive system partition. *)
         let inactive_version_compare = Semver.compare

--- a/controller/server/update.mli
+++ b/controller/server/update.mli
@@ -22,6 +22,8 @@ type state =
   | Installing of string
   | ErrorInstalling of string
   | RebootRequired
+  | OutOfDateVersionSelected
+  | ReinstallRequired
 [@@deriving sexp]
 
 val start : rauc:Rauc.t -> update_url:string -> state Lwt_react.signal * unit Lwt.t

--- a/pkgs/rauc/0001-Adapt-notion-of-GRUB-primary-slot-to-allow-for-2-uns.patch
+++ b/pkgs/rauc/0001-Adapt-notion-of-GRUB-primary-slot-to-allow-for-2-uns.patch
@@ -1,0 +1,26 @@
+From 5925821b714477df544007aa93a9e6031518e4b6 Mon Sep 17 00:00:00 2001
+From: Johannes Emerich <johannes@emerich.de>
+Date: Wed, 25 Mar 2020 12:25:42 +0100
+Subject: [PATCH] Adapt notion of GRUB primary slot to allow for 2 unsuccessful
+ tries
+
+---
+ src/bootchooser.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/bootchooser.c b/src/bootchooser.c
+index 4a0e948..e50b479 100644
+--- a/src/bootchooser.c
++++ b/src/bootchooser.c
+@@ -579,7 +579,7 @@ static RaucSlot* grub_get_primary(GError **error)
+ 				return NULL;
+ 			}
+ 
+-			if ((g_ascii_strtoull(slot_ok->str, NULL, 0) != 1) || (g_ascii_strtoull(slot_try->str, NULL, 0) > 0)) {
++			if ((g_ascii_strtoull(slot_ok->str, NULL, 0) != 1) || (g_ascii_strtoull(slot_try->str, NULL, 0) > 2)) {
+ 				continue;
+ 			}
+ 
+-- 
+2.23.0
+

--- a/pkgs/rauc/default.nix
+++ b/pkgs/rauc/default.nix
@@ -10,6 +10,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256:0qg6frrih1q81r0x9byy4nxjd3nd8mj7iai8j6wcql5c3zy86ii2";
   };
 
+  patches = [
+    ./0001-Adapt-notion-of-GRUB-primary-slot-to-allow-for-2-uns.patch
+  ];
+
   configureFlags = [
     "--with-dbuspolicydir=${placeholder "out"}/etc/dbus-1/system.d"
     "--with-dbussystemservicedir=${placeholder "out"}/etc/dbus-1/system-services"


### PR DESCRIPTION
Adds update states `ReinstallationRequired` (when both systems have repeatedly failed) and `OutOfDateVersionSelected` (when the inactive system is newer, but the booted system is primary by being set as the preferred system in GRUB).

There is one remaining blip, which is that after the system health is updated, the update status does not immediately refresh. Because of this, `ReinstallationRequired` can continue to be displayed after the health and active system was already marked good. Fixing this would require changes to the health state to trigger an immediate refresh of the update state.