### PR TITLE
Make gateway optional in connman's IPv{4,6} types

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,5 +1,9 @@
 # [UNRELEASED]
 
+## Fixed
+
+- controller: Display interfaces' IP even if there is no gateway
+
 # [2020.7.0-VALIDATION] - 2020-07-08
 
 ## Added

--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -189,7 +189,7 @@ struct
       method' : string
     ; address : string
     ; netmask : string
-    ; gateway : string
+    ; gateway : string option
     }
     [@@deriving sexp]
 
@@ -200,7 +200,7 @@ struct
          { method' = properties |> List.assoc "Method" |> cast_single basic_string
          ; address = properties |> List.assoc "Address" |> cast_single basic_string
          ; netmask = properties |> List.assoc "Netmask" |> cast_single basic_string
-         ; gateway = properties |> List.assoc "Gateway" |> cast_single basic_string
+         ; gateway = properties |> List.assoc_opt "Gateway" |> Option.map (cast_single basic_string)
          }
       )
       |> CCResult.guard
@@ -213,7 +213,7 @@ struct
       method' : string
     ; address : string
     ; prefix_length: int
-    ; gateway : string
+    ; gateway : string option
     ; privacy : string
     }
     [@@deriving sexp]
@@ -228,7 +228,7 @@ struct
                            |> List.assoc "PrefixLength"
                            |> cast_single basic_byte
                            |> int_of_char
-         ; gateway = properties |> List.assoc "Gateway" |> cast_single basic_string
+         ; gateway = properties |> List.assoc_opt "Gateway" |> Option.map (cast_single basic_string)
          ; privacy = properties |> List.assoc "Privacy" |> cast_single basic_string
          }
       )

--- a/controller/bindings/connman/connman.mli
+++ b/controller/bindings/connman/connman.mli
@@ -67,7 +67,7 @@ module Service : sig
       method' : string
     ; address : string
     ; netmask : string
-    ; gateway : string
+    ; gateway : string option
     }
     [@@deriving sexp]
   end
@@ -78,7 +78,7 @@ module Service : sig
       method' : string
     ; address : string
     ; prefix_length: int
-    ; gateway : string
+    ; gateway : string option
     ; privacy : string
     }
     [@@deriving sexp]


### PR DESCRIPTION
The Gateway field is not present for all connections, hence failing on its absence can wrongly suggest that no IP is configured for an interface at all, when really there is simply no gateway.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
