### PR TITLE
Add configurable patch to limit virtual terminals

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -3,6 +3,7 @@
 ## Changed
 
 - os: Update nixpkgs channel to 21.11
+- os: Disable virtual terminals that are not used by PlayOS
 
 # [2021.9.0] - 2021-11-11
 

--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,10 @@
 let
   version = "2021.9.0";
 
-  pkgs = import ./pkgs { inherit version updateUrl kioskUrl; };
+  # List the virtual terminals that can be switched to from the Xserver
+  activeVirtualTerminals = [ 7 8 ];
+
+  pkgs = import ./pkgs { inherit version updateUrl kioskUrl activeVirtualTerminals; };
 
   # lib.makeScope returns consistent set of packages that depend on each other (and is my new favorite nixpkgs trick)
   components = with pkgs; lib.makeScope newScope (self: with self; {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,4 @@
-{ version, updateUrl, kioskUrl }:
+{ version, updateUrl, kioskUrl, activeVirtualTerminals ? [] }:
 
 let
 
@@ -50,5 +50,8 @@ let
 in
 
   import nixpkgs {
-    overlays = [ overlay ];
+    overlays = [
+      overlay
+      (import ./xorg { inherit activeVirtualTerminals; })
+    ];
   }

--- a/pkgs/xorg/default.nix
+++ b/pkgs/xorg/default.nix
@@ -1,0 +1,47 @@
+{ activeVirtualTerminals }:
+self: super: {
+
+  # This patches Xserver to restrict the directly accessible virtual terminals (Ctrl-Alt-FN)
+
+  # The goal is primarily to limit possible cause of confusion for users, especially
+  # accidental activation of VT 12 instead of opening the PlayOS controller (Ctrl-Shift-F12).
+  # 
+  # The patch mimics the Xserver option `DontVTSwitch`, which disables VT switching entirely.
+  # We limit action event processing at the same site in Xserver code by checking
+  # the VT number.
+  #
+  # Note that while `DontVTSwitch` is considered a security measure, ours is foremost a
+  # usability measure. Once a non-Xserver VT has been switched to, VT switching is handled by
+  # the Linux kernel and thus no longer limited to our whitelist.
+
+  xorg =
+    let
+      vtChecks =
+        super.lib.concatMapStringsSep " || " (vtno: "vtno == ${builtins.toString vtno}") activeVirtualTerminals;
+      # The patch needs to be created against https://gitlab.freedesktop.org/xorg/xserver/ checked out
+      # to the version Nixpkgs references. This source file has changed at a very low frequency
+      # throughout the past few years.
+      vtPatch = builtins.toFile "limit-vts.patch" ''
+        diff --git a/hw/xfree86/common/xf86Events.c b/hw/xfree86/common/xf86Events.c
+        index 8a800bd8f..5f9c40788 100644
+        --- a/hw/xfree86/common/xf86Events.c
+        +++ b/hw/xfree86/common/xf86Events.c
+        @@ -186,7 +186,7 @@ xf86ProcessActionEvent(ActionEvent action, void *arg)
+                 if (!xf86Info.dontVTSwitch && arg) {
+                     int vtno = *((int *) arg);
+         
+        -            if (vtno != xf86Info.vtno) {
+        +            if (vtno != xf86Info.vtno && ${vtChecks}) {
+                         if (!xf86VTActivate(vtno)) {
+                             ErrorF("Failed to switch from vt%02d to vt%02d: %s\n",
+                                    xf86Info.vtno, vtno, strerror(errno));
+
+      '';
+    in
+    super.xorg // {
+      xorgserver = self.lib.overrideDerivation super.xorg.xorgserver (old: {
+        patches = (old.patches or []) ++ [ vtPatch ];
+      });
+    };
+
+}

--- a/pkgs/xorg/default.nix
+++ b/pkgs/xorg/default.nix
@@ -16,7 +16,7 @@ self: super: {
 
   xorg =
     let
-      vtChecks =
+      isActiveVTCondition =
         super.lib.concatMapStringsSep " || " (vtno: "vtno == ${builtins.toString vtno}") activeVirtualTerminals;
       # The patch needs to be created against https://gitlab.freedesktop.org/xorg/xserver/ checked out
       # to the version Nixpkgs references. This source file has changed at a very low frequency
@@ -31,7 +31,7 @@ self: super: {
                      int vtno = *((int *) arg);
          
         -            if (vtno != xf86Info.vtno) {
-        +            if (vtno != xf86Info.vtno && ${vtChecks}) {
+        +            if (vtno != xf86Info.vtno && (${isActiveVTCondition})) {
                          if (!xf86VTActivate(vtno)) {
                              ErrorF("Failed to switch from vt%02d to vt%02d: %s\n",
                                     xf86Info.vtno, vtno, strerror(errno));


### PR DESCRIPTION
In typical usage scenarios of PlayOS the virtual terminals on Ctrl-Alt-FN are not useful (no user that can be logged into) and may lead to confusion when accidentally switched to (especially terminal 12).

This patch blocks any but a few whitelisted virtual terminals from being switched to directly from the Xserver session running the kiosk.

Xserver allows to disable VT switching entirely with the DontVTSwitch option, but does not offer an option to disable specific VTs. We therefore create a suitable patch for Xserver to enforce the whitelist. Applying the patch in Xserver seems more robust than patching XKB keymaps to disable the key combinations in question, which would need to be done and tested for every locale.

The patch to the Xserver sources is minimal and targets a file that hasn't changed much in recent years. At the time of patch creation, the xorg package set is defined in
https://github.com/NixOS/nixpkgs/blob/21.11/pkgs/servers/x11/xorg/default.nix

## Alternatives considered

### Altering xkb_compat rules to unset actions

In a simple approach, it is possible to dynamically patch interpretation rules in xkb to set the key combinations to a no-op.

```
xkbcomp $DISPLAY keymap.xkb
sed -i 's/SwitchScreen(screen=12.\+)/NoAction()/' keymap.xkb
xkbcomp keymap.xkb $DISPLAY
```

This seems prone to silently failing due to future changes, and possibly only for some keymaps/languages. It is possible to [do some basic syntax checks at build time](https://nixos.wiki/wiki/Keyboard_Layout_Customization#Advanced), but one would have to make this work for each keymap and go through added effort when adding new keymaps/languages.

### Change controller key combination and block all VTs

We could consider changing the controller key combination to something simpler (e.g. Ctrl+F12). In addition, we might simply block all virtual terminals from Xserver (`DontVTSwitch`, `srvrkeys:none`). The latter would require us to find another way to present the status info now on VT 8. 

Advantages:

- Easier controller key combination for users
- No way to end up in any VTs by accident
- Slight added security from not permitting access to VTs to anyone

This seems quite attractive but demands a considered decision. In the meantime, the patch in this PR removes a source of confusion, but can be easily reverted if it causes maintenance overhead or another solution is chosen.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
