### PR TITLE
Use variable online check timeouts

### DIFF
--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -207,7 +207,7 @@ module NetworkGui = struct
       with_timeout
         { duration = check_timeout
         ; on_timeout = fun () ->
-            let%lwt () = Logs_lwt.err (fun m -> m "Timeout reaching captive portal") in
+            let%lwt () = Logs_lwt.err (fun m -> m "Timeout reaching captive portal (%f s)" check_timeout) in
             return false
         }
         (fun () ->

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -196,9 +196,14 @@ module NetworkGui = struct
 
     let proxy = Proxy.from_default_service all_services in
 
+    let check_timeout =
+      try (Opium.Std.param req "timeout" |> float_of_string |> min 5.0 |> max 0.0)
+      with _ -> 0.2
+    in
+
     let%lwt is_internet_connected =
       with_timeout
-        { duration = 1.0
+        { duration = check_timeout
         ; on_timeout = fun () ->
             let%lwt () = Logs_lwt.err (fun m -> m "Timeout reaching captive portal") in
             return false

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -197,8 +197,10 @@ module NetworkGui = struct
     let proxy = Proxy.from_default_service all_services in
 
     let check_timeout =
-      try (Opium.Std.param req "timeout" |> float_of_string |> min 5.0 |> max 0.0)
-      with _ -> 0.2
+      Option.bind (Uri.get_query_param (Request.uri req) "timeout") Float.of_string_opt
+        |> Option.map (min 5.0)
+        |> Option.map (max 0.0)
+        |> Option.value ~default:0.2
     in
 
     let%lwt is_internet_connected =

--- a/controller/server/view/network_list_page.ml
+++ b/controller/server/view/network_list_page.ml
@@ -34,7 +34,7 @@ let html { proxy; is_internet_connected; services } =
       ; div
           ~a:[ a_class [ "d-Network__Refresh" ] ]
           [ a
-              ~a:[ a_href "/network"
+              ~a:[ a_href "/network?timeout=3"
               ; a_class [ "d-Button" ]
               ]
               [ txt "Refresh" ]


### PR DESCRIPTION
The online check should time out quickly when first opening the network page, but should allow for longer probing when explicitly checking for connectivity.

The default timeout used for direct navigation to network page (200 ms) is just above the threshold for "instant" feedback[1], but subjectively just below the threshold for being annoyingly slow.

The timeout when clicking the refresh "button" is now longer and less likely to produce false negatives.

[1]: https://www.nngroup.com/articles/response-times-3-important-limits/

## Checklist

-   [ ] <del>Changelog updated</del>
-   [x] Code documented
