### PR TITLE
Clean up play-kiosk module

### DIFF
--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -19,6 +19,11 @@
     group = "users";
   };
 
+  # System-wide packages
+  environment.systemPackages = with pkgs; [
+    breeze-contrast-cursor-theme
+  ];
+
   # Kiosk session
   services.xserver = let sessionName = "kiosk-browser"; in {
     enable = true;
@@ -91,10 +96,6 @@
   # Run PulseAudio as System-Wide daemon. See [1] for why this is in general a bad idea, but ok for our case.
   # [1] https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/
   hardware.pulseaudio.systemWide = true;
-
-  environment.systemPackages = with pkgs; [
-    breeze-contrast-cursor-theme
-  ];
 
   # Enable avahi for Senso discovery
   services.avahi.enable = true;

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -20,15 +20,13 @@
   };
 
   # Kiosk session
-  services.xserver = {
+  services.xserver = let sessionName = "kiosk-browser"; in {
     enable = true;
-
-    displayManager.defaultSession = "kiosk-browser";
 
     desktopManager = {
       xterm.enable = false;
       session = [
-        { name = "kiosk-browser";
+        { name = sessionName;
           start = ''
             # Disable screen-saver control (screen blanking)
             xset s off
@@ -68,6 +66,8 @@
         enable = true;
         user = "play";
       };
+
+      defaultSession = sessionName;
 
       sessionCommands = ''
         ${pkgs.xorg.xrdb}/bin/xrdb -merge <<EOF

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -90,12 +90,14 @@
     wantedBy = [ "multi-user.target" ];
   };
 
-  # Enable audio
-  hardware.pulseaudio.enable = true;
+  # Audio
+  hardware.pulseaudio = {
+    enable = true;
 
-  # Run PulseAudio as System-Wide daemon. See [1] for why this is in general a bad idea, but ok for our case.
-  # [1] https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/
-  hardware.pulseaudio.systemWide = true;
+    # Run PulseAudio as System-Wide daemon. See [1] for why this is in general a bad idea, but ok for our case.
+    # [1] https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/
+    systemWide = true;
+  };
 
   # Enable avahi for Senso discovery
   services.avahi.enable = true;

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -92,11 +92,7 @@
   # [1] https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/
   hardware.pulseaudio.systemWide = true;
 
-  # Install a command line mixer
-  # TODO: remove when controlling audio works trough controller
   environment.systemPackages = with pkgs; [
-    pamix
-    pamixer
     breeze-contrast-cursor-theme
   ];
 


### PR DESCRIPTION
Some small cleanups in the play-kiosk module.

The only change that should affect the built OS file is the removal of the unused TUI mixers for PulseAudio. Users can not access them and we have never had a need for them.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
