### PR TITLE
Fix webview dialog memory leak

### DIFF
--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -21,7 +21,7 @@ class MainWidget(QtWidgets.QWidget):
                 "System Settings", 
                 self._settings_url, 
                 additional_close_keys = [self._toggle_settings_key],
-                on_close = lambda: self._browser_widget.reload())
+                on_close = self._show_browser_widget)
 
         self._layout = QtWidgets.QBoxLayout(QtWidgets.QBoxLayout.BottomToTop)
         self._layout.setContentsMargins(0, 0, 0, 0)
@@ -60,6 +60,7 @@ class MainWidget(QtWidgets.QWidget):
     def _show_settings(self):
         """ Show System Settings dialog.
         """
+        self._hide_browser_widget()
         self._settings_dialog.show()
 
     def _show_captive_portal(self):
@@ -67,8 +68,19 @@ class MainWidget(QtWidgets.QWidget):
         """
         self._is_captive_portal_dialog_open = True
         self._captive_portal_message.setParent(None)
+        self._hide_browser_widget()
         self._captive_portal_dialog.show()
 
     def _on_captive_portal_dialog_close(self):
         self._is_captive_portal_dialog_open = False
-        self._browser_widget.reload()
+        self._show_browser_widget()
+
+    def _hide_browser_widget(self):
+        """ Set overlay in place of the browser kiosk URL.
+        """
+        self._browser_widget.setHtml("<style>body { background-color: #999; }</style>")
+
+    def _show_browser_widget(self):
+        """ Show kiosk browser loading URL.
+        """
+        self._browser_widget.setUrl(self._kiosk_url)

--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -19,7 +19,6 @@ class MainWidget(QtWidgets.QWidget):
         self._settings_dialog = webview_dialog.WebviewDialog(
                 self, 
                 "System Settings", 
-                self._settings_url, 
                 additional_close_keys = [self._toggle_settings_key],
                 on_close = self._show_browser_widget)
 
@@ -39,7 +38,6 @@ class MainWidget(QtWidgets.QWidget):
         self._captive_portal_dialog = webview_dialog.WebviewDialog(
                 self, 
                 "Network Login", 
-                self._captive_portal_url,
                 additional_close_keys = [],
                 on_close = self._on_captive_portal_dialog_close)
 
@@ -61,7 +59,7 @@ class MainWidget(QtWidgets.QWidget):
         """ Show System Settings dialog.
         """
         self._hide_browser_widget()
-        self._settings_dialog.show()
+        self._settings_dialog.show(self._settings_url)
 
     def _show_captive_portal(self):
         """ Show Network Login to captive portal.
@@ -69,7 +67,7 @@ class MainWidget(QtWidgets.QWidget):
         self._is_captive_portal_dialog_open = True
         self._captive_portal_message.setParent(None)
         self._hide_browser_widget()
-        self._captive_portal_dialog.show()
+        self._captive_portal_dialog.show(self._captive_portal_url)
 
     def _on_captive_portal_dialog_close(self):
         self._is_captive_portal_dialog_open = False

--- a/kiosk/kiosk_browser/webview_dialog.py
+++ b/kiosk/kiosk_browser/webview_dialog.py
@@ -51,7 +51,7 @@ def show_webview_window(parent, title, url, on_close):
 
     layout.addWidget(title_line(widget, title, on_close))
 
-    webview = QtWebEngineWidgets.QWebEngineView()
+    webview = QtWebEngineWidgets.QWebEngineView(parent)
     webview.page().setUrl(url)
     layout.addWidget(webview)
 

--- a/kiosk/kiosk_browser/webview_dialog.py
+++ b/kiosk/kiosk_browser/webview_dialog.py
@@ -25,7 +25,10 @@ class WebviewDialog(QtWidgets.QDialog):
 
         # Close with shortcuts
         for key in set(['ESC', *additional_close_keys]):
-            QtWidgets.QShortcut(key, self).activated.connect(self._close)
+            QtWidgets.QShortcut(key, self).activated.connect(self.close)
+
+        # Finish after close
+        self.finished.connect(self._finish)
 
     def show(self):
         """ Show dialog on top of the current window.
@@ -89,7 +92,7 @@ class WebviewDialog(QtWidgets.QDialog):
                 background-color: rgba(255, 255, 255, 0.3);
             }
         """)
-        button.clicked.connect(self._close)
+        button.clicked.connect(self.close)
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(5, 5, 5, 0) # left, top, right, bottom
@@ -100,13 +103,10 @@ class WebviewDialog(QtWidgets.QDialog):
 
         return line
 
-    def _close(self):
-        """ Close dialog and give back the focus to the parent.
+    def _finish(self):
+        """ Cleanup webview and give back focus to the parent
         """
 
-        # Clean up webview (prevent seeing page scroll or change when re-open)
         self._webview.setHtml("") 
-
-        self.close()
         self._parent.activateWindow()
         self._on_close()

--- a/kiosk/kiosk_browser/webview_dialog.py
+++ b/kiosk/kiosk_browser/webview_dialog.py
@@ -12,13 +12,12 @@ window_color = '#222222'
 
 class WebviewDialog(QtWidgets.QDialog):
 
-    def __init__(self, parent, title, url, additional_close_keys, on_close):
+    def __init__(self, parent, title, additional_close_keys, on_close):
 
         QtWidgets.QDialog.__init__(self, parent)
 
         self._parent = parent
         self._title = title
-        self._url = url
         self._on_close = on_close
         self._webview = QtWebEngineWidgets.QWebEngineView(self)
         self._layout = QtWidgets.QVBoxLayout()
@@ -30,7 +29,7 @@ class WebviewDialog(QtWidgets.QDialog):
         # Finish after close
         self.finished.connect(self._finish)
 
-    def show(self):
+    def show(self, url):
         """ Show dialog on top of the current window.
         """
 
@@ -40,7 +39,7 @@ class WebviewDialog(QtWidgets.QDialog):
         self.setGeometry(w * (1 - dialog_ratio) / 2, h * (1 - dialog_ratio) / 2, w * dialog_ratio, h * dialog_ratio)
 
         # Reload the webview (prevent keeping previous scroll position)
-        self._webview.setUrl(self._url)
+        self._webview.setUrl(url)
 
         self._show_window()
         self.exec_()


### PR DESCRIPTION
- Fix webview dialog memory leak by assigning a parent to the webview in 17bddba
- Reduce memory usage by instantiating dialog webview only once in 8ba01db
- Reset main widget view to prevent activity like playing sounds in c0ec084
- Improve cleaning up after dialog is close in 9c2ffd8

## Testing

I open `htop` and look at global memory consumption. This in not very precise, because memory could grow because of another program running on my machine. Then I open and close the dialog modal repeatedly.

## Checklist

-   ~~[ ] Changelog updated~~
-   [x] Code documented
-   ~~[ ] User manual updated~~