### PR TITLE
Fix localization state write

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -11,6 +11,7 @@
 ## Fixed
 
 - controller: Display interfaces' IP even if there is no gateway
+- controller: Fix timezone save when shorter than the previous saved one
 
 # [2020.7.0] - 2020-09-23
 

--- a/controller/bindings/util/util.ml
+++ b/controller/bindings/util/util.ml
@@ -20,7 +20,7 @@ let read_from_file log_src path =
 let write_to_file log_src path str =
   try
     let%lwt fd =
-      Lwt_unix.openfile path [ O_WRONLY; O_CREAT ] 0o755
+      Lwt_unix.openfile path [ O_WRONLY; O_CREAT; O_TRUNC ] 0o755
     in
     let%lwt bytes_written =
       Lwt_unix.write_string fd str 0 (String.length str)


### PR DESCRIPTION
`Util.write_to_file` was writing the string to the file as a
replacement, not as a complete modification.

1. write Accra -> Accra (OK)
2. write Johannesburg -> Johannesburg (OK)
3. write Accra -> Accranesburg (KO)

Using the `O_TRUNC` flag truncate to 0 length if the file exists.
http://caml.inria.fr/pub/docs/manual-ocaml/libref/Unix.html#TYPEopen_flag

`Utils.write_to_file` is used on:

- /var/lib/gui-localization/timezone
- /var/lib/gui-localization/keymap
- /var/lib/gui-localization/lang

But only writes on the timezone file are affected, because keymaps and
langs all have the same length (see controller/server/gui.ml), hence the
bug does not appear there.

## Checklist

-   [x] Changelog updated
-   ~~[ ] Code documented~~
