### PR TITLE
Add info on installer ISO at end of deployment

### DIFF
--- a/deployment/deploy-playos-update/deploy-playos-update.py
+++ b/deployment/deploy-playos-update/deploy-playos-update.py
@@ -1,6 +1,7 @@
 #!@python36@/bin/python
 
 import argparse
+import hashlib
 import subprocess
 import os
 import os.path
@@ -48,6 +49,14 @@ def _query_continue(question, default=False):
         else:
             sys.stdout.write("Please respond with 'yes' or 'no'")
 
+def compute_sha256(filepath):
+    hash = hashlib.sha256()
+    buff = bytearray(128 * 1024)
+    mem_view = memoryview(buff)
+    with open(filepath, "rb", buffering=0) as f:
+        for n in iter(lambda : f.readinto(mem_view), 0):
+            hash.update(mem_view[:n])
+    return hash.hexdigest()
 
 def sign_rauc_bundle(key, cert, out):
     with tempfile.NamedTemporaryFile(
@@ -151,7 +160,11 @@ def _main(opts):
             ],
             check=True)
 
-        print("Deployment completed.")
+        installer_checksum = compute_sha256(installer_iso_src)
+        installer_iso_url = UPDATE_URL + VERSION + "/" + installer_iso_filename
+        print("Deployment completed.\n")
+        print("Installer URL: %s" % installer_iso_url)
+        print("Installer checksum (SHA256): %s" % installer_checksum)
 
         exit(0)
 


### PR DESCRIPTION
Provide information that will usually be required immediately following deployment.

## Testing

This is a bit tricky to test as the output is produced _after_ deployment. I tested by moving the output block further up before deployment happens.

For convenience, here's a script to run the same code on some dummy inputs and see that nothing throws and the hash is correct:

```python
import hashlib
import sys

### SETUP
UPDATE_URL = "https://dist.dividat.com/releases/playos/develop/"
VERSION = "2021.2.0"
installer_iso_src = sys.argv[1]
installer_iso_filename = f"playos-installer-{VERSION}.iso"
###

def compute_sha256(filepath):
    hash = hashlib.sha256()
    buff = bytearray(128 * 1024)
    mem_view = memoryview(buff)
    with open(filepath, "rb", buffering=0) as f:
        for n in iter(lambda : f.readinto(mem_view), 0):
            hash.update(mem_view[:n])
    return hash.hexdigest()

installer_checksum = compute_sha256(installer_iso_src)
installer_iso_url = UPDATE_URL + VERSION + "/" + installer_iso_filename
print("Deployment completed.\n")
print("Installer URL: %s" % installer_iso_url)
print("Installer checksum (SHA256): %s" % installer_checksum)
```

```
❖ python dummy-checksum.py dummy-checksum.py 
Deployment completed.

Installer URL: https://dist.dividat.com/releases/playos/develop/2021.2.0/playos-installer-2021.2.0.iso
Installer checksum (SHA256): 4205fca39f70e2ec6457a08f02280a52cd0348bd79ed824cbc75cd17da25208c
❖ sha256sum dummy-checksum.py 
4205fca39f70e2ec6457a08f02280a52cd0348bd79ed824cbc75cd17da25208c  dummy-checksum.py
```

## Checklist

-   [x] Changelog updated
-   [x] Code documented
