### PR TITLE
Update to nixpkgs 20.03

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 # Blatant misuse of make to create nice shortcuts for different build profiles. The real build tool is nix.
 
+# Allow unfree packages, required for zerotier using a BSL 1.1 licence
+# See https://nixos.wiki/wiki/FAQ/How_can_I_install_a_proprietary_or_unfree_package%3F
+export NIXPKGS_ALLOW_UNFREE=1
+
 # Get the git branch
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 

--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,9 @@ A helper is available to quickly start a virtual machine:
 make vm && ./result/bin/run-playos-in-vm
 ```
 
+In order to get the vm system journal, look at the output of `run-playos-in-vm`
+for a command starting with `socat`.
+
 See the output of `run-playos-in-vm --help` for more information.
 
 ## Deployment

--- a/bootloader/rescue/default.nix
+++ b/bootloader/rescue/default.nix
@@ -81,21 +81,21 @@ in
     };
 
     # Use ConnMan
+    services.connman = {
+      enable = true;
+      enableVPN = false;
+      networkInterfaceBlacklist = [ "vmnet" "vboxnet" "virbr" "ifb" "ve" "zt" ];
+      extraConfig = ''
+        [General]
+        AllowHostnameUpdates=false
+        AllowDomainnameUpdates=false
+
+        # Disable calling home
+        EnableOnlineCheck=false
+      '';
+    };
     networking = {
       hostName = "playos-rescue";
-      connman = {
-        enable = true;
-        enableVPN = false;
-        networkInterfaceBlacklist = [ "vmnet" "vboxnet" "virbr" "ifb" "ve" "zt" ];
-        extraConfig = ''
-          [General]
-          AllowHostnameUpdates=false
-          AllowDomainnameUpdates=false
-
-          # Disable calling home
-          EnableOnlineCheck=false
-        '';
-      };
       # enable wpa_supplicant
       wireless = {
         enable = true;

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -8,6 +8,7 @@
 
 - system: Update rauc to 1.2
 - system: Remember manual boot choice on reboot
+- os: Update nixpkgs channel to 20.03
 
 # [2020.1.0] - 2020-02-11
 

--- a/controller/Readme.md
+++ b/controller/Readme.md
@@ -9,7 +9,7 @@ PlayOS controller is an OCaml application that manages various system tasks for 
 ## Folders
 
 - `bindings/`: bindings to various things
-- `gui/`: static gui assets and client side code
+- `gui/`: static gui assets
 - `nix/`: nix stuff
 - `server/`: main application code
 

--- a/controller/default.nix
+++ b/controller/default.nix
@@ -27,7 +27,6 @@ ocamlPackages.buildDunePackage rec {
   ];
 
   propagatedBuildInputs = with ocamlPackages; [
-    # server side
     opium
     ocaml_lwt
     logs
@@ -40,10 +39,5 @@ ocamlPackages.buildDunePackage rec {
     ezjsonm
     mustache
     containers
-
-    # client side
-    js_of_ocaml
-    js_of_ocaml-tyxml
-    cohttp-lwt-jsoo
   ];
 }

--- a/controller/dune
+++ b/controller/dune
@@ -2,7 +2,6 @@
  (section share_root)
  (files
   (Changelog.html as Changelog.html)
-  (gui/client/client.bc.js as static/client.js)
   (gui/reset.css as static/reset.css)
   (gui/style.css as static/style.css)
   (gui/template/changelog.mustache as template/changelog.mustache)

--- a/controller/gui/client/client.ml
+++ b/controller/gui/client/client.ml
@@ -1,4 +1,0 @@
-(* hic sunt client side code *)
-let () =
-  print_endline "What is my purpose?"
-

--- a/controller/gui/client/dune
+++ b/controller/gui/client/dune
@@ -1,4 +1,0 @@
-(executable
- (name client)
- (modules client)
- (libraries cohttp-lwt-jsoo))

--- a/controller/gui/template/index.mustache
+++ b/controller/gui/template/index.mustache
@@ -5,7 +5,6 @@
         <title>PlayOS Controller</title>
         <link rel="stylesheet" href="/static/reset.css">
         <link rel="stylesheet" href="/static/style.css">
-        <script src="/static/client.js"></script>
     </head>
     <body class="d-Container">
 

--- a/docs/arch/Readme.org
+++ b/docs/arch/Readme.org
@@ -37,7 +37,6 @@ For a more complete test a virtual disk containing all necessary partitions and 
 
   Update the following settings:
 
-  - ~Settings > Display > Graphics controller:~ set ~VBoxSVGA~ (see [[https://discourse.nixos.org/t/trying-to-fix-very-poor-virtualbox-install-experience/2488][this issue]], but it [[https://github.com/NixOS/nixpkgs/commit/58d0134da072548eb66d9313ad629e4dffddfd9d][should be resolved on NixOS 20.03]]),
   - ~Settings > System > Motherboard~: enable EFI.
 
 3. Install PlayOS from ~result/playos-installer-VERSION.iso~ to the virtual

--- a/installer/configuration.nix
+++ b/installer/configuration.nix
@@ -35,21 +35,23 @@ with lib;
   hardware.enableRedistributableFirmware = true;
 
   # Use ConnMan
+  services.connman = {
+    enable = true;
+    enableVPN = false;
+    networkInterfaceBlacklist = [ "vmnet" "vboxnet" "virbr" "ifb" "ve" "zt" ];
+    extraConfig = ''
+      [General]
+      AllowHostnameUpdates=false
+      AllowDomainnameUpdates=false
+
+      # Disable calling home
+      EnableOnlineCheck=false
+    '';
+  };
+
   networking = {
     hostName = "playos-installer";
-    connman = {
-      enable = true;
-      enableVPN = false;
-      networkInterfaceBlacklist = [ "vmnet" "vboxnet" "virbr" "ifb" "ve" "zt" ];
-      extraConfig = ''
-        [General]
-        AllowHostnameUpdates=false
-        AllowDomainnameUpdates=false
 
-        # Disable calling home
-        EnableOnlineCheck=false
-      '';
-    };
     # enable wpa_supplicant
     wireless = {
       enable = true;

--- a/kiosk/default.nix
+++ b/kiosk/default.nix
@@ -37,6 +37,7 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     pyqt5
+    pyqtwebengine
     requests
   ];
 

--- a/kiosk/shell.nix
+++ b/kiosk/shell.nix
@@ -1,6 +1,8 @@
 let
   pkgs = import ../pkgs {
     version = "1.0.0-dev";
+    updateUrl = "http://localhost:9999";
+    kioskUrl = "https://dev-play.dividat.com/";
   };
 in
   pkgs.playos-kiosk-browser

--- a/pkgs/breeze-contrast-cursor-theme/default.nix
+++ b/pkgs/breeze-contrast-cursor-theme/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
   src = fetchzip {
     url = "https://code.jpope.org/jpope/breeze_cursor_sources/raw/master/${name}.zip";
     sha256 = "1l8ils82bq2hlsl8shkcirxfjgk0459hsf6zvjnk9zrav47y9vjk";
+    # See issue https://github.com/NixOS/nixpkgs/issues/38649
+    extraPostFetch = "chmod go-w $out";
   };
 
   installPhase = ''

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2,11 +2,11 @@
 
 let
 
-  nixpkgs = (import <nixpkgs> {}).fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nixpkgs";
-    rev = "19.03";
-    sha256 = "0q2m2qhyga9yq29yz90ywgjbn9hdahs7i8wwlq7b55rdbyiwa5dy";
+  nixpkgs = builtins.fetchGit {
+    name = "nixpkgs-20.03";
+    url = "git@github.com:nixos/nixpkgs.git";
+    rev = "5272327b81ed355bbed5659b8d303cf2979b6953";
+    ref = "refs/tags/20.03";
   };
 
   overlay =
@@ -49,11 +49,6 @@ let
         obus = self.callPackage ./ocaml-modules/obus {};
 
         mustache = self.callPackage ./ocaml-modules/mustache {};
-
-        cohttp-lwt-jsoo = super.cohttp.overrideAttrs (oldAttrs: {
-          buildPhase = "jbuilder build -p cohttp-lwt-jsoo";
-          propagatedBuildInputs = with self; [ cohttp cohttp-lwt ocaml_lwt js_of_ocaml js_of_ocaml-lwt js_of_ocaml-ppx ppx_tools_versioned ];
-        });
       });
 
       # Controller

--- a/pkgs/ocaml-modules/obus/default.nix
+++ b/pkgs/ocaml-modules/obus/default.nix
@@ -1,26 +1,36 @@
 { stdenv, fetchFromGitHub, buildDunePackage
-, camlp4, ocaml-migrate-parsetree, ppx_metaquot, ppx_tools_versioned, ocaml_lwt
-, lwt_react, lwt_ppx, lwt_log, react, type_conv, xmlm }:
+, ocaml-migrate-parsetree, ppxlib, ppx_tools_versioned, ocaml_lwt
+, lwt_react, lwt_ppx, lwt_log, react, type_conv, xmlm, menhir }:
 
 buildDunePackage rec {
   pname = "obus";
-  version = "1.2.0-dev";
+  version = "1.2.2";
 
-  minimumOCamlVersion = "4.03";
+  minimumOCamlVersion = "4.04";
 
   src = fetchFromGitHub {
-    owner = "dividat";
+    owner = "ocaml-community";
     repo = "obus";
-    rev = "383ed2f7cbf22ae77fcf1d6399cbf7c667161114";
-    sha256 = "1b5mg7npnsllg2kgdcqkpjd71w7abxzvzvyrnazqakzrw4sqw08y";
+    rev = "59c93162a4d4fc239761874f83d489332844e7c7"; # 1.2.0
+    sha256 = "0qb42634dmx8g6rf6vv5js88d8vgbzz8646dsg638352yzgsi3a3";
   };
 
   buildInputs = [ ];
-  propagatedBuildInputs = 
-    [ camlp4 ocaml-migrate-parsetree ppx_metaquot ppx_tools_versioned ocaml_lwt lwt_react lwt_ppx lwt_log react type_conv xmlm ];
+  propagatedBuildInputs = [
+    lwt_log
+    lwt_ppx
+    lwt_react
+    menhir
+    ocaml-migrate-parsetree
+    ocaml_lwt
+    ppxlib
+    react
+    type_conv
+    xmlm
+  ];
 
   meta = {
-    homepage = https://github.com/dividat/obus;
+    homepage = https://github.com/ocaml-community/obus;
     description = "Pure OCaml implementation of the D-Bus protocol";
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ ];

--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -26,6 +26,7 @@ with lib;
   systemPartition = {
     enable = true;
     device = "/dev/root";
+    options = [ "rw" ];
   };
 
   volatileRoot.persistentDataPartition.device = "/dev/disk/by-label/data";

--- a/system/modules/playos.nix
+++ b/system/modules/playos.nix
@@ -14,12 +14,12 @@ with lib;
 
   options = {
     playos.version = mkOption {
-      type = types.string;
+      type = types.str;
       default = version;
     };
 
     playos.kioskUrl = mkOption {
-      type = types.string;
+      type = types.str;
     };
 
     playos.updateCert = mkOption {

--- a/system/modules/system-partition.nix
+++ b/system/modules/system-partition.nix
@@ -53,5 +53,15 @@ in
       ln -s mnt/system/init init
       cd /
     '';
+
+    # Replace /dev/root by /dev/disk/by-label/system.x in /etc/fstab
+    boot.postBootCommands = with pkgs; ''
+      SYSTEM_DEVICE=$(readlink /dev/root)
+      mv /etc/fstab /etc/fstab.old
+      cp -L /etc/fstab.old /etc/fstab
+      chmod u+w /etc/fstab
+      ${gnused}/bin/sed -i "s|/dev/root|$SYSTEM_DEVICE|" /etc/fstab
+      chmod u-w /etc/fstab
+    '';
   };
 }

--- a/system/modules/system-partition.nix
+++ b/system/modules/system-partition.nix
@@ -11,14 +11,14 @@ in
       device = mkOption {
         default = null;
         example = "/dev/sda";
-        type = types.string;
+        type = types.str;
         description = "Location of the device.";
       };
 
       fsType = mkOption {
         default = "auto";
         example = "ext3";
-        type = types.string;
+        type = types.str;
         description = "Type of the file system.";
       };
 
@@ -26,7 +26,7 @@ in
         default = [ "ro" ];
         example = [ "data=journal" ];
         description = "Options used to mount the file system.";
-        type = types.listOf types.string;
+        type = types.listOf types.str;
       };
 
     };

--- a/system/modules/volatile-root.nix
+++ b/system/modules/volatile-root.nix
@@ -10,13 +10,13 @@ with lib;
         device = mkOption {
           default = null;
           example = "/dev/sda";
-          type = types.nullOr types.string;
+          type = types.nullOr types.str;
         };
 
         fsType = mkOption {
           default = "auto";
           example = "ext3";
-          type = types.string;
+          type = types.str;
           description = "Type of the file system.";
         };
 
@@ -24,7 +24,7 @@ with lib;
           default = [ "defaults" ];
           example = [ "data=journal" ];
           description = "Options used to mount the file system.";
-          type = types.listOf types.string;
+          type = types.listOf types.str;
         };
 
       };

--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -61,20 +61,15 @@
   #          This addresses the problem of wpa_supplicant with connman not seeing any
   #          networks if wlan was initially soft blocked. (https://01.org/jira/browse/CM-670)
   services.udev.packages = [ pkgs.rfkill_udev ];
-  environment.etc = {
-    "rfkill.hook" = {
-      text = ''
-        #!${pkgs.runtimeShell}
-        # States: 1 - normal, 0 - soft-blocked, 2 - hardware-blocked
-        if [ "$RFKILL_STATE" == 1 ]; then
-          # Wait an instant. Immediate restart gets wpa_supplicant stuck in the same way.
-          sleep 5
-          ${config.systemd.package}/bin/systemctl try-restart wpa_supplicant.service
-        fi
-      '';
-      mode = "0740";
-    };
-  };
+  environment.etc."rfkill.hook".source = pkgs.writeShellScript "rfkill.hook" ''
+    # States: 1 - normal, 0 - soft-blocked, 2 - hardware-blocked
+    if [ "$RFKILL_STATE" == 1 ]; then
+      # Wait an instant. Immediate restart gets wpa_supplicant stuck in the same way.
+      sleep 5
+
+      ${config.systemd.package}/bin/systemctl try-restart wpa_supplicant.service
+    fi
+  '';
 
   # Make connman folder persistent
   volatileRoot.persistentFolders."/var/lib/connman" = {

--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -6,27 +6,29 @@
   # Set up networking with ConnMan
   # We need to work around various issues in the interplay of
   # connman and wpa_supplicant for this to work.
+  services.connman = {
+    enable = true;
+    enableVPN = false;
+    networkInterfaceBlacklist = [ "vmnet" "vboxnet" "virbr" "ifb" "ve" "zt" ];
+    extraConfig = ''
+      [General]
+      AllowHostnameUpdates=false
+      AllowDomainnameUpdates=false
+
+      # Wifi will generally be used for internet, use as default route
+      PreferredTechnologies=wifi,ethernet
+
+      # Allow simultaneous connection to ethernet and wifi
+      SingleConnectedTechnology=false
+
+      # Enable online check to favour connected services
+      EnableOnlineCheck=true
+    '';
+  };
+
   networking = {
     hostName = "playos";
-    connman = {
-      enable = true;
-      enableVPN = false;
-      networkInterfaceBlacklist = [ "vmnet" "vboxnet" "virbr" "ifb" "ve" "zt" ];
-      extraConfig = ''
-        [General]
-        AllowHostnameUpdates=false
-        AllowDomainnameUpdates=false
 
-        # Wifi will generally be used for internet, use as default route
-        PreferredTechnologies=wifi,ethernet
-
-        # Allow simultaneous connection to ethernet and wifi
-        SingleConnectedTechnology=false
-
-        # Enable online check to favour connected services
-        EnableOnlineCheck=true
-      '';
-    };
     wireless = {
       enable = true;
 
@@ -59,19 +61,20 @@
   #          This addresses the problem of wpa_supplicant with connman not seeing any
   #          networks if wlan was initially soft blocked. (https://01.org/jira/browse/CM-670)
   services.udev.packages = [ pkgs.rfkill_udev ];
-  environment.etc = [
-    { source = pkgs.writeScript "rfkill.hook" ''
-      #!${pkgs.runtimeShell}
-      # States: 1 - normal, 0 - soft-blocked, 2 - hardware-blocked
-      if [ "$RFKILL_STATE" == 1 ]; then
-        # Wait an instant. Immediate restart gets wpa_supplicant stuck in the same way.
-        sleep 5
-        ${config.systemd.package}/bin/systemctl try-restart wpa_supplicant.service
-      fi
+  environment.etc = {
+    "rfkill.hook" = {
+      text = ''
+        #!${pkgs.runtimeShell}
+        # States: 1 - normal, 0 - soft-blocked, 2 - hardware-blocked
+        if [ "$RFKILL_STATE" == 1 ]; then
+          # Wait an instant. Immediate restart gets wpa_supplicant stuck in the same way.
+          sleep 5
+          ${config.systemd.package}/bin/systemctl try-restart wpa_supplicant.service
+        fi
       '';
-      target = "rfkill.hook";
-    }
-  ];
+      mode = "0740";
+    };
+  };
 
   # Make connman folder persistent
   volatileRoot.persistentFolders."/var/lib/connman" = {

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -21,9 +21,10 @@
   services.xserver = {
     enable = true;
 
+    displayManager.defaultSession = "kiosk-browser";
+
     desktopManager = {
       xterm.enable = false;
-      default = "kiosk-browser";
       session = [
         { name = "kiosk-browser";
           start = ''


### PR DESCRIPTION
Nix derivation modifications:

- Rename `networking.connman` to `services.connman`
- Remove write permissions to breeze theme downloaded files
- Use `types.str` instead of `types.string`
- Adapt `environment.etc` file creation
- Rename `desktopManager.default` to `displayManager.defaultSession`

Controller:

- Remove client code that just did a test log (I had trouble building cohttp-lwt-jsoo)
- Use `ocaml-community/obus` instead of `dividat/obus`. I had an error
with `dividat/obus`, that’s the reason I investigated to use the
community version instead.

Kiosk:

- Add pyqtwebengine dependency
- Add missing `updateUrl` and `kioskUrl` to be able to run `nix-shell`
for developers

The important change is on the `obus` library. `dividat/obus` is forked from `steinuil/obus`, and we have a commit on top of it to use `dune`. Do you know why we needed this fork from `steinuil` ?

## Tests

On a physical machine, I verified that I could use a gamepad (the recorded version comes from a test on VirtualBox):

![2020-04-28_15-41-18](https://user-images.githubusercontent.com/6768842/80501891-45495e00-8970-11ea-8710-11918edd20de.gif)

(website: http://gamepadviewer.com/)

## Checklist

-   [x] Changelog updated
-   [x] Code documented
