### PR TITLE
Improve controller's robustness against exceptions

### DIFF
--- a/controller/bindings/locale/locale.ml
+++ b/controller/bindings/locale/locale.ml
@@ -4,13 +4,16 @@ let log_src = Logs.Src.create "locale"
 
 let get_lang () =
   Util.read_from_file log_src "/var/lib/gui-localization/lang"
+  |> Lwt_result.catch
+  >|= Base.Result.ok
 
 let set_lang lang_code =
   Util.write_to_file log_src "/var/lib/gui-localization/lang" lang_code
 
 let get_keymap () =
   Util.read_from_file log_src "/var/lib/gui-localization/keymap"
+  |> Lwt_result.catch
+  >|= Base.Result.ok
 
 let set_keymap keymap_code =
   Util.write_to_file log_src "/var/lib/gui-localization/keymap" keymap_code
-

--- a/controller/bindings/locale/locale.mli
+++ b/controller/bindings/locale/locale.mli
@@ -1,5 +1,5 @@
 val get_lang : unit -> (string option) Lwt.t
-val set_lang : string -> bool Lwt.t
+val set_lang : string -> unit Lwt.t
 
 val get_keymap : unit -> (string option) Lwt.t
-val set_keymap : string -> bool Lwt.t
+val set_keymap : string -> unit Lwt.t

--- a/controller/bindings/timedate/timedate.ml
+++ b/controller/bindings/timedate/timedate.ml
@@ -9,6 +9,8 @@ type t = OBus_peer.Private.t
 
 let get_configured_timezone () =
   Util.read_from_file log_src "/var/lib/gui-localization/timezone"
+  |> Lwt_result.catch
+  >|= Base.Result.ok
 
 let set_timezone timezone =
   Util.write_to_file log_src "/var/lib/gui-localization/timezone" timezone

--- a/controller/bindings/timedate/timedate.mli
+++ b/controller/bindings/timedate/timedate.mli
@@ -16,7 +16,7 @@ val get_active_timezone : t -> (string option) Lwt.t
 val get_configured_timezone : unit -> (string option) Lwt.t
 
 (** [set_timezone daemon timezone] sets the timezone *)
-val set_timezone : string -> bool Lwt.t
+val set_timezone : string -> unit Lwt.t
 
 module Org_freedesktop_timedate1 : sig
   val timezone : OBus_proxy.t -> (string, [ `readable ]) OBus_property.t

--- a/controller/bindings/util/util.ml
+++ b/controller/bindings/util/util.ml
@@ -15,6 +15,9 @@ let read_from_file log_src path =
       in
       fail exn
     | exn ->
+      let%lwt () = Logs_lwt.err ~src:log_src
+        (fun m -> m "failed to read from %s: %s" path (Printexc.to_string exn))
+      in
       fail exn
   else
     fail (Failure ("File does not exist: " ^ path))
@@ -35,4 +38,7 @@ let write_to_file log_src path str =
     in
     fail exn
   | exn ->
+    let%lwt () = Logs_lwt.err ~src:log_src
+      (fun m -> m "failed to write to %s: %s" path (Printexc.to_string exn))
+    in
     fail exn

--- a/controller/bindings/util/util.ml
+++ b/controller/bindings/util/util.ml
@@ -27,11 +27,12 @@ let write_to_file log_src path str =
     let%lwt bytes_written =
       Lwt_unix.write_string fd str 0 (String.length str)
     in
-    let%lwt () = Lwt_unix.close fd in
-    Lwt.return true
+    Lwt_unix.close fd
   with
-  | Unix.Unix_error (err, fn, _) ->
+  | (Unix.Unix_error (err, fn, _)) as exn ->
     let%lwt () = Logs_lwt.err ~src:log_src
       (fun m -> m "failed to write to %s: %s" path (Unix.error_message err))
     in
-    Lwt.return false
+    fail exn
+  | exn ->
+    fail exn

--- a/controller/bindings/util/util.ml
+++ b/controller/bindings/util/util.ml
@@ -7,15 +7,17 @@ let read_from_file log_src path =
       let%lwt in_chan = Lwt_io.(open_file ~mode:Lwt_io.Input) path in
       let%lwt contents = Lwt_io.read in_chan >|= String.trim in
       let%lwt () = Lwt_io.close in_chan in
-      Some contents |> Lwt.return
+      return contents
     with
-    | Unix.Unix_error (err, fn, _) ->
+    | (Unix.Unix_error (err, fn, _)) as exn ->
       let%lwt () = Logs_lwt.err ~src:log_src
         (fun m -> m "failed to read from %s: %s" path (Unix.error_message err))
       in
-      Lwt.return None
+      fail exn
+    | exn ->
+      fail exn
   else
-    Lwt.return None
+    fail (Failure ("File does not exist: " ^ path))
 
 let write_to_file log_src path str =
   try

--- a/controller/bindings/zerotier/dune
+++ b/controller/bindings/zerotier/dune
@@ -1,6 +1,5 @@
 (library
  (name zerotier)
  (modules zerotier)
- (libraries logs logs.lwt cohttp-lwt-unix ezjsonm sexplib)
+ (libraries logs logs.lwt cohttp-lwt-unix ezjsonm sexplib util)
  (preprocess (pps lwt_ppx  ppx_sexp_conv)))
-

--- a/controller/bindings/zerotier/zerotier.ml
+++ b/controller/bindings/zerotier/zerotier.ml
@@ -1,5 +1,7 @@
 open Lwt
 
+let log_src = Logs.Src.create "zerotier"
+
 let base_url =
   Uri.make
     ~scheme:"http"
@@ -8,15 +10,9 @@ let base_url =
     ()
 
 let get_authtoken () =
-  let%lwt ic =
-    Lwt_io.(open_file ~mode:Lwt_io.Input)
-      "/var/lib/zerotier-one/authtoken.secret"
-  in
-  let%lwt authtoken = Lwt_io.read ic in
-  let%lwt () = Lwt_io.close ic in
-  authtoken
-  |> String.trim
-  |> return
+  Util.read_from_file
+    log_src
+    "/var/lib/zerotier-one/authtoken.secret"
 
 type status = {
   address: string

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -5,16 +5,6 @@ open Opium.App
 
 let log_src = Logs.Src.create "gui"
 
-(* Helper to load file *)
-let of_file f =
-  let%lwt ic = Lwt_io.(open_file ~mode:Lwt_io.Input) f in
-  let%lwt template_f = Lwt_io.read ic in
-  let%lwt () = Lwt_io.close ic in
-  template_f
-  |> Mustache.of_string
-  |> return
-
-
 (* Require the resource directory to be at a directory fixed to the binary location. This is not optimal, but works for the moment. TODO: figure out a better way to do this.
 *)
 let resource_path end_path =
@@ -23,12 +13,11 @@ let resource_path end_path =
   |> to_string
 
 (* Load a template file
-
-   TODO: cache templates
 *)
 let template name =
   Fpath.(resource_path (v "template" / (name ^ ".mustache")))
-  |> of_file
+  |> Util.read_from_file log_src
+  >|= Mustache.of_string
 
 (* Helper to render template *)
 let render name dict =

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -53,7 +53,9 @@ let success msg =
 let error_handling =
   let open Opium_kernel.Rock in
   let filter handler req =
-    match%lwt handler req |> Lwt_result.catch with
+    (* Catch any exceptions that previously escaped Lwt *)
+    let res = try handler req with exn -> Lwt.fail exn in
+    match%lwt res |> Lwt_result.catch with
     | Ok res ->
       return res
     | Error exn ->

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -201,7 +201,7 @@ module LocalizationGui = struct
       | Some [ tz_id ] ->
         Timedate.set_timezone tz_id
       | _ ->
-        return false
+        return ()
     in
     "/localization" |> Uri.of_string |> redirect'
 
@@ -214,7 +214,7 @@ module LocalizationGui = struct
       | Some [ lang ] ->
         Locale.set_lang lang
       | _ ->
-        return false
+        return ()
     in
     "/localization" |> Uri.of_string |> redirect'
 
@@ -227,7 +227,7 @@ module LocalizationGui = struct
       | Some [ keymap ] ->
         Locale.set_keymap keymap
       | _ ->
-        return false
+        return ()
     in
     "/localization" |> Uri.of_string |> redirect'
 

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -421,7 +421,7 @@ module ChangelogGui = struct
     |> get "/changelog" (fun _ ->
         let%lwt changelog = Util.read_from_file log_src (resource_path (Fpath.v "Changelog.html")) in
         page "changelog" [
-          "changelog", changelog |> Option.value ~default:"" |> Ezjsonm.string
+          "changelog", changelog |> Ezjsonm.string
         ])
 end
 

--- a/controller/server/info.ml
+++ b/controller/server/info.ml
@@ -1,5 +1,7 @@
 open Lwt
 
+let log_src = Logs.Src.create "info"
+
 type t =
   { app: string
   ; version: string
@@ -38,14 +40,6 @@ let update_url =
 let kiosk_url =
   "@PLAYOS_KIOSK_URL@"
 
-let of_file f =
-  let%lwt ic = Lwt_io.(open_file ~mode:Lwt_io.Input) f in
-  let%lwt template_f = Lwt_io.read ic in
-  let%lwt () = Lwt_io.close ic in
-  template_f
-  |> Mustache.of_string
-  |> return
-
 (** Break up a string into groups of size n *)
 let rec grouped n s =
   let l = String.length s in
@@ -59,8 +53,11 @@ let rec grouped n s =
     List.cons (String.sub s 0 n) (grouped n (String.sub s n (l - n)))
 
 let get () =
-  let%lwt ic = "/etc/machine-id" |> Lwt_io.(open_file ~mode:Input) in
-  let%lwt machine_id = Lwt_io.read ic >|= String.trim >|= grouped 4 >|= String.concat "-" in
+  let%lwt machine_id =
+    Util.read_from_file log_src "/etc/machine-id"
+    >|= grouped 4
+    >|= String.concat "-"
+  in
   let%lwt zerotier_address =
     (match%lwt Zerotier.get_status () with
      | Ok status -> Some status.address |> return
@@ -76,7 +73,6 @@ let get () =
     )
   in
   let local_time = current_time ^ " (" ^ timezone ^ ")" in
-  let%lwt () = Lwt_io.close ic in
   { app = "PlayOS Controller"
   ; version
   ; update_url


### PR DESCRIPTION
Makes the controller more robust against exceptions by

- encapsulating use of Unix lib to read from files,
- adding an outermost try-with as a last resort in the Opium middleware.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
