### PR TITLE
Static IP support

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -5,6 +5,7 @@
 - controller: Enable HTTPS support for system update hosts
 - os: Support manually configured authenticated proxies
 - system: Add status screen to tty8
+- controller: Add support for static IP configuration
 
 ## Changed
 

--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -379,25 +379,25 @@ struct
     set_property service "Proxy.Configuration" dict
 
 
-  let set_ipv4 ?address ?netmask ?gateway service ~method'  =
-    let values =
-      List.fold_right (fun (name, value) acc ->
-          match value with
-          | Some v -> acc @ [ (name, OBus_value.C.(make_single basic_string) v) ]
-          | None -> acc
-        ) [ ("Method", Some method')
-          ; ("Address", address)
-          ; ("Netmask", netmask)
-          ; ("Gateway", gateway)
-          ]
-        []
-    in
+  let set_manual_ipv4 service ~address ~netmask ~gateway =
     let dict =
       OBus_value.C.make_single
         (OBus_value.C.(dict string variant))
-        values
-     in
-     set_property service "IPv4.Configuration" dict
+        [ ("Method", OBus_value.C.(make_single basic_string) "manual")
+        ; ("Address", OBus_value.C.(make_single basic_string) address)
+        ; ("Netmask", OBus_value.C.(make_single basic_string) netmask)
+        ; ("Gateway", OBus_value.C.(make_single basic_string) gateway)
+        ]
+    in
+    set_property service "IPv4.Configuration" dict
+
+  let set_dhcp_ipv4 service =
+    let dict =
+      OBus_value.C.make_single
+        (OBus_value.C.(dict string variant))
+        [("Method", OBus_value.C.(make_single basic_string) "dhcp")]
+    in
+    set_property service "IPv4.Configuration" dict
 
   let set_nameservers service nameservers =
     let config =

--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -276,7 +276,13 @@ struct
   ; strength : int option
   ; favorite : bool
   ; autoconnect : bool
+
+  (* The ipv4 field represents the actual system configuration,
+     while the ipv4_user_config represents values manually configured by the user.
+  *)
   ; ipv4 : IPv4.t option
+  ; ipv4_user_config : IPv4.t option
+
   ; ipv6 : IPv6.t option
   ; ethernet : Ethernet.t
   ; proxy : string option
@@ -322,12 +328,12 @@ struct
         _ -> None
     in
     CCOpt.(
-      pure (fun name type' state strength favorite autoconnect ipv4 ipv6 ethernet proxy nameservers ->
+      pure (fun name type' state strength favorite autoconnect ipv4 ipv4_user_config ipv6 ethernet proxy nameservers ->
           { _proxy = OBus_proxy.make (OBus_context.sender context) path
           ; _manager = manager
           ; id = path |> CCList.last 1 |> CCList.hd
           ; name ; type'; state; strength; favorite; autoconnect
-          ; ipv4; ipv6; ethernet; proxy; nameservers
+          ; ipv4; ipv4_user_config; ipv6; ethernet; proxy; nameservers
           })
       <*> (properties |> List.assoc_opt "Name" >>= string_of_obus)
       <*> (properties |> List.assoc_opt "Type" >>= string_of_obus >>= Technology.type_of_string)
@@ -336,6 +342,7 @@ struct
       <*> (properties |> List.assoc_opt "Favorite" >>= bool_of_obus)
       <*> (properties |> List.assoc_opt "AutoConnect" >>= bool_of_obus)
       <*> (properties |> List.assoc_opt "IPv4" >>= IPv4.of_obus |> pure)
+      <*> (properties |> List.assoc_opt "IPv4.Configuration" >>= IPv4.of_obus |> pure)
       <*> (properties |> List.assoc_opt "IPv6" >>= IPv6.of_obus |> pure)
       <*> (properties |> List.assoc_opt "Ethernet" >>= Ethernet.of_obus)
       <*> (properties |> List.assoc_opt "Proxy" >>= proxy_of_obus |> pure)

--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -19,6 +19,12 @@ let bool_of_obus value =
   with
     _ -> None
 
+let string_list_of_obus value =
+   try
+    OBus_value.C.(value |> cast_single (array basic_string))
+   with
+     _ -> []
+
 module Technology =
 struct
   type type' =
@@ -274,6 +280,7 @@ struct
   ; ipv6 : IPv6.t option
   ; ethernet : Ethernet.t
   ; proxy : string option
+  ; nameservers : string list
   }
   [@@deriving sexp]
 
@@ -315,12 +322,12 @@ struct
         _ -> None
     in
     CCOpt.(
-      pure (fun name type' state strength favorite autoconnect ipv4 ipv6 ethernet proxy ->
+      pure (fun name type' state strength favorite autoconnect ipv4 ipv6 ethernet proxy nameservers ->
           { _proxy = OBus_proxy.make (OBus_context.sender context) path
           ; _manager = manager
           ; id = path |> CCList.last 1 |> CCList.hd
           ; name ; type'; state; strength; favorite; autoconnect
-          ; ipv4; ipv6; ethernet; proxy
+          ; ipv4; ipv6; ethernet; proxy; nameservers
           })
       <*> (properties |> List.assoc_opt "Name" >>= string_of_obus)
       <*> (properties |> List.assoc_opt "Type" >>= string_of_obus >>= Technology.type_of_string)
@@ -332,7 +339,7 @@ struct
       <*> (properties |> List.assoc_opt "IPv6" >>= IPv6.of_obus |> pure)
       <*> (properties |> List.assoc_opt "Ethernet" >>= Ethernet.of_obus)
       <*> (properties |> List.assoc_opt "Proxy" >>= proxy_of_obus |> pure)
-    )
+      <*> (properties |> List.assoc_opt "Nameservers.Configuration" >|= string_list_of_obus))
 
   let is_connected t =
     match t.state with
@@ -363,6 +370,15 @@ struct
         ]
     in
     set_property service "Proxy.Configuration" dict
+
+
+  let set_nameservers service nameservers =
+    let config =
+        OBus_value.C.make_single
+          (OBus_value.C.(array basic_string)) nameservers
+    in
+    set_property service "Nameservers.Configuration" config
+
 
 
   let connect ?(input=Agent.None) service =

--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -379,6 +379,26 @@ struct
     set_property service "Proxy.Configuration" dict
 
 
+  let set_ipv4 ?address ?netmask ?gateway service ~method'  =
+    let values =
+      List.fold_right (fun (name, value) acc ->
+          match value with
+          | Some v -> acc @ [ (name, OBus_value.C.(make_single basic_string) v) ]
+          | None -> acc
+        ) [ ("Method", Some method')
+          ; ("Address", address)
+          ; ("Netmask", netmask)
+          ; ("Gateway", gateway)
+          ]
+        []
+    in
+    let dict =
+      OBus_value.C.make_single
+        (OBus_value.C.(dict string variant))
+        values
+     in
+     set_property service "IPv4.Configuration" dict
+
   let set_nameservers service nameservers =
     let config =
         OBus_value.C.make_single

--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -276,13 +276,7 @@ struct
   ; strength : int option
   ; favorite : bool
   ; autoconnect : bool
-
-  (* The ipv4 field represents the actual system configuration,
-     while the ipv4_user_config represents values manually configured by the user.
-  *)
   ; ipv4 : IPv4.t option
-  ; ipv4_user_config : IPv4.t option
-
   ; ipv6 : IPv6.t option
   ; ethernet : Ethernet.t
   ; proxy : string option
@@ -333,7 +327,8 @@ struct
           ; _manager = manager
           ; id = path |> CCList.last 1 |> CCList.hd
           ; name ; type'; state; strength; favorite; autoconnect
-          ; ipv4; ipv4_user_config; ipv6; ethernet; proxy; nameservers
+          ; ipv4 = (if Option.is_some ipv4_user_config then ipv4_user_config else ipv4)
+          ; ipv6; ethernet; proxy; nameservers
           })
       <*> (properties |> List.assoc_opt "Name" >>= string_of_obus)
       <*> (properties |> List.assoc_opt "Type" >>= string_of_obus >>= Technology.type_of_string)

--- a/controller/bindings/connman/connman.mli
+++ b/controller/bindings/connman/connman.mli
@@ -110,7 +110,6 @@ module Service : sig
   ; favorite : bool
   ; autoconnect : bool
   ; ipv4 : IPv4.t option
-  ; ipv4_user_config : IPv4.t option
   ; ipv6 : IPv6.t option
   ; ethernet : Ethernet.t
   ; proxy : string option

--- a/controller/bindings/connman/connman.mli
+++ b/controller/bindings/connman/connman.mli
@@ -113,6 +113,7 @@ module Service : sig
   ; ipv6 : IPv6.t option
   ; ethernet : Ethernet.t
   ; proxy : string option
+  ; nameservers : string list
   }
   [@@deriving sexp]
 
@@ -122,6 +123,8 @@ module Service : sig
   val set_direct_proxy : t -> unit Lwt.t
 
   val set_manual_proxy : t -> string -> unit Lwt.t
+
+  val set_nameservers : t -> string list -> unit Lwt.t
 
   val connect : ?input:Agent.input -> t -> unit Lwt.t
 

--- a/controller/bindings/connman/connman.mli
+++ b/controller/bindings/connman/connman.mli
@@ -125,7 +125,9 @@ module Service : sig
 
   val set_manual_proxy : t -> string -> unit Lwt.t
 
-  val set_ipv4 : ?address:string -> ?netmask:string -> ?gateway:string -> t -> method':string -> unit Lwt.t
+  val set_manual_ipv4 : t -> address:string -> netmask:string -> gateway:string -> unit Lwt.t
+
+  val set_dhcp_ipv4 : t -> unit Lwt.t
 
   val set_nameservers : t -> string list -> unit Lwt.t
 

--- a/controller/bindings/connman/connman.mli
+++ b/controller/bindings/connman/connman.mli
@@ -125,6 +125,8 @@ module Service : sig
 
   val set_manual_proxy : t -> string -> unit Lwt.t
 
+  val set_ipv4 : ?address:string -> ?netmask:string -> ?gateway:string -> t -> method':string -> unit Lwt.t
+
   val set_nameservers : t -> string list -> unit Lwt.t
 
   val connect : ?input:Agent.input -> t -> unit Lwt.t

--- a/controller/bindings/connman/connman.mli
+++ b/controller/bindings/connman/connman.mli
@@ -110,6 +110,7 @@ module Service : sig
   ; favorite : bool
   ; autoconnect : bool
   ; ipv4 : IPv4.t option
+  ; ipv4_user_config : IPv4.t option
   ; ipv6 : IPv6.t option
   ; ethernet : Ethernet.t
   ; proxy : string option

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -363,9 +363,9 @@
 }
 
 .d-BackLink {
-  color: blue;
-  font-size: 1rem;
-  text-decoration: none;
+    color: blue;
+    font-size: 1rem;
+    text-decoration: none;
 }
 
 .d-BackLink:hover {
@@ -373,5 +373,5 @@
 }
 
 .d-BackLink:before {
-  content: "❮ ";
+    content: "❮ ";
 }

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -177,6 +177,31 @@
     margin-bottom: 1rem;
 }
 
+
+
+/* Nameserver form */
+
+.d-NameserverRemoveForm {
+    margin-bottom: 0.5rem;
+    align-items: center;
+    line-height: 1;
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-columns: 20ch min-content;
+    height: var(--form-component-height);
+}
+
+.d-NameserverRemoveForm__Nameserver {
+    background: #f1f1f1;
+    width: 100%;
+    height: calc(100%);
+    padding: 0.5rem;
+    font-size: var(--form-component-font-size);
+    display: flex;
+    align-items: center;
+}
+
+
 /* Switch */
 
 .d-Switch--On {
@@ -374,4 +399,8 @@
 
 .d-BackLink:before {
     content: "❮ ";
+}
+
+.d-TabularNums {
+    font-variant-numeric: tabular-nums;
 }

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -376,7 +376,3 @@
 .d-BackLink:before {
     content: "❮ ";
 }
-
-.d-TabularNums {
-    font-variant-numeric: tabular-nums;
-}

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -178,30 +178,6 @@
 }
 
 
-
-/* Nameserver form */
-
-.d-NameserverRemoveForm {
-    margin-bottom: 0.5rem;
-    align-items: center;
-    line-height: 1;
-    display: grid;
-    grid-auto-flow: column;
-    grid-template-columns: 20ch min-content;
-    height: var(--form-component-height);
-}
-
-.d-NameserverRemoveForm__Nameserver {
-    background: #f1f1f1;
-    width: 100%;
-    height: calc(100%);
-    padding: 0.5rem;
-    font-size: var(--form-component-font-size);
-    display: flex;
-    align-items: center;
-}
-
-
 /* Switch */
 
 .d-Switch--On {

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -344,8 +344,8 @@ module NetworkGui = struct
     |> post "/network/:id/proxy/update" (update_proxy ~connman)
     |> post "/network/:id/proxy/remove" (remove_proxy ~connman)
     |> post "/network/:id/remove" (remove ~connman)
-    |> post "/network/:id/staticip/update" (update_static_ip ~connman)
-    |> post "/network/:id/staticip/remove" (remove_static_ip ~connman)
+    |> post "/network/:id/static-ip/update" (update_static_ip ~connman)
+    |> post "/network/:id/static-ip/remove" (remove_static_ip ~connman)
 end
 
 

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -313,7 +313,7 @@ module NetworkGui = struct
     let netmask = get_prop "netmask" in
     let gateway = get_prop "gateway" in
     let nameservers = get_prop "nameservers" |> String.split_on_char ',' |> List.map (String.trim) in
-    let%lwt () = Connman.Service.set_ipv4 service  ~method':"manual" ~address ~netmask ~gateway in
+    let%lwt () = Connman.Service.set_manual_ipv4 service ~address ~netmask ~gateway in
     let%lwt () = Connman.Service.set_nameservers service nameservers in
     Lwt.return (success (Format.sprintf "Configured static IP for %s." service.name))
 
@@ -321,7 +321,7 @@ module NetworkGui = struct
   let remove_static_ip ~(connman: Connman.Manager.t) req =
     let%lwt form_data = urlencoded_pairs_of_body req in
     let%lwt service = with_service ~connman (param req "id") in
-    let%lwt () = Connman.Service.set_ipv4 service  ~method':"dhcp" in
+    let%lwt () = Connman.Service.set_dhcp_ipv4 service in
     let%lwt () = Connman.Service.set_nameservers service [] in
     Lwt.return (success (Format.sprintf "Removed static IP configuration of %s." service.name))
 
@@ -331,7 +331,7 @@ module NetworkGui = struct
 
     (* Clear settings that might have been configured on the service. *)
     let%lwt () = Connman.Service.set_nameservers service [] in
-    let%lwt () = Connman.Service.set_ipv4 service ~method':"dhcp" in
+    let%lwt () = Connman.Service.set_dhcp_ipv4 service in
 
     let%lwt () = Connman.Service.remove service in
     Lwt.return (success (Format.sprintf "Removed service %s." service.name))

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -266,6 +266,11 @@ module NetworkGui = struct
         Connman.Agent.None
     in
     let%lwt service = with_service ~connman (param req "id") in
+
+    (* Clear settings that might have been configured previously. *)
+    let%lwt () =     Connman.Service.set_nameservers service [] in
+    let%lwt () = Connman.Service.set_dhcp_ipv4 service in
+
     let%lwt proxy = with_empty_or_valid_proxy form_data in
     let%lwt () = Connman.Service.connect ~input:passphrase service in
     match proxy with
@@ -328,11 +333,6 @@ module NetworkGui = struct
   (** Remove a service **)
   let remove ~(connman:Connman.Manager.t) req =
     let%lwt service = with_service ~connman (param req "id") in
-
-    (* Clear settings that might have been configured on the service. *)
-    let%lwt () = Connman.Service.set_nameservers service [] in
-    let%lwt () = Connman.Service.set_dhcp_ipv4 service in
-
     let%lwt () = Connman.Service.remove service in
     Lwt.return (success (Format.sprintf "Removed service %s." service.name))
 

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -312,7 +312,9 @@ module NetworkGui = struct
     let address = get_prop "address" in
     let netmask = get_prop "netmask" in
     let gateway = get_prop "gateway" in
+    let nameservers = get_prop "nameservers" |> String.split_on_char ',' |> List.map (String.trim) in
     let%lwt () = Connman.Service.set_ipv4 service  ~method':"manual" ~address ~netmask ~gateway in
+    let%lwt () = Connman.Service.set_nameservers service nameservers in
     Lwt.return (success (Format.sprintf "Configured static IP for %s." service.name))
 
   (** Remove static IP configuration from a service *)
@@ -320,22 +322,8 @@ module NetworkGui = struct
     let%lwt form_data = urlencoded_pairs_of_body req in
     let%lwt service = with_service ~connman (param req "id") in
     let%lwt () = Connman.Service.set_ipv4 service  ~method':"dhcp" in
+    let%lwt () = Connman.Service.set_nameservers service [] in
     Lwt.return (success (Format.sprintf "Removed static IP configuration of %s." service.name))
-
-  (** Add nameserver to a service *)
-  let add_nameserver ~(connman:Connman.Manager.t) req =
-    let%lwt service = with_service ~connman (param req "id") in
-    let%lwt form_data = urlencoded_pairs_of_body req in
-    let new_nameserver = List.assoc "nameserver" form_data |> List.hd in
-    let%lwt () = Connman.Service.set_nameservers service (service.nameservers @ [ new_nameserver ]) in
-    Lwt.return (success (Format.sprintf "Added %s to nameservers of %s" new_nameserver service.name))
-
-  (** Remove a nameserver from a service *)
-  let remove_nameserver ~(connman:Connman.Manager.t) req =
-    let%lwt service = with_service ~connman (param req "id") in
-    let nameserver = param req "nameserver" in
-    let%lwt () = Connman.Service.set_nameservers service (service.nameservers |> List.filter(fun ns -> ns <> nameserver)) in
-    Lwt.return (success (Format.sprintf "Removed %s from nameservers of %s." nameserver service.name))
 
   (** Remove a service **)
   let remove ~(connman:Connman.Manager.t) req =
@@ -358,9 +346,6 @@ module NetworkGui = struct
     |> post "/network/:id/remove" (remove ~connman)
     |> post "/network/:id/staticip/update" (update_static_ip ~connman)
     |> post "/network/:id/staticip/remove" (remove_static_ip ~connman)
-    |> post "/network/:id/nameservers/add" (add_nameserver ~connman)
-    |> post "/network/:id/nameservers/:nameserver/remove" (remove_nameserver ~connman)
-
 end
 
 

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -268,7 +268,7 @@ module NetworkGui = struct
     let%lwt service = with_service ~connman (param req "id") in
 
     (* Clear settings that might have been configured previously. *)
-    let%lwt () =     Connman.Service.set_nameservers service [] in
+    let%lwt () = Connman.Service.set_nameservers service [] in
     let%lwt () = Connman.Service.set_dhcp_ipv4 service in
 
     let%lwt proxy = with_empty_or_valid_proxy form_data in

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -118,7 +118,9 @@ let static_ip_form service =
   in
   div ~a:[ a_class [ "d-Network__Form" ]]
     [ p ~a: [ a_class ["d-Network__Note"]  ][
-          txt "A valid IP address must be in the form of n.n.n.n,"
+          txt "A valid IP address must be in the form of "
+        ; code ~a:[ a_class [ "d-Code" ] ] [ txt "n.n.n.n" ]
+        ; txt ","
         ; br ()
         ; txt "where n is a number in the range of 0-255."
         ]

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -119,7 +119,7 @@ let static_ip_form service =
         ; br ()
         ; txt "where n is a number in the range of 0-255."
         ]
-    ; form ~a:[ a_action ("/network/" ^ service.id ^ "/staticip/update")
+    ; form ~a:[ a_action ("/network/" ^ service.id ^ "/static-ip/update")
               ; a_id "static-ip-form"
               ; a_method `Post
               ]
@@ -158,7 +158,7 @@ let static_ip_form service =
                      ; a_class [ "d-Button" ]
                      ]()
           ; if is_static then
-              form ~a:[ a_action ( "/network/" ^ service.id ^ "/staticip/remove" )
+              form ~a:[ a_action ( "/network/" ^ service.id ^ "/static-ip/remove" )
                       ; a_method `Post
                       ; a_style "display: inline; margin-left: 0.5rem"
                       ]

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -87,6 +87,73 @@ let disable_proxy_form service =
 let ip_address_regex_pattern =
   "^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\\.(?!$)|$)){4}$"
 
+let static_ip_form service =
+  let is_static =
+    service.ipv4
+    |> Option.map(fun (ipv4: IPv4.t) -> ipv4.method' = "manual")
+    |> Option.value ~default:false
+  in
+  let ip_input ~id ~labelTxt ~name ~value =
+    [
+      div ~a:[ a_class [ "d-Network__Label" ] ] [ label ~a:[ a_label_for id ] [ txt labelTxt ] ]
+    ; input ~a:[ a_id id
+               ; a_value value
+               ; a_class [ "d-Input"; "d-Network__Input" ]
+               ; a_name name
+               ; a_required ()
+               ; a_pattern ip_address_regex_pattern
+               ]()
+    ]
+  in
+  let inputValue f =
+    if is_static then
+      service.ipv4_user_config |> Option.map (fun (ipv4:IPv4.t) -> f ipv4) |> Option.value ~default:""
+    else
+      ""
+  in
+  div ~a:[ a_class [ "d-Network__Form" ]]
+    [ form ~a:[ a_action ("/network/" ^ service.id ^ "/staticip/update")
+              ; a_id "static-ip-form"
+              ; a_method `Post
+              ]
+        [ div ( ip_input
+                  ~id:"static-ip-address"
+                  ~labelTxt:"Address"
+                  ~name:"address"
+                  ~value:(inputValue(fun ipv4 -> ipv4.address))
+                @ ip_input
+                  ~id:"static-ip-netmask"
+                  ~labelTxt:"Netmask"
+                  ~name:"netmask"
+                  ~value:(inputValue(fun ipv4 -> ipv4.netmask))
+                @ ip_input
+                  ~id:"static-ip-gateway"
+                  ~labelTxt:"Gateway"
+                  ~name:"gateway"
+                  ~value:(inputValue(fun ipv4 -> ipv4.gateway |> Option.value ~default:""))
+              )
+        ]
+    ; div
+        [ input ~a:[ a_value "Update"
+                     ; a_form "static-ip-form"
+                     ; a_input_type `Submit
+                     ; a_class [ "d-Button" ]
+                     ]()
+          ; if is_static then
+              form ~a:[ a_action ( "/network/" ^ service.id ^ "/staticip/remove" )
+                      ; a_method `Post
+                      ; a_style "display: inline; margin-left: 0.5rem"
+                      ]
+                [ input ~a:[ a_value "Remove"
+                           ; a_input_type `Submit
+                           ; a_class [ "d-Button" ]
+                           ]()
+                ]
+            else
+              txt ""
+          ]
+    ]
+
 let nameservers_form service =
   let nameserver_remove_form nameserver =
     form ~a:[ a_action ("/network/" ^ service.id ^ "/nameservers/" ^ nameserver ^ "/remove")
@@ -165,6 +232,9 @@ let connected_form service =
             ; proxy_form_note
             ]
         ]
+
+    ; details (summary [ txt "Static IP" ])
+      [ static_ip_form service ]
     ; details (summary [ txt "Nameservers" ])
       [ nameservers_form service ]
     ]

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -9,7 +9,7 @@ let proxy_label service_id =
     ~a:[ a_class [ "d-Network__Label" ] ]
     [ label
         ~a:[ a_label_for (proxy_id service_id) ]
-        [ txt "Proxy" ]
+        [ txt "URL" ]
     ]
 
 let proxy_input ?proxy service_id =

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -53,7 +53,7 @@ let not_connected_form service =
           ]
           ()
       ; details
-          (summary [ txt "Advanced Settings" ])
+          (summary [ txt "Proxy Settings" ])
           [ div
               ~a:[ a_class [ "d-Network__AdvancedSettingsTitle" ] ]
               [ proxy_label service.id
@@ -82,6 +82,47 @@ let disable_proxy_form service =
           ()
       ]
 
+(* Regex pattern to validate IP addresses
+ * From: https://stackoverflow.com/a/36760050 *)
+let ip_address_regex_pattern =
+  "^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\\.(?!$)|$)){4}$"
+
+let nameservers_form service =
+  let nameserver_remove_form nameserver =
+    form ~a:[ a_action ("/network/" ^ service.id ^ "/nameservers/" ^ nameserver ^ "/remove")
+            ; a_method `Post
+            ; a_class [ "d-NameserverRemoveForm" ]
+            ]
+      [ div ~a: [ a_class [ "d-TabularNums"; "d-NameserverRemoveForm__Nameserver" ] ] [ txt nameserver ]
+      ; input ~a:[ a_input_type `Submit
+                 ; a_class [ "d-Button" ]
+                 ; a_value "Remove"
+                 ] ()
+      ]
+  in
+  let nameserver_add_form =
+    form
+      ~a:[ a_action ("/network/" ^ service.id ^ "/nameservers/add")
+         ; a_method `Post
+         ; a_class []
+         ]
+      [ input ~a:[ a_class [ "d-Input"; "d-Network__Input" ]
+                 ; a_input_type `Text
+                 ; a_name "nameserver"
+                 ; a_required ()
+                 ; a_pattern ip_address_regex_pattern
+                 ] ()
+      ; input
+          ~a:[ a_input_type `Submit
+             ; a_class [ "d-Button" ]
+             ; a_value "Add"
+             ]
+          ()
+      ]
+  in
+  div ~a:[ a_class [ "d-Network__Form" ] ]
+    ((service.nameservers |> List.map nameserver_remove_form) @ [ nameserver_add_form ])
+
 let connected_form service =
   div
     [ form
@@ -97,7 +138,7 @@ let connected_form service =
             ()
         ]
     ; details
-        (summary [ txt "Advanced Settings" ])
+        (summary [ txt "Proxy Settings" ])
         [ div
             ~a:[ a_class [ "d-Network__Form" ] ]
             [ proxy_label service.id
@@ -124,6 +165,8 @@ let connected_form service =
             ; proxy_form_note
             ]
         ]
+    ; details (summary [ txt "Nameservers" ])
+      [ nameservers_form service ]
     ]
 
 let html service =

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -109,7 +109,7 @@ let static_ip_form service =
   in
   let ipv4_value f =
     if is_static then
-      service.ipv4_user_config |> Option.map (fun (ipv4:IPv4.t) -> f ipv4) |> Option.value ~default:""
+      service.ipv4 |> Option.map (fun (ipv4:IPv4.t) -> f ipv4) |> Option.value ~default:""
     else
       ""
   in

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -114,7 +114,12 @@ let static_ip_form service =
       ""
   in
   div ~a:[ a_class [ "d-Network__Form" ]]
-    [ form ~a:[ a_action ("/network/" ^ service.id ^ "/staticip/update")
+    [ p ~a: [ a_class ["d-Network__Note"]  ][
+          txt "A valid IP address must be in the form of n.n.n.n,"
+        ; br ()
+        ; txt "where n is a number in the range of 0-255."
+        ]
+    ; form ~a:[ a_action ("/network/" ^ service.id ^ "/staticip/update")
               ; a_id "static-ip-form"
               ; a_method `Post
               ]
@@ -138,6 +143,12 @@ let static_ip_form service =
                   ~labelTxt:"Nameservers"
                   ~name:"nameservers"
                   ~value:(if is_static then String.concat ", " service.nameservers else "")
+                @ [ p ~a:[a_class ["d-Network__Note"]][
+                    txt  "To set multiple nameservers, use a comma separated list of addresses."
+                  ; br ()
+                  ; txt "eg. 1.1.1.1, 8.8.8.8"
+                  ]
+                  ]
               )
         ]
     ; div


### PR DESCRIPTION
[Trello card](https://trello.com/c/0M7ApRSF/685-static-ip-support-in-playos)

---

This PR adds support for setting up static IP and nameservers.

For simplicity the forms to configure these are currently shown only when a service is already connected. Is it necessary to be able to configure these during the initial connection too?

The IP address inputs are validated on the client side using html5 validation with regex.

Removing the static IP configuration resets the method to `dhcp`, but does not clear the `local_address`, `netmask`, and `gateway` settings of connman (there doesn't seem to be a way of clearing these values), but they become ineffective when `method` is reset to `dhcp`.

When removing a service altogether, the IPv4 method is also reset to `dhcp` and nameservers are removed from the service.

We discussed with @knuton that we can go ahead with the [release of PlayOS](https://trello.com/c/zFs6mLJu/876-release-playos-2130) without this, if more iterations will be needed to complete this work.

## Checklist

-   [X] Changelog updated
-   [X] Code documented
