### PR TITLE
Start ZeroTier on demand

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -11,6 +11,7 @@
 - controller: Format machine-id in groups of 4 for readability
 - os: Update nixpkgs channel to 20.09
 - controller: Display network configuration on separate pages
+- controller: Enable remote management on demand only
 
 ## Fixed
 

--- a/controller/bindings/systemd/systemd.ml
+++ b/controller/bindings/systemd/systemd.ml
@@ -64,6 +64,20 @@ struct
     (* but we don't use it. *)
     return_unit
 
+  let start_unit proxy name =
+    let%lwt (context, x1) =
+      OBus_method.call_with_context
+        Org_freedesktop_systemd1_Manager.m_StartUnit proxy (name, "replace")
+    in
+    return_unit
+
+  let stop_unit proxy name =
+    let%lwt (context, x1) =
+      OBus_method.call_with_context
+        Org_freedesktop_systemd1_Manager.m_StopUnit proxy (name, "replace")
+    in
+    return_unit
+
 end
 
 

--- a/controller/bindings/systemd/systemd.mli
+++ b/controller/bindings/systemd/systemd.mli
@@ -11,7 +11,7 @@ module Manager : sig
   (** connect with systemd D-Bus API *)
   val connect : unit -> t Lwt.t
 
-  (** System state *) 
+  (** System state *)
   type system_state =
     | Initializing
     | Starting
@@ -29,7 +29,7 @@ module Manager : sig
   (** [get_unit t name] returns the unit [name] *)
   val get_unit : t -> string -> Unit.t Lwt.t
 
-  (** [restart_unit t name] a unit with name [unit].
+  (** [restart_unit t name] a unit with name [name].
 
       Example:
 
@@ -37,5 +37,23 @@ module Manager : sig
 
   *)
   val restart_unit : t -> string -> unit Lwt.t
+
+  (** [start_unit t name] a unit with name [name].
+
+      Example:
+
+        start_unit t "zerotierone.service"
+
+   *)
+  val start_unit : t -> string -> unit Lwt.t
+
+  (** [stop_unit t name] a unit with name [name].
+
+      Example:
+
+        stop_unit t "zerotierone.service"
+
+   *)
+  val stop_unit : t -> string -> unit Lwt.t
 
 end

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -70,6 +70,13 @@
     filter: invert(70%) sepia(70%) saturate(100%);
 }
 
+/* Info */
+
+.d-Info__RemoteManagementForm {
+    display: inline;
+    margin-left: 1rem;
+}
+
 /* Network list */
 
 .d-NetworkList__Network {
@@ -165,6 +172,16 @@
     font-size: 80%;
     color: #404040;
     margin-bottom: 1rem;
+}
+
+/* Switch */
+
+.d-Switch--On {
+    color: green;
+}
+
+.d-Switch--Off {
+    color: red;
 }
 
 /* Wifi signal */

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -74,7 +74,10 @@
 
 .d-Info__RemoteManagementForm {
     display: inline;
-    margin-left: 1rem;
+}
+
+.d-Info__RemoteManagementAddress {
+    margin-right: 1rem;
 }
 
 /* Network list */

--- a/controller/server/gui.mli
+++ b/controller/server/gui.mli
@@ -1,5 +1,6 @@
 val start :
   port : int
+  -> systemd : Systemd.Manager.t
   -> shutdown : (unit -> unit Lwt.t)
   -> health_s : Health.state Lwt_react.S.t
   -> update_s : Update.state Lwt_react.S.t

--- a/controller/server/network.ml
+++ b/controller/server/network.ml
@@ -33,7 +33,7 @@ let enable_and_scan_wifi_devices ~connman =
   |> Lwt_result.catch
 
 
-let init ~systemd ~connman =
+let init ~connman =
   let%lwt () = Logs_lwt.info (fun m -> m "initializing network connections") in
 
   match%lwt enable_and_scan_wifi_devices ~connman with

--- a/controller/server/network.mli
+++ b/controller/server/network.mli
@@ -1,6 +1,6 @@
 (** Initialize Network connectivity *)
-val init : systemd : Systemd.Manager.t
-  -> connman : Connman.Manager.t
+val init
+  : connman : Connman.Manager.t
   -> (unit,exn) Lwt_result.t
 
 module Interface : sig

--- a/controller/server/server.ml
+++ b/controller/server/server.ml
@@ -69,6 +69,7 @@ let main debug port =
   (* Start the GUI *)
   let gui_p =
     Gui.start
+      ~systemd
       ~port
       ~shutdown
       ~rauc

--- a/controller/server/server.ml
+++ b/controller/server/server.ml
@@ -80,7 +80,7 @@ let main debug port =
   let%lwt () =
     (* Initialize Network, parallel to starting server *)
     begin
-      match%lwt Network.init ~systemd ~connman with
+      match%lwt Network.init ~connman with
       | Ok () ->
         return_unit
       | Error exn ->

--- a/controller/server/view/info_page.ml
+++ b/controller/server/view/info_page.ml
@@ -18,13 +18,13 @@ let remote_management_form action button_label =
 let remote_management address =
   match address with
   | Some address ->
-      [ span ~a:[ a_class [ "d-Switch--On" ] ] [ txt address ]
+      [ span
+          ~a:[ a_class [ "d-Switch--On"; "d-Info__RemoteManagementAddress" ] ]
+          [ txt address ]
       ; remote_management_form "disable" "Disable"
       ]
   | None ->
-      [ span ~a:[ a_class [ "d-Switch--Off" ] ] [ txt "off" ]
-      ; remote_management_form "enable" "Enable"
-      ]
+      [ remote_management_form "enable" "Enable" ]
 
 let html server_info =
   Page.html ~current_page:Page.Info (

--- a/controller/server/view/info_page.ml
+++ b/controller/server/view/info_page.ml
@@ -1,7 +1,7 @@
 open Info
 open Tyxml.Html
 
-let zerotier_form action button_label =
+let remote_management_form action button_label =
   form
     ~a:[ a_action ("/remote-management/" ^ action)
     ; a_method `Post
@@ -15,15 +15,15 @@ let zerotier_form action button_label =
         ()
     ]
 
-let zerotier address =
+let remote_management address =
   match address with
   | Some address ->
       [ span ~a:[ a_class [ "d-Switch--On" ] ] [ txt address ]
-      ; zerotier_form "disable" "Disable"
+      ; remote_management_form "disable" "Disable"
       ]
   | None ->
       [ span ~a:[ a_class [ "d-Switch--Off" ] ] [ txt "off" ]
-      ; zerotier_form "enable" "Enable"
+      ; remote_management_form "enable" "Enable"
       ]
 
 let html server_info =
@@ -44,7 +44,7 @@ let html server_info =
           ; Definition.description [ txt server_info.machine_id ]
 
           ; Definition.term [ txt "Remote management" ]
-          ; Definition.description (zerotier server_info.zerotier_address)
+          ; Definition.description (remote_management server_info.zerotier_address)
 
           ; Definition.term [ txt "Local time" ]
           ; Definition.description [ txt server_info.local_time ]

--- a/controller/server/view/info_page.ml
+++ b/controller/server/view/info_page.ml
@@ -1,6 +1,31 @@
 open Info
 open Tyxml.Html
 
+let zerotier_form action button_label =
+  form
+    ~a:[ a_action ("/remote-management/" ^ action)
+    ; a_method `Post
+    ; a_class [ "d-Info__RemoteManagementForm" ]
+    ]
+    [ input
+        ~a:[ a_input_type `Submit
+        ; a_class [ "d-Button" ]
+        ; a_value button_label
+        ]
+        ()
+    ]
+
+let zerotier address =
+  match address with
+  | Some address ->
+      [ span ~a:[ a_class [ "d-Switch--On" ] ] [ txt address ]
+      ; zerotier_form "disable" "Disable"
+      ]
+  | None ->
+      [ span ~a:[ a_class [ "d-Switch--Off" ] ] [ txt "off" ]
+      ; zerotier_form "enable" "Enable"
+      ]
+
 let html server_info =
   Page.html ~current_page:Page.Info (
     div
@@ -18,9 +43,8 @@ let html server_info =
           ; Definition.term [ txt "Machine ID" ]
           ; Definition.description [ txt server_info.machine_id ]
 
-          ; Definition.term [ txt "ZeroTier address" ]
-          ; Definition.description
-              [ txt (server_info.zerotier_address |> Option.value ~default:"—") ]
+          ; Definition.term [ txt "Remote management" ]
+          ; Definition.description (zerotier server_info.zerotier_address)
 
           ; Definition.term [ txt "Local time" ]
           ; Definition.description [ txt server_info.local_time ]

--- a/controller/server/view/info_page.ml
+++ b/controller/server/view/info_page.ml
@@ -19,7 +19,7 @@ let remote_management address =
   match address with
   | Some address ->
       [ span
-          ~a:[ a_class [ "d-Switch--On"; "d-Info__RemoteManagementAddress" ] ]
+          ~a:[ a_class [ "d-Info__RemoteManagementAddress" ] ]
           [ txt address ]
       ; remote_management_form "disable" "Disable"
       ]

--- a/controller/server/view/network_list_page.ml
+++ b/controller/server/view/network_list_page.ml
@@ -53,11 +53,11 @@ let html { proxy; is_internet_connected; services } =
           ; Definition.description
               [ if is_internet_connected then
                   span
-                    ~a:[ a_class [ "d-Network__InternetConnected" ] ]
+                    ~a:[ a_class [ "d-Switch--On" ] ]
                     [ txt "Connected" ]
                 else
                   span
-                    ~a:[ a_class [ "d-Network__InternetNotConnected" ] ]
+                    ~a:[ a_class [ "d-Switch--Off" ] ]
                     [ txt "Not connected" ]
               ]
           ]

--- a/system/remote-management.nix
+++ b/system/remote-management.nix
@@ -9,15 +9,6 @@
   # Prevent ZeroTier from running on startup
   systemd.services.zerotierone.wantedBy = lib.mkForce [];
 
-  # Make the zerotier data directory persistent (on user data partition). This
-  # means zerotier id of this machine will be persisted on updates but not when
-  # wiping user data partition.
-  volatileRoot.persistentFolders."/var/lib/zerotier-one/" = {
-    mode = "0700";
-    user = "root";
-    group = "root";
-  };
-
   # Allow remote access via OpenSSH
   services.openssh = {
     enable = true;

--- a/system/remote-management.nix
+++ b/system/remote-management.nix
@@ -6,6 +6,8 @@
     # from the ext.dividat.com network.
     joinNetworks = [ "a09acf02330ccc60" ];
   };
+  # Prevent ZeroTier from running on startup
+  systemd.services.zerotierone.wantedBy = lib.mkForce [];
 
   # Make the zerotier data directory persistent (on user data partition). This
   # means zerotier id of this machine will be persisted on updates but not when


### PR DESCRIPTION
We don’t want to connect every PlayOS computer by default to the
ZeroTier network. Instead, we are now providing an UI to activate
ZeroTier on demand.

See https://trello.com/c/Hfs6LMKf/687-zerotier-off-by-default-in-playos

## Checklist

-   [x] Changelog updated
-   [x] Code documented
