### PR TITLE
Introduce password-input webcomponent for the network passphrase

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -3,6 +3,7 @@
 ## Added
 
 - driver: Upgrade to support Senso Flex
+- controller: Hide the passphrase by default in the network form
 
 # [2021.3.0] - 2021-04-08
 

--- a/controller/dune
+++ b/controller/dune
@@ -4,6 +4,7 @@
   (Changelog.html as Changelog.html)
   (gui/reset.css as static/reset.css)
   (gui/style.css as static/style.css)
+  (gui/client.js as static/client.js)
   (gui/info.svg as static/info.svg)
   (gui/check.svg as static/check.svg)
   (gui/wifi.svg as static/wifi.svg)

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -1,13 +1,14 @@
 /* Password input web component with a SHOW/HIDE toggle button
  */
 customElements.define(
-  'password-input',
-  class extends HTMLElement {
+  'show-password',
+  class extends HTMLInputElement {
     constructor() {
       super()
 
-      const root = this
-      const input = document.createElement('input')
+      const parentNode = this.parentNode
+      const input = this
+      const root = document.createElement('span')
       const button = document.createElement('input')
 
       let isPasswordShown = false
@@ -22,16 +23,15 @@ customElements.define(
         }
       }
 
-      // If the input has a right margin, position the button accordingly
-      const rightMargin = parseFloat(
-        window.getComputedStyle(root).getPropertyValue('margin-right'))
-
-      root.style = 'position: relative'
+      // Move the input (current root) under the new artificial root, and also
+      // append the button
+      parentNode.replaceChild(root, input)
       root.appendChild(input)
       root.appendChild(button)
+      root.style = 'position: relative'
 
       input.type = 'password'
-      input.style = 'padding-right: 3.5rem';
+      input.style = 'padding-right: 3.5rem'; // Space for the button
       input.oninput = function (e) {
         if (e.target.value.length > 0) {
           button.style.visibility = 'visible'
@@ -41,11 +41,8 @@ customElements.define(
         }
       }
 
-      // Move root attributes to the input
-      for (const attr of root.attributes) {
-        input.setAttribute(attr.nodeName, attr.nodeValue)
-        root.removeAttribute(attr.nodeName)
-      }
+      // If the input has a right margin, position the button accordingly
+      const rightMargin = parseFloat(window.getComputedStyle(input).getPropertyValue('margin-right'))
 
       button.type = 'button'
       button.value = 'SHOW'
@@ -65,5 +62,6 @@ customElements.define(
         updatePasswordVisibility(!isPasswordShown)
       }
     }
-  }
+  },
+  { extends: 'input' }
 )

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -34,7 +34,7 @@ customElements.define(
         root.removeAttribute(attr.nodeName)
       }
 
-      let isShowed = false
+      let isShown = false
       button.type = 'button'
       button.value = 'SHOW'
       button.style = `
@@ -50,8 +50,8 @@ customElements.define(
         cursor: pointer;
       `
       button.onclick = function() {
-        isShowed = !isShowed
-        if (isShowed) {
+        isShown = !isShown
+        if (isShown) {
           button.value = 'HIDE'
           input.type = 'text'
         } else {

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -1,0 +1,64 @@
+/* Password input web component with a SHOW/HIDE toggle button
+ */
+customElements.define(
+  'password-input',
+  class extends HTMLElement {
+    constructor() {
+      super()
+
+      const root = this
+      const input = document.createElement('input')
+      const button = document.createElement('input')
+
+      // If the input has a right margin, position the button accordingly
+      const rightMargin = parseFloat(
+        window.getComputedStyle(root).getPropertyValue('margin-right'))
+
+      root.style = 'position: relative'
+      root.appendChild(input)
+      root.appendChild(button)
+
+      input.type = 'password'
+      input.style = 'padding-right: 3.5rem';
+      input.oninput = function (e) {
+        if (e.target.value.length > 0) {
+          button.style.visibility = 'visible'
+        } else {
+          button.style.visibility = 'hidden'
+        }
+      }
+
+      // Move root attributes to the input
+      for (const attr of root.attributes) {
+        input.setAttribute(attr.nodeName, attr.nodeValue)
+        root.removeAttribute(attr.nodeName)
+      }
+
+      let isShowed = false
+      button.type = 'button'
+      button.value = 'SHOW'
+      button.style = `
+        visibility: hidden;
+        border: none;
+        background-color: transparent;
+        color: #555555;
+        position: absolute;
+        top: 50%;
+        right: calc(${rightMargin}px + 0.5rem);
+        font-size: 50%;
+        transform: translateY(-50%);
+        cursor: pointer;
+      `
+      button.onclick = function() {
+        isShowed = !isShowed
+        if (isShowed) {
+          button.value = 'HIDE'
+          input.type = 'text'
+        } else {
+          button.value = 'SHOW'
+          input.type = 'password'
+        }
+      }
+    }
+  }
+)

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -10,6 +10,18 @@ customElements.define(
       const input = document.createElement('input')
       const button = document.createElement('input')
 
+      let isPasswordShown = false
+      function updatePasswordVisibility(b) {
+        isPasswordShown = b
+        if (isPasswordShown) {
+          button.value = 'HIDE'
+          input.type = 'text'
+        } else {
+          button.value = 'SHOW'
+          input.type = 'password'
+        }
+      }
+
       // If the input has a right margin, position the button accordingly
       const rightMargin = parseFloat(
         window.getComputedStyle(root).getPropertyValue('margin-right'))
@@ -25,6 +37,7 @@ customElements.define(
           button.style.visibility = 'visible'
         } else {
           button.style.visibility = 'hidden'
+          updatePasswordVisibility(false)
         }
       }
 
@@ -34,7 +47,6 @@ customElements.define(
         root.removeAttribute(attr.nodeName)
       }
 
-      let isShown = false
       button.type = 'button'
       button.value = 'SHOW'
       button.style = `
@@ -50,14 +62,7 @@ customElements.define(
         cursor: pointer;
       `
       button.onclick = function() {
-        isShown = !isShown
-        if (isShown) {
-          button.value = 'HIDE'
-          input.type = 'text'
-        } else {
-          button.value = 'SHOW'
-          input.type = 'password'
-        }
+        updatePasswordVisibility(!isPasswordShown)
       }
     }
   }

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -163,10 +163,6 @@
     margin-right: 1rem;
 }
 
-.d-Network__Button {
-    margin-top: 1rem;
-}
-
 .d-Network__AdvancedSettingsTitle {
     margin-top: 1rem;
 }
@@ -218,7 +214,6 @@
     opacity:.3;
     stroke-width:.5;
 }
-
 
 /* Localization */
 
@@ -375,4 +370,8 @@
 
 .d-BackLink:before {
     content: "❮ ";
+}
+
+.d-Details {
+    margin-bottom: 1rem;
 }

--- a/controller/server/view/common/page.ml
+++ b/controller/server/view/common/page.ml
@@ -77,5 +77,6 @@ let html ?current_page content =
               ]
               [ txt "system status" ]
           ]
+      ; script ~a:[ a_src "/static/client.js" ] (txt "")
       ]
     )

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -52,6 +52,7 @@ let not_connected_form service =
           ]
           []
       ; details
+          ~a:[ a_class [ "d-Details" ] ]
           (summary [ txt "Proxy Settings" ])
           [ div
               ~a:[ a_class [ "d-Network__AdvancedSettingsTitle" ] ]
@@ -62,7 +63,7 @@ let not_connected_form service =
           ]
       ; input
           ~a:[ a_input_type `Submit
-          ; a_class [ "d-Button"; "d-Network__Button" ]
+          ; a_class [ "d-Button" ]
           ; a_value "Connect"
           ]
           ()
@@ -190,12 +191,13 @@ let connected_form service =
         ]
         [ input
             ~a:[ a_input_type `Submit
-            ; a_class [ "d-Button"; "d-Network__Button" ]
+            ; a_class [ "d-Button" ]
             ; a_value "Remove"
             ]
             ()
         ]
     ; details
+        ~a:[ a_class [ "d-Details" ] ]
         (summary [ txt "Proxy Settings" ])
         [ div
             ~a:[ a_class [ "d-Network__Form" ] ]
@@ -224,7 +226,7 @@ let connected_form service =
             ]
         ]
 
-    ; details (summary [ txt "Static IP" ])
+    ; details ~a:[ a_class [ "d-Details" ] ] (summary [ txt "Static IP" ])
       [ static_ip_form service ]
     ]
 

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -45,13 +45,12 @@ let not_connected_form service =
               ~a:[ a_label_for passphrase_id ]
               [ txt "Passphrase" ]
           ]
-      ; input
-          ~a:[ a_input_type `Text
-          ; a_class [ "d-Input";  "d-Network__Input" ]
+      ; Unsafe.node "password-input"
+          ~a:[ a_class [ "d-Input"; "d-Network__Input" ]
           ; a_id passphrase_id
           ; a_name "passphrase"
           ]
-          ()
+          []
       ; details
           (summary [ txt "Proxy Settings" ])
           [ div

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -45,12 +45,14 @@ let not_connected_form service =
               ~a:[ a_label_for passphrase_id ]
               [ txt "Passphrase" ]
           ]
-      ; Unsafe.node "password-input"
-          ~a:[ a_class [ "d-Input"; "d-Network__Input" ]
+      ; input
+          ~a:[ a_input_type `Password
+          ; a_class [ "d-Input"; "d-Network__Input" ]
           ; a_id passphrase_id
           ; a_name "passphrase"
+          ; Unsafe.string_attrib "is" "show-password"
           ]
-          []
+          ()
       ; details
           ~a:[ a_class [ "d-Details" ] ]
           (summary [ txt "Proxy Settings" ])


### PR DESCRIPTION
This hides the network passphrase by default, but its visibility can be
toggled with a SHOW/HIDE button.

There is one commit that is modifying margins, see individual commits for a simpler changeset.

## Demo

https://user-images.githubusercontent.com/6768842/117157707-1bb2e600-adbf-11eb-88de-a4e8aa9a38c5.mp4

## Checklist

-   [x] Changelog updated
-   [x] Code documented
