### PR TITLE
Move network interface list to network page

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -6,6 +6,10 @@
 - controller: Hide the passphrase by default in the network form
 - controller: Display IP addresses in network list
 
+## Changed
+
+- controller: Move network interface list to network page
+
 # [2021.3.0] - 2021-04-08
 
 # [2021.3.0-VALIDATION] - 2021-03-24

--- a/controller/gui/reset.css
+++ b/controller/gui/reset.css
@@ -1,17 +1,10 @@
 /* See https://hankchizljaw.com/wrote/a-modern-css-reset/ */
 
 /* Box sizing rules */
-
 *,
 *::before,
 *::after {
-    box-sizing: border-box;
-}
-
-/* Remove default padding */
-ul[class],
-ol[class] {
-    padding: 0;
+  box-sizing: border-box;
 }
 
 /* Remove default margin */
@@ -21,45 +14,41 @@ h2,
 h3,
 h4,
 p,
-ul[class],
-ol[class],
-li,
 figure,
-figcaption,
 blockquote,
 dl,
 dd {
-    margin: 0;
+  margin: 0;
+}
+
+/* Remove list styles on ul, ol elements with a list role, which suggests default styling will be removed */
+ul[role="list"],
+ol[role="list"] {
+  list-style: none;
+}
+
+/* Set core root defaults */
+html:focus-within {
+  scroll-behavior: smooth;
 }
 
 /* Set core body defaults */
 body {
-    min-height: 100vh;
-    scroll-behavior: smooth;
-    text-rendering: optimizeSpeed;
-    line-height: 1.5;
-}
-
-/* Remove list styles on ul, ol elements with a class attribute */
-ul[class],
-ol[class] {
-    list-style: none;
+  min-height: 100vh;
+  text-rendering: optimizeSpeed;
+  line-height: 1.5;
 }
 
 /* A elements that don't have a class get default styles */
 a:not([class]) {
-    text-decoration-skip-ink: auto;
+  text-decoration-skip-ink: auto;
 }
 
 /* Make images easier to work with */
-img {
-    max-width: 100%;
-    display: block;
-}
-
-/* Natural flow and rhythm in articles by default */
-article > * + * {
-    margin-top: 1em;
+img,
+picture {
+  max-width: 100%;
+  display: block;
 }
 
 /* Inherit fonts for inputs and buttons */
@@ -67,15 +56,20 @@ input,
 button,
 textarea,
 select {
-    font: inherit;
+  font: inherit;
 }
 
 /* Remove all animations and transitions for people that prefer not to see them */
 @media (prefers-reduced-motion: reduce) {
-    * {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
-    }
+  html:focus-within {
+   scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/controller/gui/reset.css
+++ b/controller/gui/reset.css
@@ -1,4 +1,4 @@
-/* See https://hankchizljaw.com/wrote/a-modern-css-reset/ */
+/* Based on https://hankchizljaw.com/wrote/a-modern-css-reset/ */
 
 /* Box sizing rules */
 *,
@@ -17,14 +17,10 @@ p,
 figure,
 blockquote,
 dl,
-dd {
+dd,
+ul,
+ol {
   margin: 0;
-}
-
-/* Remove list styles on ul, ol elements with a list role, which suggests default styling will be removed */
-ul[role="list"],
-ol[role="list"] {
-  list-style: none;
 }
 
 /* Set core root defaults */

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -86,6 +86,10 @@
 
 /* Network list */
 
+.d-NetworkList[class] {
+  margin-bottom: 1rem;
+}
+
 .d-NetworkList__Network {
   text-decoration: none;
   color: black;

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -86,7 +86,9 @@
 
 /* Network list */
 
-.d-NetworkList[class] {
+.d-NetworkList {
+  list-style: none;
+  padding: 0;
   margin-bottom: 1rem;
 }
 

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -227,6 +227,7 @@ module NetworkGui = struct
       all_services
         |> List.filter (fun s -> not is_internet_connected || Service.is_connected s)
     in
+    let%lwt interfaces = Network.Interface.get_all () in
 
     Lwt.return (page (Network_list_page.html
       { proxy = proxy
@@ -234,6 +235,9 @@ module NetworkGui = struct
       ; is_internet_connected
       ; services = showed_services
           |> List.map blur_service_proxy_password
+      ; interfaces = interfaces
+          |> [%sexp_of: Network.Interface.t list]
+          |> Sexplib.Sexp.to_string_hum
       }))
 
   (** Helper to find a service by id *)
@@ -424,7 +428,6 @@ module StatusGui = struct
             (fun exn -> Printexc.to_string exn
                         |> return)
         in
-        let%lwt interfaces = Network.Interface.get_all () in
         Lwt.return (page (Status_page.html
           { health = health_s
               |> Lwt_react.S.value
@@ -435,9 +438,6 @@ module StatusGui = struct
               |> Update.sexp_of_state
               |> Sexplib.Sexp.to_string_hum
           ; rauc
-          ; interfaces = interfaces
-              |> [%sexp_of: Network.Interface.t list]
-              |> Sexplib.Sexp.to_string_hum
           }))
       )
 end

--- a/controller/server/view/network_list_page.ml
+++ b/controller/server/view/network_list_page.ml
@@ -30,9 +30,10 @@ type params =
   { proxy: string option
   ; is_internet_connected: bool
   ; services: Connman.Service.t list
+  ; interfaces: string
   }
 
-let html { proxy; is_internet_connected; services } =
+let html { proxy; is_internet_connected; services; interfaces } =
   Page.html ~current_page:Page.Network (
     div
       [ h1 ~a:[ a_class [ "d-Title" ] ] [ txt "Network" ]
@@ -75,6 +76,11 @@ let html { proxy; is_internet_connected; services } =
               txt "No services available"
             else
               ul ~a:[ a_class [ "d-NetworkList" ] ] (List.map service services)
+          ]
+
+      ; section
+          [ h2 ~a:[ a_class [ "d-Subtitle" ] ] [ txt "Network Interfaces" ]
+          ; pre ~a: [ a_class [ "d-Preformatted" ] ]  [ txt interfaces ]
           ]
       ]
   )

--- a/controller/server/view/network_list_page.ml
+++ b/controller/server/view/network_list_page.ml
@@ -75,7 +75,9 @@ let html { proxy; is_internet_connected; services; interfaces } =
           ; if List.length services = 0 then
               txt "No services available"
             else
-              ul ~a:[ a_class [ "d-NetworkList" ] ] (List.map service services)
+              ul
+                ~a:[ a_class [ "d-NetworkList" ]; a_role [ "list" ] ]
+                (List.map service services)
           ]
 
       ; section

--- a/controller/server/view/network_list_page.mli
+++ b/controller/server/view/network_list_page.mli
@@ -2,6 +2,7 @@ type params =
   { proxy: string option
   ; is_internet_connected: bool
   ; services: Connman.Service.t list
+  ; interfaces: string
   }
 
 val html :

--- a/controller/server/view/status_page.ml
+++ b/controller/server/view/status_page.ml
@@ -10,10 +10,9 @@ type params =
   { health: string
   ; update: string
   ; rauc: string
-  ; interfaces: string
   }
 
-let html { health; update; rauc; interfaces } =
+let html { health; update; rauc } =
   Page.html (
     div
       [ h1
@@ -28,6 +27,5 @@ let html { health; update; rauc; interfaces } =
       ; section "Health" health
       ; section "Update State" update
       ; section "RAUC" rauc
-      ; section "Interfaces" interfaces
       ]
   )

--- a/controller/server/view/status_page.mli
+++ b/controller/server/view/status_page.mli
@@ -2,7 +2,6 @@ type params =
   { health: string
   ; update: string
   ; rauc: string
-  ; interfaces: string
   }
 
 val html :


### PR DESCRIPTION
Triggered by having to explain where to find MAC addresses, the list should be easier to find when placed within the network page.

Reserve the status page for actual dynamic status.

@guyonvarch I updated and then altered `reset.css`, as it used overly specific selectors like `ul[class]` or `ul[role]`. Probably this was done in good intention to only reset styles on styled elements (having a class), but in practice this leads to specificity issues and makes it a hassle to override the reset styles.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
