### PR TITLE
Improve network connection error message

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -4,6 +4,7 @@
 
 - os: Update nixpkgs channel to 21.11
 - os: Disable virtual terminals that are not used by PlayOS
+- controller: Provide a more helpful error message when network connection is failing
 
 ## Fixed
 


### PR DESCRIPTION
When using an invalid passphrase, users got “Input/output error” message. That is not very informative to help them fix the problem.

Instead, use the message reported by ConnMan agent. In case the input is invalid, this is `invalid-key`.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   ~~[ ] User manual updated~~