### PR TITLE
Display IP addresses in network list

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -4,6 +4,7 @@
 
 - driver: Upgrade to support Senso Flex
 - controller: Hide the passphrase by default in the network form
+- controller: Display IP addresses in network list
 
 # [2021.3.0] - 2021-04-08
 

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -91,7 +91,8 @@
   color: black;
   line-height: 1;
   display: grid;
-  grid-template-columns: 10fr 1fr 1fr;
+  grid-template-columns: 10fr auto auto auto;
+  grid-gap: 1rem;
   align-items: center;
   padding-right: 1.5rem;
   padding-left: 1.5rem;
@@ -102,6 +103,11 @@
 
 .d-NetworkList__Network:hover {
     background: #E0CB52;
+}
+
+.d-NetworkList__Address {
+  color: var(--color-hint);
+  font-size: small;
 }
 
 .d-NetworkList__Chevron {

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -92,7 +92,7 @@
   line-height: 1;
   display: grid;
   grid-template-columns: 10fr auto auto auto;
-  grid-gap: 1rem;
+  grid-gap: 3rem;
   align-items: center;
   padding-right: 1.5rem;
   padding-left: 1.5rem;

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -1,5 +1,9 @@
 /* Template */
 
+:root {
+    --color-hint: #404040;
+}
+
 .d-Container {
     font-family: monospace;
     padding: 5vh 5vw 5vh 5vw;
@@ -169,7 +173,7 @@
 
 .d-Network__Note {
     font-size: 80%;
-    color: #404040;
+    color: var(--color-hint);
     margin-bottom: 1rem;
 }
 

--- a/controller/server/view/network_list_page.ml
+++ b/controller/server/view/network_list_page.ml
@@ -1,7 +1,7 @@
 open Connman.Service
 open Tyxml.Html
 
-let service { id; name; strength } =
+let service { id; name; strength; ipv4 } =
   let strength =
     match strength with
     | Some s -> [ Signal_strength.html s ]
@@ -13,6 +13,12 @@ let service { id; name; strength } =
         ; a_href ("/network/" ^ id)
         ]
         [ div [ txt name ]
+        ; (match ipv4 with
+          | Some ipv4_addr ->
+                div ~a:[ a_class [ "d-NetworkList__Address" ] ] [ txt (ipv4_addr.address) ]
+          | None ->
+                space ()
+          )
         ; div
             ~a:[ a_class [ "d-NetworkList__SignalStrength" ] ]
             strength


### PR DESCRIPTION
Display IPs in the network list to help identify network vs Senso in setups with dual Ethernet.

![image](https://user-images.githubusercontent.com/47458/121326812-2eb35b80-c913-11eb-8b5b-99395f000134.png)


## Checklist

-   [x] Changelog updated
-   [x] Code documented
