### PR TITLE
Disable autoplay policy restrictions

### DIFF
--- a/kiosk/kiosk_browser/browser_widget.py
+++ b/kiosk/kiosk_browser/browser_widget.py
@@ -1,7 +1,7 @@
 import re
 from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QShortcut
-from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage, QWebEngineProfile
+from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEngineSettings
 from PyQt5.QtWidgets import QSizePolicy
 
 from kiosk_browser import system
@@ -16,6 +16,10 @@ class BrowserWidget(QWebEngineView):
             system_name = system.NAME,
             system_version = system.VERSION
         ))
+
+        # Allow sound playback without user gesture
+        self.page().settings().setAttribute(QWebEngineSettings.PlaybackRequiresUserGesture, False)
+
         self.page().setUrl(url)
 
         # Shortcut to manually reload


### PR DESCRIPTION
The autoplay policy has now landed in QtWebEngine and we need to set the policy to allow-all to avoid delayed or missing sound in the application.

https://wiki.qt.io/QtWebEngine/ChromiumVersions

## Checklist

-   [x] Changelog updated
-   [x] Code documented
