### PR TITLE
Add note about non-GDPR compliant service

### DIFF
--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -183,12 +183,6 @@
     margin-top: 1rem;
 }
 
-.d-Network__Note {
-    font-size: 80%;
-    color: var(--color-hint);
-    margin-bottom: 1rem;
-}
-
 
 /* Switch */
 
@@ -199,6 +193,16 @@
 .d-Switch--Off {
     color: red;
 }
+
+
+/* Side note */
+
+.d-Note {
+    font-size: 80%;
+    color: var(--color-hint);
+    margin-bottom: 1rem;
+}
+
 
 /* Wifi signal */
 

--- a/controller/server/view/info_page.ml
+++ b/controller/server/view/info_page.ml
@@ -24,7 +24,12 @@ let remote_management address =
       ; remote_management_form "disable" "Disable"
       ]
   | None ->
-      [ remote_management_form "enable" "Enable" ]
+      [ remote_management_form "enable" "Enable"
+      ; p
+          ~a:[ a_class [ "d-Note" ] ]
+          [ txt "During remote management this computer's IP address is shared with ZeroTier, a US-based company whose overlay network enables us to connect at a distance."
+          ]
+      ]
 
 let html server_info =
   Page.html ~current_page:Page.Info (
@@ -43,11 +48,11 @@ let html server_info =
           ; Definition.term [ txt "Machine ID" ]
           ; Definition.description [ txt server_info.machine_id ]
 
-          ; Definition.term [ txt "Remote management" ]
-          ; Definition.description (remote_management server_info.zerotier_address)
-
           ; Definition.term [ txt "Local time" ]
           ; Definition.description [ txt server_info.local_time ]
+
+          ; Definition.term [ txt "Remote management" ]
+          ; Definition.description (remote_management server_info.zerotier_address)
           ]
       ]
   )

--- a/controller/server/view/info_page.ml
+++ b/controller/server/view/info_page.ml
@@ -24,11 +24,11 @@ let remote_management address =
       ; remote_management_form "disable" "Disable"
       ]
   | None ->
-      [ remote_management_form "enable" "Enable"
-      ; p
+      [ div
           ~a:[ a_class [ "d-Note" ] ]
-          [ txt "During remote management this computer's IP address is shared with ZeroTier, a US-based company whose overlay network enables us to connect at a distance."
+          [ txt "Enabling remote management allows Dividat to access this computer at a distance. For this purpose the computer's public IP address is shared with ZeroTier, a US-based company providing an overlay network."
           ]
+      ; remote_management_form "enable" "Enable"
       ]
 
 let html server_info =

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -24,7 +24,7 @@ let proxy_input ?proxy service_id =
 
 let proxy_form_note =
   p
-    ~a:[ a_class [ "d-Network__Note" ] ]
+    ~a:[ a_class [ "d-Note" ] ]
     [ txt "URL in the form "
     ; em ~a:[ a_class [ "d-Code" ] ] [ txt "http://host:port" ]
     ; txt " or "
@@ -119,7 +119,7 @@ let static_ip_form service =
       ""
   in
   div ~a:[ a_class [ "d-Network__Form" ]]
-    [ p ~a: [ a_class ["d-Network__Note"]  ][
+    [ p ~a: [ a_class ["d-Note"]  ][
           txt "A valid IP address must be in the form of "
         ; code ~a:[ a_class [ "d-Code" ] ] [ txt "n.n.n.n" ]
         ; txt ","
@@ -154,7 +154,7 @@ let static_ip_form service =
                   ~name:"nameservers"
                   ~value:(if is_static then String.concat ", " service.nameservers else "")
                   ~pattern:multi_ip_address_regex_pattern
-                @ [ p ~a:[a_class ["d-Network__Note"]][
+                @ [ p ~a:[a_class ["d-Note"]][
                     txt  "To set multiple nameservers, use a comma separated list of addresses."
                   ; br ()
                   ; txt "eg. 1.1.1.1, 8.8.8.8"


### PR DESCRIPTION
Actively inform users that by enabling remote management the Play Computer's IP address will be sent to US-based ZeroTier.

This is necessary due to lack of a Data Processing Addendum on ZeroTier's part.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
