### PR TITLE
Suppress RAUC status error during installation

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -4,6 +4,10 @@
 
 - os: Update nixpkgs channel to 21.11
 
+## Fixed
+
+- controller: Suppress a confusing error message during regular system updates
+
 # [2021.9.0] - 2021-11-11
 
 # [2021.9.0-VALIDATION] - 2021-09-28


### PR DESCRIPTION
RAUC does not provide meaningful status information while an installation is in progress.

We default to a placeholder message to avoid the impression of error during a perfectly normal update.

![rauc-downloading](https://user-images.githubusercontent.com/47458/159684041-8fae2483-9450-426d-b1ba-8d5752ff1a72.jpeg)
![rauc-installing](https://user-images.githubusercontent.com/47458/159684033-0af2e879-7530-42fb-b6f1-bbbba1b127e3.jpeg)
![rauc1](https://user-images.githubusercontent.com/47458/159684050-f708a86b-e237-469e-bab5-f109394e639e.jpeg)

## Testing

Can be tested by building and installing after setting main `default.nix`'s version to e.g. `2010.10.0`, installing to PC or VM, observing update process.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
