### PR TITLE
Update nixpkgs channel to 21.11

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ See the output of `run-playos-in-vm --help` for more information.
 
 #### Guest networking
 
-The default user-mode network stack is used to create a virtual Ethernet connection with bridged Internet access for the guest. If you find that the guest has a dysfunctional Internet connection, check your host's firewall settings. If using ConnMan, make sure that the virtual bridge interfaces (`virbr0` etc.) are not blacklisted.
+The default user-mode network stack is used to create a virtual Ethernet connection with bridged Internet access for the guest. If you find that the guest has a dysfunctional Internet connection, check your host's firewall settings. If using ConnMan, restart ConnMan service and try again.
 
 ## Deployment
 

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,5 +1,9 @@
 # [UNRELEASED]
 
+## Changed
+
+- os: Update nixpkgs channel to 21.11
+
 # [2021.9.0] - 2021-11-11
 
 # [2021.9.0-VALIDATION] - 2021-09-28

--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -300,7 +300,7 @@ struct
       try
         OBus_value.C.(v |> cast_single basic_byte)
         |> int_of_char
-        |> CCOpt.return
+        |> CCOption.return
       with
       | _ -> None
     in
@@ -321,7 +321,7 @@ struct
       with
         _ -> None
     in
-    CCOpt.(
+    CCOption.(
       pure (fun name type' state strength favorite autoconnect ipv4 ipv4_user_config ipv6 ethernet proxy nameservers ->
           { _proxy = OBus_proxy.make (OBus_context.sender context) path
           ; _manager = manager
@@ -456,7 +456,7 @@ struct
       OBus_method.call_with_context
         Net_connman_Manager.m_GetTechnologies proxy () in
     let to_technology (path, properties) : Technology.t option =
-      CCOpt.(pure
+      CCOption.(pure
                (fun name type' powered connected : Technology.t ->
                   { _proxy = OBus_proxy.make (OBus_context.sender context) path
                   ; name

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -373,13 +373,13 @@ module LabelGui = struct
     let%lwt server_info = Info.get () in
     return
       ({ machine_id = server_info.machine_id
-       ; mac_1 = CCOpt.(
+       ; mac_1 = CCOption.(
              ethernet_interfaces
              |> CCList.get_at_idx 0
              >|= (fun i -> i.address)
              |> get_or ~default:"-"
            )
-       ; mac_2 = CCOpt.(
+       ; mac_2 = CCOption.(
              ethernet_interfaces
              |> CCList.get_at_idx 1
              >|= (fun i -> i.address)

--- a/default.nix
+++ b/default.nix
@@ -89,7 +89,7 @@ with pkgs; stdenv.mkDerivation {
 
   buildInputs = [
     rauc
-    (python36.withPackages(ps: with ps; [pyparted]))
+    (python39.withPackages(ps: with ps; [pyparted]))
     components.install-playos
   ];
 

--- a/deployment/deploy-playos-update/default.nix
+++ b/deployment/deploy-playos-update/default.nix
@@ -1,11 +1,11 @@
 { substituteAll
 , version, updateCert, unsignedRaucBundle, installer
 , deployUrl, updateUrl, kioskUrl
-, rauc, awscli, python36
+, rauc, awscli, python39
 }:
 substituteAll {
   src = ./deploy-playos-update.py;
   dummyBuildCert = ../../pki/dummy/cert.pem;
   inherit version updateCert unsignedRaucBundle installer deployUrl updateUrl kioskUrl;
-  inherit rauc awscli python36;
+  inherit rauc awscli python39;
 }

--- a/deployment/deploy-playos-update/deploy-playos-update.py
+++ b/deployment/deploy-playos-update/deploy-playos-update.py
@@ -1,4 +1,4 @@
-#!@python36@/bin/python
+#!@python39@/bin/python
 
 import argparse
 import hashlib

--- a/installer/install-playos/default.nix
+++ b/installer/install-playos/default.nix
@@ -5,7 +5,7 @@
 , e2fsprogs
 , dosfstools
 , utillinux
-, python36
+, python39
 , pv
 , closureInfo
 
@@ -19,7 +19,7 @@
 let
   systemClosureInfo = closureInfo { rootPaths = [ systemToplevel ]; };
 
-  python = python36.withPackages(ps: with ps; [pyparted]);
+  python = python39.withPackages(ps: with ps; [pyparted]);
 in
 stdenv.mkDerivation {
   name = "install-playos-${version}";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4,15 +4,12 @@ let
 
   nixpkgs = import ./patch-nixpkgs.nix {
     src = builtins.fetchGit {
-      name = "nixos-21.05-2021-08-02";
+      name = "nixos-21.11-2021-03-07";
       url = "https://github.com/nixos/nixpkgs";
-      ref = "refs/heads/nixos-21.05";
-      rev = "d4590d21006387dcb190c516724cb1e41c0f8fdf";
+      ref = "refs/heads/nixos-21.11";
+      rev = "9b1c7ba323732ddc85a51850a7f10ecc5269b8e9";
     };
-    patches = [
-      # Fix merged in master 2021/08/12: https://github.com/NixOS/nixpkgs/pull/127595
-      ./patches/nixos-wireless-use-udev-to-wait-for-interfaces.patch
-    ];
+    patches = [];
   };
 
   overlay =

--- a/pkgs/dividat-driver/default.nix
+++ b/pkgs/dividat-driver/default.nix
@@ -25,8 +25,7 @@ in buildGoModule rec {
   nativeBuildInputs = with pkgs; [ pkgconfig pcsclite ];
   buildInputs = with pkgs; [ pcsclite ];
 
-  buildFlagsArray = [
-    "-ldflags="
+  ldflags = [
     "-X github.com/dividat/driver/src/dividat-driver/server.channel=${channel}"
     "-X github.com/dividat/driver/src/dividat-driver/server.version=${version}"
     "-X github.com/dividat/driver/src/dividat-driver/update.releaseUrl=${releaseUrl}"

--- a/testing/run-playos-in-vm/default.nix
+++ b/testing/run-playos-in-vm/default.nix
@@ -1,10 +1,10 @@
 { substituteAll
 , version, disk, testingToplevel
-, bindfs, qemu, OVMF, python36
+, bindfs, qemu, OVMF, python39
 }:
 substituteAll {
   src = ./run-playos-in-vm.py;
   inherit version disk testingToplevel;
-  inherit bindfs qemu python36;
+  inherit bindfs qemu python39;
   ovmf = "${OVMF.fd}/FV/OVMF.fd";
 }

--- a/testing/run-playos-in-vm/run-playos-in-vm.py
+++ b/testing/run-playos-in-vm/run-playos-in-vm.py
@@ -1,4 +1,4 @@
-#!@python36@/bin/python
+#!@python39@/bin/python
 
 import tempfile
 from contextlib import contextmanager

--- a/testing/system/default.nix
+++ b/testing/system/default.nix
@@ -1,19 +1,19 @@
 {pkgs, lib, version, updateCert, kioskUrl, playos-controller, greeting}:
+
 let nixos = pkgs.importFromNixos ""; in
+
 (nixos {
   configuration = {...}: {
   imports = [
     # general PlayOS modules
-    ((import ../../system/modules/playos.nix) {inherit pkgs version updateCert kioskUrl greeting playos-controller;})
+    (import ../../system/modules/playos.nix { inherit pkgs version updateCert kioskUrl greeting playos-controller; })
 
     # system configuration
     ../../system/configuration.nix
 
     # Testing machinery
-    # FIXME: the importFromNixos should be in the pkgs anyways which is passed to the testing.nix module. But I get an infinite recursion somewhere if using from pkgs.
-    ((import ./testing.nix) {inherit (pkgs) importFromNixos;})
+    (import ./testing.nix { inherit lib pkgs; })
   ];
   };
   system = "x86_64-linux";
 }).config.system.build.toplevel
-

--- a/testing/system/testing.nix
+++ b/testing/system/testing.nix
@@ -1,10 +1,10 @@
 # Test machinery
-{importFromNixos}:
-{config, lib, pkgs, ...}:
+{lib, pkgs, ...}:
+
 {
   imports = [
-    (importFromNixos "modules/profiles/qemu-guest.nix")
-    (importFromNixos "modules/testing/test-instrumentation.nix")
+    (pkgs.importFromNixos "modules/profiles/qemu-guest.nix")
+    (pkgs.importFromNixos "modules/testing/test-instrumentation.nix")
   ];
 
   config = {


### PR DESCRIPTION
With the planned changes to come, that’s a good idea to upgrade `nixpkgs`, because we’ll do additional testing with the features we’ll work on. Moreover, we waited enough time for `21.11` to be enough tested.

## Completed tests

- Run the kiosk directly
- Run the controller directly
- Run with Qemu
- Run live system on VirtualBox
- Run lab stick on a computer
- `./build` in 33 minutes

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   ~~[ ] User manual updated~~