### PR TITLE
Robust wpa_supplicant startup

### DIFF
--- a/bootloader/rescue/default.nix
+++ b/bootloader/rescue/default.nix
@@ -95,8 +95,6 @@ in
       # enable wpa_supplicant
       wireless = {
         enable = true;
-        # Add a dummy network to make sure that wpa_supplicant.conf is created (see https://github.com/NixOS/nixpkgs/issues/23196)
-        networks."12345-i-do-not-exist"= {};
       };
     };
 

--- a/installer/configuration.nix
+++ b/installer/configuration.nix
@@ -54,8 +54,6 @@ with lib;
     # enable wpa_supplicant
     wireless = {
       enable = true;
-      # Add a dummy network to make sure that wpa_supplicant.conf is created (see https://github.com/NixOS/nixpkgs/issues/23196)
-      networks."12345-i-do-not-exist"= {};
     };
   };
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -12,6 +12,8 @@ let
     patches = [
       # Fixed on *master* but not on *nixos-20.09*, as of 2020/11/30
       ./patches/fix-lvm2-warnings-on-activation.patch
+      # Fix from unmerged PR as of 2020/12/14: https://github.com/NixOS/nixpkgs/pull/104722
+      ./patches/fix-wpa_supplicant-udev-restart.patch
     ];
   };
 

--- a/pkgs/patches/fix-wpa_supplicant-udev-restart.patch
+++ b/pkgs/patches/fix-wpa_supplicant-udev-restart.patch
@@ -1,0 +1,55 @@
+From 8f177612b14063b644288a5a1058bf47f44b43a5 Mon Sep 17 00:00:00 2001
+From: rnhmjoj <rnhmjoj@inventati.org>
+Date: Tue, 24 Nov 2020 00:18:18 +0100
+Subject: [PATCH] nixos/wireless: fix failure with no interfaces
+
+This resolves issue #101963.
+
+When the service is started and no interface is ready yet, wpa_supplicant
+is being exec'd with no `-i` flags, thus failing. Once the interfaces
+are ready, the udev rule would fire but wouldn't restart the unit because
+it wasn't currently running (see systemctl(1) try-restart).
+
+The solution is to exit (with a clear error message) but always restart
+wpa_supplicant when the interfaces are modified.
+---
+ nixos/modules/services/networking/wpa_supplicant.nix | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/nixos/modules/services/networking/wpa_supplicant.nix b/nixos/modules/services/networking/wpa_supplicant.nix
+index 395139879036a..3cfcb535ef5b8 100644
+--- a/nixos/modules/services/networking/wpa_supplicant.nix
++++ b/nixos/modules/services/networking/wpa_supplicant.nix
+@@ -233,9 +233,10 @@ in {
+       path = [ pkgs.wpa_supplicant ];
+ 
+       script = ''
+-        if [ -f /etc/wpa_supplicant.conf -a "/etc/wpa_supplicant.conf" != "${configFile}" ]
+-        then echo >&2 "<3>/etc/wpa_supplicant.conf present but ignored. Generated ${configFile} is used instead."
++        if [ -f /etc/wpa_supplicant.conf -a "/etc/wpa_supplicant.conf" != "${configFile}" ]; then
++          echo >&2 "<3>/etc/wpa_supplicant.conf present but ignored. Generated ${configFile} is used instead."
+         fi
++
+         iface_args="-s -u -D${cfg.driver} -c ${configFile}"
+         ${if ifaces == [] then ''
+           for i in $(cd /sys/class/net && echo *); do
+@@ -248,6 +249,10 @@ in {
+               fi
+             fi
+           done
++          if [ -z "$args" ]; then
++            echo >&2 "<3>No wireless interfaces detected (yet)."
++            exit 1
++          fi
+         '' else ''
+           args="${concatMapStringsSep " -N " (i: "-i${i} $iface_args") ifaces}"
+         ''}
+@@ -261,7 +266,7 @@ in {
+ 
+     # Restart wpa_supplicant when a wlan device appears or disappears.
+     services.udev.extraRules = ''
+-      ACTION=="add|remove", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", RUN+="/run/current-system/systemd/bin/systemctl try-restart wpa_supplicant.service"
++      ACTION=="add|remove", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", RUN+="/run/current-system/systemd/bin/systemctl restart wpa_supplicant.service"
+     '';
+   };
+ 

--- a/system/networking/default.nix
+++ b/system/networking/default.nix
@@ -45,19 +45,11 @@
         # Default is 2.
         bss_expiration_scan_count=1000
       '';
-
-      # Issue 1: Add a dummy network to make sure wpa_supplicant.conf
-      # is created (see https://github.com/NixOS/nixpkgs/issues/23196)
-      networks."12345-i-do-not-exist"= {
-        extraConfig = ''
-          disabled=1
-        '';
-      };
     };
   };
-  # Issue 2: Make sure connman starts after wpa_supplicant
+  # Issue 1: Make sure connman starts after wpa_supplicant
   systemd.services."connman".after = [ "wpa_supplicant.service" ];
-  # Issue 3: Restart wpa_supplicant (and thereby connman) after rfkill unblock of wlan
+  # Issue 2: Restart wpa_supplicant (and thereby connman) after rfkill unblock of wlan
   #          This addresses the problem of wpa_supplicant with connman not seeing any
   #          networks if wlan was initially soft blocked. (https://01.org/jira/browse/CM-670)
   services.udev.packages = [ pkgs.rfkill_udev ];


### PR DESCRIPTION
Restores wifi connectivity after upgrade to NixOS 20.09.

@guyonvarch I think you are right that this makes the dummy wifi workaround unnecessary. We should verify and suggest the connection upstream.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
