### PR TITLE
Enable use of HTTPS for dist host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ develop:
 	[[ $(BRANCH) = "develop" ]]
 	nix-build \
 		--arg updateCert ./pki/develop/cert.pem \
-		--arg updateUrl http://dist.dividat.com/releases/playos/develop/ \
+		--arg updateUrl https://dist.dividat.com/releases/playos/develop/ \
 		--arg deployUrl s3://dist.dividat.ch/releases/playos/develop/ \
 		--arg kioskUrl https://dev-play.dividat.com/ \
 		--arg buildDisk false
@@ -36,7 +36,7 @@ validation:
 	[[ $(BRANCH) = "validation" ]]
 	nix-build \
 		--arg updateCert ./pki/validation/cert.pem \
-		--arg updateUrl http://dist.dividat.com/releases/playos/validation/ \
+		--arg updateUrl https://dist.dividat.com/releases/playos/validation/ \
 		--arg deployUrl s3://dist.dividat.ch/releases/playos/validation/ \
 		--arg kioskUrl https://val-play.dividat.com/ \
 		--arg buildDisk false
@@ -47,7 +47,7 @@ master:
 	[[ $(BRANCH) = "master" ]]
 	nix-build \
 		--arg updateCert ./pki/master/cert.pem \
-		--arg updateUrl http://dist.dividat.com/releases/playos/master/ \
+		--arg updateUrl https://dist.dividat.com/releases/playos/master/ \
 		--arg deployUrl s3://dist.dividat.ch/releases/playos/master/ \
 		--arg kioskUrl https://play.dividat.com/ \
 		--arg buildDisk false

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,5 +1,9 @@
 # [UNRELEASED]
 
+## Added
+
+- controller: Enable HTTPS support for system update hosts
+
 ## Fixed
 
 - controller: Display interfaces' IP even if there is no gateway

--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -36,7 +36,7 @@ struct
     | _ -> None
 
   type t = {
-    _proxy: OBus_proxy.t sexp_opaque
+    _proxy: (OBus_proxy.t [@sexp.opaque])
   ; name : string
   ; type' : type'
   ; powered : bool
@@ -261,8 +261,8 @@ struct
   end
 
   type t = {
-    _proxy : OBus_proxy.t sexp_opaque
-  ; _manager : OBus_proxy.t sexp_opaque
+    _proxy : (OBus_proxy.t [@sexp.opaque])
+  ; _manager : (OBus_proxy.t [@sexp.opaque])
   ; id : string
   ; name : string
   ; type' : Technology.type'

--- a/controller/bindings/connman/connman.mli
+++ b/controller/bindings/connman/connman.mli
@@ -14,7 +14,7 @@ module Technology : sig
       Note that not all properties are encoded.
   *)
   type t = {
-    _proxy: OBus_proxy.t Sexplib.Conv.sexp_opaque
+    _proxy: (OBus_proxy.t [@sexp.opaque])
   ; name : string
   ; type' : type'
   ; powered : bool
@@ -100,8 +100,8 @@ module Service : sig
       Note that not all properties are encoded.
   *)
   type t = {
-    _proxy : OBus_proxy.t Sexplib.Conv.sexp_opaque
-  ; _manager: OBus_proxy.t Sexplib.Conv.sexp_opaque
+    _proxy : (OBus_proxy.t [@sexp.opaque])
+  ; _manager: (OBus_proxy.t [@sexp.opaque])
   ; id : string
   ; name : string
   ; type' : Technology.type'

--- a/controller/server/update.ml
+++ b/controller/server/update.ml
@@ -11,13 +11,13 @@ let log_src = Logs.Src.create "update"
 (** Type containing version information *)
 type version_info =
   {(* the latest available version *)
-    latest : Semver.t sexp_opaque * string
+    latest : (Semver.t [@sexp.opaque]) * string
 
   (* version of currently booted system *)
-  ; booted : Semver.t sexp_opaque * string
+  ; booted : (Semver.t [@sexp.opaque]) * string
 
   (* version of inactive system *)
-  ; inactive : Semver.t sexp_opaque * string
+  ; inactive : (Semver.t [@sexp.opaque]) * string
   }
 [@@deriving sexp]
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,7 +3,7 @@
 let
 
   nixpkgs = builtins.fetchGit {
-    name = "nixpkgs-20.03";
+    name = "nixpkgs-20.03-snapshot";
     url = "git@github.com:nixos/nixpkgs.git";
     rev = "3f690bfcd4adde6dd0733c2d9f8f4d61e09dfc60";
   };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5,8 +5,7 @@ let
   nixpkgs = builtins.fetchGit {
     name = "nixpkgs-20.03";
     url = "git@github.com:nixos/nixpkgs.git";
-    rev = "5272327b81ed355bbed5659b8d303cf2979b6953";
-    ref = "refs/tags/20.03";
+    rev = "3f690bfcd4adde6dd0733c2d9f8f4d61e09dfc60";
   };
 
   overlay =

--- a/pkgs/ocaml-modules/obus/default.nix
+++ b/pkgs/ocaml-modules/obus/default.nix
@@ -11,8 +11,8 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "ocaml-community";
     repo = "obus";
-    rev = "59c93162a4d4fc239761874f83d489332844e7c7"; # 1.2.0
-    sha256 = "0qb42634dmx8g6rf6vv5js88d8vgbzz8646dsg638352yzgsi3a3";
+    rev = "8aaf3d4e5538e42a62ae206dcfc01d2b898e54dc"; # 1.2.2
+    sha256 = "145c9ir0a4ld054npq80q8974fangirmd4r7z0736qjva27raqr7";
   };
 
   buildInputs = [ ];
@@ -25,7 +25,6 @@ buildDunePackage rec {
     ocaml_lwt
     ppxlib
     react
-    type_conv
     xmlm
   ];
 


### PR DESCRIPTION
Previously the module ocaml-tls used by cohttp had spotty support for some modern TLS variants and hence http://dist.dividat.com/... was referenced as the update base URL.

While this does not put the self-update mechanism at danger due to a signature check on update bundles, it requires users to allow PlayOS machines to contact dist.dividat.com via HTTP. Being able to configure HTTPS means users can restrict network traffic to HTTPS for tighter control.

The ocaml-tls module just received a major upgrade, adding support for TLS 1.3 and new cryptographic methods. This patch updates to the latest version 0.12.0 of ocaml-tls.

This requires using a slightly newer version of nixpkgs, after 20.03.

## Doubts

- Will this lock out customers whose sysadmins already enabled HTTP but not HTTPS for the dist host?
- Will this cause problems in several years, when a "sleeping beauty" machine wakes up from a long slumber and can no longer talk to the HTTPS host with its by then advanced TLS version?

## Checklist

-   [x] Changelog updated
-   [x] Code documented
