### PR TITLE
Auto reload the controller dev server

### DIFF
--- a/controller/Readme.md
+++ b/controller/Readme.md
@@ -17,7 +17,7 @@ PlayOS controller is an OCaml application that manages various system tasks for 
 
 Run `nix-shell` to create a suitable development environment.
 
-Then, start the the controller with `./dev`.
+Then, start the the controller with `bin/dev-server`.
 
 ## Code style
 

--- a/controller/bin/build
+++ b/controller/bin/build
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd $(dirname "$0")/..
+
+markdown Changelog.md > Changelog.html
+
+# The controller application requires certain artifacts to be in a specific location relative to binary location. The `dune build @install` command ensures this.
+# The `--profile release` option disables dune from failing on warnings (which are currently present in the `obus` library)
+dune build @install --profile release

--- a/controller/bin/dev-server
+++ b/controller/bin/dev-server
@@ -2,16 +2,18 @@
 set -euo pipefail
 cd $(dirname "$0")/..
 
-function finish {
-  # Stop the running server
-  lsof -i tcp:3333 | grep LISTEN | awk '{print $2}' | xargs kill
-}
+trap bin/stop-server EXIT
 
-trap finish EXIT
-
-bin/watch-command &
+bin/watch-command || true
 
 watchman-make \
-  --pattern 'server/**' 'bindings/**' 'gui/**' dune Changelog.md \
-  --settle 0.5 \
-  --run "bin/watch-command"
+  --pattern \
+    'server/**' \
+    'bindings/**' \
+    'gui/**' \
+    dune \
+    Changelog.md \
+  --settle \
+    0.5 \
+  --run \
+    "bin/watch-command"

--- a/controller/bin/dev-server
+++ b/controller/bin/dev-server
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd $(dirname "$0")/..
+
+function finish {
+  # Stop the running server
+  lsof -i tcp:3333 | grep LISTEN | awk '{print $2}' | xargs kill
+}
+
+trap finish EXIT
+
+bin/watch-command &
+
+watchman-make \
+  --pattern 'server/**' 'bindings/**' 'gui/**' dune Changelog.md \
+  --settle 0.5 \
+  --run "bin/watch-command"

--- a/controller/bin/stop-server
+++ b/controller/bin/stop-server
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+lsof -i tcp:3333 | grep LISTEN | awk '{print $2}' | xargs kill 2>/dev/null

--- a/controller/bin/watch-command
+++ b/controller/bin/watch-command
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+tput reset
+
+markdown Changelog.md > Changelog.html
+
+# The controller application requires certain artifacts to be in a specific location relative to binary location. The `dune build @install` command ensures this.
+# The `--profile release` option disables dune from failing on warnings (which are currently present in the `obus` library)
+dune build @install --profile release
+
+if [ "$?" -eq 0 ]; then
+
+  # Kill already running server if any
+  lsof -i tcp:3333 | grep LISTEN | awk '{print $2}' | xargs kill 2>/dev/null
+
+  echo -e "$(tput setaf 2)$(tput bold)\nCompilation succeeded\n$(tput sgr0)"
+  ./_build/install/default/bin/playos-controller &
+  LIVE_SERVER_PID="$!"
+
+else
+
+  echo -e "$(tput setaf 1)$(tput bold)\nCompilation failed\n$(tput sgr0)"
+
+fi

--- a/controller/bin/watch-command
+++ b/controller/bin/watch-command
@@ -1,24 +1,18 @@
 #!/usr/bin/env bash
+set -euo pipefail
+cd $(dirname "$0")/..
 
-tput reset
+clear
 
-markdown Changelog.md > Changelog.html
+if bin/build; then
 
-# The controller application requires certain artifacts to be in a specific location relative to binary location. The `dune build @install` command ensures this.
-# The `--profile release` option disables dune from failing on warnings (which are currently present in the `obus` library)
-dune build @install --profile release
-
-if [ "$?" -eq 0 ]; then
-
-  # Kill already running server if any
-  lsof -i tcp:3333 | grep LISTEN | awk '{print $2}' | xargs kill 2>/dev/null
-
-  echo -e "$(tput setaf 2)$(tput bold)\nCompilation succeeded\n$(tput sgr0)"
+  bin/stop-server || true
+  echo -e "$(tput setaf 2)$(tput bold)\nSuccess\n$(tput sgr0)"
   ./_build/install/default/bin/playos-controller &
-  LIVE_SERVER_PID="$!"
 
 else
 
-  echo -e "$(tput setaf 1)$(tput bold)\nCompilation failed\n$(tput sgr0)"
+  bin/stop-server || true
+  exit 1
 
 fi

--- a/controller/dev
+++ b/controller/dev
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-markdown Changelog.md > Changelog.html
-
-# The controller application requires certain artifacts to be in a specific location relative to binary location. The `dune build @install` command ensures this.
-# The `--profile release` option disables dune from failing on warnings (which are currently present in the `obus` library)
-dune build @install --profile release
-
-./_build/install/default/bin/playos-controller

--- a/controller/shell.nix
+++ b/controller/shell.nix
@@ -5,4 +5,8 @@ let
     kioskUrl = "https://dev-play.dividat.com/";
   };
 in
-  pkgs.playos-controller
+  pkgs.playos-controller.overrideAttrs(oldAttrs: {
+    buildInputs = oldAttrs.buildInputs ++ (with pkgs; [
+      python37Packages.pywatchman
+    ]);
+  })


### PR DESCRIPTION
Previously, we had to manually stop and restart the server after
each change.

Dune accepts the `--watch` parameter, But it does not work with
`--exec`, see https://github.com/ocaml/dune/issues/2934.

There is a workaround, using an alias, see https://github.com/ocaml/dune/issues/2934#issuecomment-589087241.

`dune build --watch @install @run --profile release -j1 --no-buffer`

`server/dune`

```
(alias
  (name run)
  (action (run ./run-server)))
```

`run-server`

```bash
cd ../../..

function finish {
  # Stop the running server
  lsof -i tcp:3333 | grep LISTEN | awk '{print $2}' | xargs kill
}

trap finish EXIT

finish
./_build/install/default/bin/playos-controller
```

But there are 2 problems:

1. the server is started whenever the build succeeded or not. We could
find a solution to inquire whether the build ran successfully or not in
the `run-server` command.

2. A long output is appended after the error message, requiring
to scroll to see the error message. There may also be a solution to this
problem.

It seems simpler to stick to our custom solution at this point.

## Checklist

-   ~~[ ] Changelog updated~~
-   ~~[ ] Code documented~~
