### PR TITLE
Make journald use persistent storage

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -9,6 +9,7 @@
 ## Changed
 
 - controller: Move network interface list to network page
+- os: Make system journal persist across reboots
 
 # [2021.3.0] - 2021-04-08
 

--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -44,4 +44,15 @@ with lib;
   # disable installation of documentation
   documentation.enable = false;
 
+  # Enable persistent journaling with low maximum size
+  volatileRoot.persistentFolders."/var/log/journal" = {
+    mode = "0755";
+    user = "root";
+    group = "root";
+  };
+  services.journald.extraConfig = ''
+    Storage=persistent
+    SystemMaxUse=1G
+  '';
+
 }


### PR DESCRIPTION
Lets journald store logs in a persistent folder, to preserve logs across reboots.

While it can not be easily tested that the configured maximum is respected, journald should cap the size at 4 GB in the worst case.

https://www.freedesktop.org/software/systemd/man/journald.conf.html

## Checklist

-   [x] Changelog updated
-   [x] Code documented
