### PR TITLE
Limit max resolution

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -15,6 +15,7 @@
 - kiosk: Show a loader when connecting to Play
 - kiosk: Show an informative error page when connecting to Play has failed
 - kiosk: Open System Settings (Ctrl+Shift+F12) and Network Login (behind captive portal) in a dialog
+- os: Limit resolution to 1080p on UHD screens
 
 ## Fixed
 

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -28,6 +28,31 @@
   services.xserver = let sessionName = "kiosk-browser"; in {
     enable = true;
 
+    # Limit resolution to full HD on UHD screens.
+    # This is to avoid performance issues with games
+    # and scaling issues of the controller UI.
+    extraConfig = ''
+      Section "Monitor"
+              Identifier      "HDMI-1"
+              Option "PreferredMode"  "1920x1080"
+      EndSection
+
+      Section "Monitor"
+              Identifier      "HDMI-2"
+              Option "PreferredMode"  "1920x1080"
+      EndSection
+
+      Section "Monitor"
+              Identifier      "DP-1"
+              Option "PreferredMode"  "1920x1080"
+      EndSection
+
+      Section "Monitor"
+              Identifier      "DP-2"
+              Option "PreferredMode"  "1920x1080"
+      EndSection
+    '';
+
     desktopManager = {
       xterm.enable = false;
       session = [


### PR DESCRIPTION
This xorg config seems to work to cap the resolution that X will use.
`Identifier` needs to be the name of the output, as returned by `xrandr -q`.
We'll probably need separate entries for each port on PlayOS machines (`DP, HDMI` etc).
The current config is only for testing inside a VM.

### Considerations
- The identifiers for the monitors are generated by the video card driver. I wonder if it's safe to rely on these labels, I am not sure how stable they are.

- I wonder what will happen if a TV is connected with an aspect ratio other than what we specify in `PreferredMode`. Most TVs will have a 16:9 aspect ratio, but with at home installations it's possible people might use a non-standard aspect ratio such as 21:9 (ultrawide monitors).


## Checklist

-   [X] Changelog updated
-   [X] Code documented
-   ~[ ] User manual updated~
