### PR TITLE
Fix webview dialog memory leak

### DIFF
--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -42,15 +42,17 @@ class MainWidget(QtWidgets.QWidget):
             self._layout.addWidget(self._captive_portal_message)
 
     def _show_settings(self):
+        self._hide_browser_widget()
         webview_dialog.widget(
                 self, 
                 "System Settings", 
                 self._settings_url, 
                 additional_close_keys = [self._toggle_settings_key],
-                on_dialog_close = lambda: self._browser_widget.reload()
+                on_dialog_close = lambda: self._show_browser_widget()
             ).exec_()
 
     def _show_captive_portal(self):
+        self._hide_browser_widget()
         self._is_captive_portal_dialog_open = True
         self._captive_portal_message.setParent(None)
         webview_dialog.widget(
@@ -63,4 +65,14 @@ class MainWidget(QtWidgets.QWidget):
 
     def _on_captive_portal_dialog_close(self):
         self._is_captive_portal_dialog_open = False
-        self._browser_widget.reload()
+        self._show_browser_widget()
+
+    def _hide_browser_widget(self):
+        """ Show a blank page.
+        """
+        self._browser_widget.setHtml("")
+
+    def _show_browser_widget(self):
+        """ Show kiosk browser loading URL.
+        """
+        self._browser_widget.setUrl(self._kiosk_url)

--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -44,11 +44,11 @@ class MainWidget(QtWidgets.QWidget):
     def _show_settings(self):
         self._hide_browser_widget()
         webview_dialog.widget(
-                self, 
-                "System Settings", 
-                self._settings_url, 
+                parent = self, 
+                title = "System Settings", 
+                url = self._settings_url, 
                 additional_close_keys = [self._toggle_settings_key],
-                on_dialog_close = lambda: self._show_browser_widget()
+                on_close = lambda: self._show_browser_widget()
             ).exec_()
 
     def _show_captive_portal(self):
@@ -56,11 +56,11 @@ class MainWidget(QtWidgets.QWidget):
         self._is_captive_portal_dialog_open = True
         self._captive_portal_message.setParent(None)
         webview_dialog.widget(
-                self, 
-                "Network Login", 
-                self._captive_portal_url,
+                parent = self, 
+                title = "Network Login", 
+                url = self._captive_portal_url,
                 additional_close_keys = [],
-                on_dialog_close = self._on_captive_portal_dialog_close
+                on_close = self._on_captive_portal_dialog_close
             ).exec_()
 
     def _on_captive_portal_dialog_close(self):
@@ -68,7 +68,7 @@ class MainWidget(QtWidgets.QWidget):
         self._show_browser_widget()
 
     def _hide_browser_widget(self):
-        """ Show a blank page.
+        """ Hide browser widget by showing a blank page.
         """
         self._browser_widget.setHtml("")
 

--- a/kiosk/kiosk_browser/webview_dialog.py
+++ b/kiosk/kiosk_browser/webview_dialog.py
@@ -51,7 +51,7 @@ def show_webview_window(parent, title, url, on_close):
 
     layout.addWidget(title_line(widget, title, on_close))
 
-    webview = QtWebEngineWidgets.QWebEngineView()
+    webview = QtWebEngineWidgets.QWebEngineView(parent)
     webview.page().setUrl(url)
     layout.addWidget(webview)
 

--- a/kiosk/kiosk_browser/webview_dialog.py
+++ b/kiosk/kiosk_browser/webview_dialog.py
@@ -7,7 +7,7 @@ dialog_ratio = 0.8
 window_border = 2
 window_color = '#222222'
 
-def widget(parent, title, url, additional_close_keys, on_dialog_close):
+def widget(parent, title, url, additional_close_keys, on_close):
     """ Embed a web view in a dialog.
 
         Close with ESC, additional_close_keys, or clicking on the cross.
@@ -18,17 +18,19 @@ def widget(parent, title, url, additional_close_keys, on_dialog_close):
     h = parent.height()
     dialog.setGeometry(w * (1 - dialog_ratio) / 2, h * (1 - dialog_ratio) / 2, w * dialog_ratio, h * dialog_ratio)
 
-    overlay = show_overlay(parent)
-    on_close = lambda: close(parent, overlay, dialog, on_dialog_close)
-    show_webview_window(dialog, title, url, on_close)
+    overlay = get_overlay(parent)
+    overlay.show()
+    show_webview_window(dialog, title, url)
 
     for key in set(['ESC', *additional_close_keys]):
-        QtWidgets.QShortcut(key, dialog).activated.connect(on_close)
+        QtWidgets.QShortcut(key, dialog).activated.connect(dialog.close)
 
-    overlay.show()
+    # Finish after close
+    dialog.finished.connect(lambda: finish(parent, overlay, dialog, on_close))
+
     return dialog
 
-def show_overlay(parent):
+def get_overlay(parent):
     """ Show overlay on all the surface of the parent.
     """
 
@@ -37,29 +39,29 @@ def show_overlay(parent):
     widget.setStyleSheet("background-color: rgba(0, 0, 0, 0.4)")
     return widget
 
-def show_webview_window(parent, title, url, on_close):
+def show_webview_window(dialog, title, url):
     """ Show webview window with decorations.
     """
 
-    widget = QtWidgets.QWidget(parent)
-    widget.setGeometry(0, 0, parent.width(), parent.height())
+    widget = QtWidgets.QWidget(dialog)
+    widget.setGeometry(0, 0, dialog.width(), dialog.height())
     widget.setStyleSheet(f"background-color: {window_color};")
 
     layout = QtWidgets.QVBoxLayout(widget)
     layout.setContentsMargins(window_border, 0, window_border, window_border) # left, top, right, bottom
     widget.setLayout(layout)
 
-    layout.addWidget(title_line(widget, title, on_close))
+    layout.addWidget(title_line(dialog, title))
 
-    webview = QtWebEngineWidgets.QWebEngineView(parent)
+    webview = QtWebEngineWidgets.QWebEngineView(dialog)
     webview.page().setUrl(url)
     layout.addWidget(webview)
 
-def title_line(parent, title, on_close):
+def title_line(dialog, title):
     """ Title and close button.
     """
 
-    line = QtWidgets.QWidget(parent)
+    line = QtWidgets.QWidget(dialog)
     line.setFixedHeight(30)
 
     label = QtWidgets.QLabel(title)
@@ -69,7 +71,7 @@ def title_line(parent, title, on_close):
         font-size: 16px;
     """);
 
-    button = QtWidgets.QPushButton("❌", parent)
+    button = QtWidgets.QPushButton("❌", dialog)
     button.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
     button.setStyleSheet("""
         QPushButton {
@@ -85,7 +87,7 @@ def title_line(parent, title, on_close):
             background-color: rgba(255, 255, 255, 0.3);
         }
     """)
-    button.clicked.connect(on_close)
+    button.clicked.connect(dialog.close)
 
     layout = QtWidgets.QHBoxLayout()
     layout.setContentsMargins(5, 5, 5, 0) # left, top, right, bottom
@@ -96,11 +98,10 @@ def title_line(parent, title, on_close):
 
     return line
 
-def close(parent, overlay, dialog, on_close):
-    """ Close dialog and give back the focus to the parent.
+def finish(parent, overlay, dialog, on_close):
+    """ Remove overlay and give back the focus to the parent.
     """
 
     overlay.setParent(None)
-    dialog.close()
     parent.activateWindow()
     on_close()

--- a/kiosk/kiosk_browser/webview_dialog.py
+++ b/kiosk/kiosk_browser/webview_dialog.py
@@ -59,7 +59,7 @@ def title_line(parent, title, on_close):
     """ Title and close button.
     """
 
-    line = QtWidgets.QWidget()
+    line = QtWidgets.QWidget(parent)
     line.setFixedHeight(30)
 
     label = QtWidgets.QLabel(title)
@@ -69,7 +69,7 @@ def title_line(parent, title, on_close):
         font-size: 16px;
     """);
 
-    button = QtWidgets.QPushButton("❌")
+    button = QtWidgets.QPushButton("❌", parent)
     button.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
     button.setStyleSheet("""
         QPushButton {


### PR DESCRIPTION
This makes fewer modifications compared to #85. I didn’t know how to reset the web view of the dialog, so that when we open the dialog again, we don’t briefly see what was loaded before.

Memory usage grows faster here, but it’s getting down from time to time when repeatedly opening and closing it.

## Checklist

-   ~~[ ] Changelog updated~~
-   [x] Code documented
-   ~~[ ] User manual updated~~