### PR TITLE
Use value instead of physical equality in controller

### DIFF
--- a/controller/bindings/rauc/rauc.ml
+++ b/controller/bindings/rauc/rauc.ml
@@ -58,7 +58,7 @@ let mark_good daemon slot =
       ("good", slot |> Slot.string_of_t)
   in
   let%lwt () = Logs_lwt.info ~src:log_src (fun m -> m "%s" msg) in
-  if Slot.of_string marked == slot then
+  if Slot.of_string marked = slot then
     return_unit
   else
     Lwt.fail_with "Wrong slot marked good."

--- a/controller/bindings/timedate/timedate.ml
+++ b/controller/bindings/timedate/timedate.ml
@@ -30,7 +30,7 @@ let get_active_timezone daemon =
       (proxy daemon)
     |> OBus_property.get
   in
-  if String.length raw_tz == 0 then
+  if String.length raw_tz = 0 then
     None |> return
   else
     Some raw_tz |> return

--- a/controller/server/network.ml
+++ b/controller/server/network.ml
@@ -68,7 +68,7 @@ struct
     with
 
     | Ok (resp, _) ->
-      if Response.status resp == `OK then
+      if Response.status resp = `OK then
         return Connected
       else
         return (NotConnected "Captive portal login required")

--- a/controller/server/update.ml
+++ b/controller/server/update.ml
@@ -145,13 +145,13 @@ let rec run ~update_url ~rauc ~set_state =
         let booted_version_compare = Semver.compare
             (fst version_info.latest)
             (fst version_info.booted) in
-        let booted_up_to_date = booted_version_compare == 0 in
+        let booted_up_to_date = booted_version_compare = 0 in
 
         (* Compare latest available version to version on inactive system partition. *)
         let inactive_version_compare = Semver.compare
             (fst version_info.latest)
             (fst version_info.inactive) in
-        let inactive_up_to_date = inactive_version_compare == 0 in
+        let inactive_up_to_date = inactive_version_compare = 0 in
         let inactive_update_available = inactive_version_compare > 0 in
 
         if booted_up_to_date || inactive_up_to_date then
@@ -162,7 +162,7 @@ let rec run ~update_url ~rauc ~set_state =
               UpToDate version_info |> set
             else
               let%lwt booted_slot = Rauc.get_booted_slot rauc in
-              if booted_slot == primary_slot then
+              if booted_slot = primary_slot then
                 (* Inactive is up to date while booted is out of date, but booted was specifically selected for boot *)
                 OutOfDateVersionSelected |> set
               else


### PR DESCRIPTION
Because we are only interested in value equality, we should stick using
value (structural) equality rather than physical equality.

https://stackoverflow.com/questions/13590307/whats-the-difference-between-equal-and-identical-in-ocaml

From this small program:

```ocaml
let a = "foo" == "foo"
let b = "foo" = "foo"
let c = 1 == 1
let d = 1 = 1

let () = Printf.printf "a: %b\nb: %b\nc: %b\nd: %b\n" a b c d
```

It outputs:

```
a: false
b: true
c: true
d: true
```

I got bitten using the `==` equality on strings, which did not
work as I initially expected.

The current modification does not change the behavior of the program,
but it will help future changes not to use the more complex `==`
operator.

## Checklist

-   ~~[ ] Changelog updated~~
-   ~~[ ] Code documented~~