### PR TITLE
Fix driver requests to pcscd (smart cards)

### DIFF
--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -107,5 +107,13 @@
   services.pcscd.enable = true;
   # Blacklist NFC modules conflicting with CCID (https://ludovicrousseau.blogspot.com/2013/11/linux-nfc-driver-conflicts-with-ccid.html)
   boot.blacklistedKernelModules = [ "pn533_usb" "pn533" "nfc" ];
+  # Allow play user to access pcsc
+  security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if (subject.user == "play" && (action.id == "org.debian.pcsc-lite.access_pcsc" || action.id == "org.debian.pcsc-lite.access_card")) {
+          return polkit.Result.YES;
+        }
+      });
+  '';
 
 }


### PR DESCRIPTION
We need to allow the driver (running as unprivileged user) to access smart cards via pcscd. Polkit integration is new in NixOS 21.05.

Restores RFID auth after #72.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
