### PR TITLE
Update driver to support senso flex

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,5 +1,9 @@
 # [UNRELEASED]
 
+## Added
+
+- driver: Upgrade to support Senso Flex
+
 # [2021.3.0] - 2021-04-08
 
 # [2021.3.0-VALIDATION] - 2021-03-24

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -25,7 +25,7 @@ let
       rauc = (import ./rauc) super;
 
       dividat-driver = (import ./dividat-driver) {
-        inherit (super) stdenv fetchFromGitHub buildGoPackage;
+        inherit (super) stdenv fetchFromGitHub buildGoModule;
         pkgs = self;
       };
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -35,15 +35,6 @@ let
         system_version = version;
       };
 
-      # pin pcsclite to 1.8.23 because of break in ABI (https://github.com/LudovicRousseau/PCSC/commit/984f84df10e2d0f432039e3b31f94c74e95092eb)
-      pcsclite = super.pcsclite.overrideAttrs (oldAttrs: rec {
-        version = "1.8.23";
-        src = super.fetchurl {
-          url = "https://pcsclite.apdu.fr/files/pcsc-lite-${version}.tar.bz2";
-          sha256 = "1jc9ws5ra6v3plwraqixin0w0wfxj64drahrbkyrrwzghqjjc9ss";
-        };
-      });
-
       breeze-contrast-cursor-theme = super.callPackage ./breeze-contrast-cursor-theme {};
 
       ocamlPackages = super.ocamlPackages.overrideScope' (self: super: {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -25,7 +25,8 @@ let
       rauc = (import ./rauc) super;
 
       dividat-driver = (import ./dividat-driver) {
-        inherit (super) stdenv fetchurl;
+        inherit (super) stdenv fetchFromGitHub buildGoPackage;
+        pkgs = self;
       };
 
       playos-kiosk-browser = import ../kiosk {

--- a/pkgs/dividat-driver/default.nix
+++ b/pkgs/dividat-driver/default.nix
@@ -1,22 +1,35 @@
-{stdenv, fetchFromGitHub, buildGoPackage, pkgs}:
+{ stdenv, fetchFromGitHub, pkgs, buildGoModule }:
 
 let
-  sources = fetchFromGitHub {
+
+  channel = "develop";
+
+  version = "unstable";
+
+  releaseUrl = "https://dist.dividat.com/releases/driver2/";
+
+in buildGoModule rec {
+
+  pname = "dividat-driver";
+  inherit version;
+
+  src = fetchFromGitHub {
     owner = "dividat";
     repo = "driver";
-    rev = "6b1f9c925bdb4f91cb3b92393ed5425bb95cd351";
-    sha256 = "11xpgkbpl5l1n3xg770zjyg48h5zkwrfhw98ii7iw2lxpiis3gm7";
+    rev = "9146cbf2f540cd5aa9cea5828f83993c8629657b";
+    sha256 = "1lsh0lyjwdhk24zrryaqszl1k3356yzckzx32q7mbcvvkh17hs9q";
   };
-in
-buildGoPackage rec {
-  name = "dividat-driver-${version}";
-  version = "2.1.0";
 
-  src = "${sources}/src/dividat-driver";
-
-  goPackagePath = "dividat-driver";
-  goDeps = "${sources}/nix/deps.nix";
+  vendorSha256 = "1lvgp9q3g3mpmj6khbg6f1z9zgdlmwgf65rqx4d7v50a1m7g9a0m";
 
   nativeBuildInputs = with pkgs; [ pkgconfig pcsclite ];
   buildInputs = with pkgs; [ pcsclite ];
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-X github.com/dividat/driver/src/dividat-driver/server.channel=${channel}"
+    "-X github.com/dividat/driver/src/dividat-driver/server.version=${version}"
+    "-X github.com/dividat/driver/src/dividat-driver/update.releaseUrl=${releaseUrl}"
+  ];
+
 }

--- a/pkgs/dividat-driver/default.nix
+++ b/pkgs/dividat-driver/default.nix
@@ -1,18 +1,22 @@
-{stdenv, fetchurl}:
-stdenv.mkDerivation rec {
+{stdenv, fetchFromGitHub, buildGoPackage, pkgs}:
+
+let
+  sources = fetchFromGitHub {
+    owner = "dividat";
+    repo = "driver";
+    rev = "6b1f9c925bdb4f91cb3b92393ed5425bb95cd351";
+    sha256 = "11xpgkbpl5l1n3xg770zjyg48h5zkwrfhw98ii7iw2lxpiis3gm7";
+  };
+in
+buildGoPackage rec {
   name = "dividat-driver-${version}";
   version = "2.1.0";
-  channel = "master";
 
-  src = fetchurl {
-    url = "https://dist.dividat.com/releases/driver2/${channel}/${version}/dividat-driver-linux-amd64-${version}";
-    sha256 = "0f5hd7mxrhsaxmwdyys1vk9z5rxm57y3w7qjlqj7l5v2v41g0vrm";
-  };
+  src = "${sources}/src/dividat-driver";
 
-  buildCommand = ''
-    mkdir -p $out/bin
-    cp $src $out/bin/dividat-driver
-    chmod +x $out/bin/dividat-driver
-  '';
+  goPackagePath = "dividat-driver";
+  goDeps = "${sources}/nix/deps.nix";
 
+  nativeBuildInputs = with pkgs; [ pkgconfig pcsclite ];
+  buildInputs = with pkgs; [ pcsclite ];
 }

--- a/pkgs/dividat-driver/default.nix
+++ b/pkgs/dividat-driver/default.nix
@@ -4,7 +4,7 @@ let
 
   channel = "develop";
 
-  version = "unstable";
+  version = "2.2.0-rc2";
 
   releaseUrl = "https://dist.dividat.com/releases/driver2/";
 

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -6,8 +6,10 @@
   users.users.play = {
     isNormalUser = true;
     home = "/home/play";
-    # who can play audio.
-    extraGroups = [ "audio" ];
+    extraGroups = [
+      "audio" # Play audio
+      "dialout" # Access to serial ports for the Senso flex
+    ];
   };
 
   # Note that setting up "/home" as persistent fails due to https://github.com/NixOS/nixpkgs/issues/6481


### PR DESCRIPTION
- Build driver from sources and use the latest version,
- Remove pcsclite pin on 1.8.23,
- Add play user to the dialout group.

## Tests

- I can use Senso flex on a live PlayOS

We should also check that RFID cards are still working, but I don’t have any RFID reader.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
