### PR TITLE
Prevent “Already connected” error when connecting to a network

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,8 +1,16 @@
 # [UNRELEASED]
 
+## Added
+
+- controller: Show a loader in submit buttons when submitting forms
+
 ## Changed
 
 - os: Update nixpkgs channel to 21.11
+
+## Fixed
+
+- controller: Prevent “Already connected” errors when connecting to a network
 
 # [2021.9.0] - 2021-11-11
 

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -97,7 +97,6 @@ customElements.define(
       form.addEventListener('submit', function() {
         button.disabled = true
         button.style.color = 'transparent'
-        button.className += ' d-Button--Disabled'
         buttonParent.appendChild(spinnerParent)
       })
     }

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -8,7 +8,7 @@ customElements.define(
 
       const input = this
 
-      const root = installParent(input, document.createElement('span'))
+      const root = wrap(input, document.createElement('span'))
       root.style = 'position: relative'
 
       const button = document.createElement('input')
@@ -75,7 +75,7 @@ customElements.define(
       const form = this
       const button = form.querySelector('input[type=submit]')
 
-      const buttonParent = installParent(button, document.createElement('span'))
+      const buttonParent = wrap(button, document.createElement('span'))
       buttonParent.style = `
         position: relative;
         height: fit-content;
@@ -109,7 +109,7 @@ customElements.define(
  * Useful to extend nodes that can not have children in web components, for
  * ex. inputs.
  */
-function installParent(node, newParent) {
+function wrap(node, newParent) {
     node.parentNode.replaceChild(newParent, node)
     newParent.appendChild(node)
     return newParent

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -107,7 +107,7 @@ customElements.define(
 
 /* Place given node under a new parent node.
  *
- * Useful to extend nodes that can not have childreen in web components, for
+ * Useful to extend nodes that can not have children in web components, for
  * ex. inputs.
  */
 function installParent(node, newParent) {

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -1,4 +1,4 @@
-/* Password input web component with a SHOW/HIDE toggle button
+/* Password input web component with a SHOW/HIDE toggle button.
  */
 customElements.define(
   'show-password',
@@ -6,10 +6,13 @@ customElements.define(
     constructor() {
       super()
 
-      const parentNode = this.parentNode
       const input = this
-      const root = document.createElement('span')
+
+      const root = installParent(input, document.createElement('span'))
+      root.style = 'position: relative'
+
       const button = document.createElement('input')
+      root.appendChild(button)
 
       let isPasswordShown = false
       function updatePasswordVisibility(b) {
@@ -23,15 +26,8 @@ customElements.define(
         }
       }
 
-      // Move the input (current root) under the new artificial root, and also
-      // append the button
-      parentNode.replaceChild(root, input)
-      root.appendChild(input)
-      root.appendChild(button)
-      root.style = 'position: relative'
-
       input.type = 'password'
-      input.style = 'padding-right: 3.5rem'; // Space for the button
+      input.style = 'padding-right: 3.5rem' // Space for the button
       input.oninput = function (e) {
         if (e.target.value.length > 0) {
           button.style.visibility = 'visible'
@@ -65,3 +61,14 @@ customElements.define(
   },
   { extends: 'input' }
 )
+
+/* Place given node under a new parent node.
+ *
+ * Useful to extend nodes that can not have childreen in web components, for
+ * ex. inputs.
+ */
+function installParent(node, newParent) {
+    node.parentNode.replaceChild(newParent, node)
+    newParent.appendChild(node)
+    return newParent
+}

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -62,6 +62,49 @@ customElements.define(
   { extends: 'input' }
 )
 
+/* Form web component preventing more than one submission.
+ *
+ * Disable submit input inside the form after the first submission.
+ */
+customElements.define(
+  'disable-after-submit',
+  class extends HTMLFormElement {
+    constructor() {
+      super()
+
+      const form = this
+      const button = form.querySelector('input[type=submit]')
+
+      const buttonParent = installParent(button, document.createElement('span'))
+      buttonParent.style = `
+        position: relative;
+        height: fit-content;
+      `
+
+      const spinnerParent = document.createElement('div')
+      spinnerParent.style = `
+        display: flex;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      `
+
+      const spinner = document.createElement('span')
+      spinner.className = 'd-Spinner'
+      spinnerParent.appendChild(spinner)
+
+      form.addEventListener('submit', function() {
+        button.disabled = true
+        button.style.color = 'transparent'
+        button.className += ' d-Button--Disabled'
+        buttonParent.appendChild(spinnerParent)
+      })
+    }
+  },
+  { extends: 'form' }
+)
+
 /* Place given node under a new parent node.
  *
  * Useful to extend nodes that can not have childreen in web components, for

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -290,10 +290,13 @@
     color: black;
     background-color: var(--form-border-color);
     border: var(--form-input-border);
+}
+
+.d-Button:not([disabled]) {
     cursor: pointer;
 }
 
-.d-Button:hover {
+.d-Button:not([disabled]):hover {
     border-color: var(--form-border-color-hover);
 }
 
@@ -343,6 +346,22 @@
     background: #f1f1f1;
     border: 1px solid #e1e1e1;
     border-radius: 4px;
+}
+
+/* Loading */
+
+.d-Spinner {
+    border: 2px solid #eeeeee;
+    border-top: 2px solid #aeaeae;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 }
 
 /* Other */

--- a/controller/server/view/info_page.ml
+++ b/controller/server/view/info_page.ml
@@ -6,6 +6,7 @@ let remote_management_form action button_label =
     ~a:[ a_action ("/remote-management/" ^ action)
     ; a_method `Post
     ; a_class [ "d-Info__RemoteManagementForm" ]
+    ; Unsafe.string_attrib "is" "disable-after-submit"
     ]
     [ input
         ~a:[ a_input_type `Submit

--- a/controller/server/view/label_page.ml
+++ b/controller/server/view/label_page.ml
@@ -22,6 +22,7 @@ let html { machine_id; mac_1; mac_2 } =
       ; form
           ~a:[ a_action "/label/print"
           ; a_method `Post
+          ; Unsafe.string_attrib "is" "disable-after-submit"
           ]
           [ Definition.list
               [ Definition.term [ txt "Label Printer URL" ]

--- a/controller/server/view/localization_page.ml
+++ b/controller/server/view/localization_page.ml
@@ -12,6 +12,7 @@ let select_form params options =
     ~a:[ a_action params.action_url
     ; a_method `Post
     ; a_class [ "d-Localization__Form" ]
+    ; Unsafe.string_attrib "is" "disable-after-submit"
     ]
     [ label
         ~a:[ a_class [ "d-Localization__Legend" ] ]

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -76,6 +76,7 @@ let disable_proxy_form service =
   form
       ~a:[ a_action ("/network/" ^ service.id ^ "/proxy/remove")
       ; a_method `Post
+      ; Unsafe.string_attrib "is" "disable-after-submit"
       ]
       [ input
           ~a:[ a_input_type `Submit
@@ -130,6 +131,7 @@ let static_ip_form service =
     ; form ~a:[ a_action ("/network/" ^ service.id ^ "/static-ip/update")
               ; a_id "static-ip-form"
               ; a_method `Post
+              ; Unsafe.string_attrib "is" "disable-after-submit"
               ]
         [ div ( ip_input
                   ~id:"static-ip-address"
@@ -173,6 +175,7 @@ let static_ip_form service =
               form ~a:[ a_action ( "/network/" ^ service.id ^ "/static-ip/remove" )
                       ; a_method `Post
                       ; a_style "display: inline; margin-left: 0.5rem"
+                      ; Unsafe.string_attrib "is" "disable-after-submit"
                       ]
                 [ input ~a:[ a_value "Remove"
                            ; a_input_type `Submit
@@ -191,6 +194,7 @@ let connected_form service =
         ~a:[ a_action ("/network/" ^ service.id ^ "/remove")
         ; a_method `Post
         ; a_class [ "d-Network__Form" ]
+        ; Unsafe.string_attrib "is" "disable-after-submit"
         ]
         [ input
             ~a:[ a_input_type `Submit
@@ -211,6 +215,7 @@ let connected_form service =
                     ~a:[ a_action ("/network/" ^ service.id ^ "/proxy/update")
                     ; a_method `Post
                     ; a_class [ "d-Network__ProxyUpdate" ]
+                    ; Unsafe.string_attrib "is" "disable-after-submit"
                     ]
                     [ proxy_input ?proxy:service.proxy service.id
                     ; input

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -38,6 +38,7 @@ let not_connected_form service =
       ~a:[ a_action ("/network/" ^ service.id ^ "/connect")
       ; a_method `Post
       ; a_class [ "d-Network__Form" ]
+      ; Unsafe.string_attrib "is" "disable-after-submit"
       ]
       [ div
           ~a:[ a_class [ "d-Network__Label" ] ]


### PR DESCRIPTION
Prevent submiting a form more than once. Once a form is submitted,
disable the submit input and show a loader.

This prevent geting the “Already connected” error, because (I think) 
the connection process is being worked on after the 1st submission.

## Loader

https://user-images.githubusercontent.com/6768842/160345478-c30f00c4-2b81-4d75-aed2-49fbd7820705.mp4

## Problem reproduction to check the fix

Add a delay when connecting to networks:

```patch
diff --git a/controller/server/gui.ml b/controller/server/gui.ml
index e59bd4f..9950377 100644
--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -268,6 +268,11 @@ module NetworkGui = struct
 
   (** Connect to a service *)
   let connect ~(connman:Connman.Manager.t) req =
+
+    let _ = Logs.warn (fun m -> m "\n\nTrying to connect, but sleeping before…\n") in
+    let%lwt () = Lwt_unix.sleep 2. in
+    let _ = Logs.warn (fun m -> m "\nOK\n") in
+
     let%lwt form_data = urlencoded_pairs_of_body req in
     let passphrase =
       match form_data |> List.assoc_opt "passphrase" with
```

On `develop`, when submitting connecting to a network multiple times, we get an “Already connected” error (at least when the password is wrong).

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   ~~[ ] User manual updated~~