### PR TITLE
Ease keeping previously defined proxy password

### DIFF
--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -134,6 +134,42 @@ customElements.define(
   { extends: 'div' }
 )
 
+/* Keep previous password web component.
+ *
+ * Propose to keep the previously defined password instead of re-defining a new one.
+ */
+customElements.define(
+  'keep-previous-password',
+  class extends HTMLDivElement {
+    constructor() {
+      super()
+
+      const passwordInput = this
+      const root = wrap(passwordInput, document.createElement('div'))
+
+      // Prepend checkbox to enable or disable keeping previous password
+      const input = document.createElement('input')
+      input.name = 'keep_password'
+      input.type = 'checkbox'
+      input.className = 'd-Checkbox'
+      input.checked = true
+      const label = document.createElement('label')
+      label.appendChild(input)
+      label.appendChild(document.createTextNode('Keep previously defined password'))
+      root.prepend(label)
+
+      // Hide password input
+      passwordInput.style = 'display: none'
+
+      // Toggle password input display on click
+      input.addEventListener('click', function() {
+        passwordInput.style.display = passwordInput.style.display === 'block' ? 'none' : 'block'
+      })
+    }
+  },
+  { extends: 'div' }
+)
+
 /* Place given node under a new parent node.
  *
  * Useful to extend nodes that can not have children in web components, for

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -328,6 +328,10 @@
     border-color: var(--form-border-color-hover);
 }
 
+.d-Checkbox {
+    margin-right: 0.5rem;
+}
+
 /* Definitions */
 
 .d-Definitions__Term {

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -337,8 +337,6 @@ module NetworkGui = struct
       | Some proxy -> Connman.Service.set_manual_proxy service proxy
     in
 
-    (* Grant time for changes to take effect and return to overview *)
-    let%lwt () = Lwt_unix.sleep 0.5 in
     redirect' (Uri.of_string "/network")
 
   (** Remove a service **)

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -257,13 +257,24 @@ module NetworkGui = struct
       let password_input =
         form_data |> List.assoc "proxy_password" |> List.hd |> non_empty
       in
-      match host_input, port_input, user_input, password_input with
+      let keep_password = 
+        form_data |> List.assoc_opt "keep_password" |> Option.is_some
+      in
+      let password = 
+        match (keep_password, current_proxy_opt) with
+        | (true, Some ({ credentials = Some { password } })) -> Some password
+        | _ -> password_input
+      in
+      match host_input, port_input, user_input, password with
+      (* Configuration without credentials was submitted *)
+      | Some host, Some port, None, None ->
+        return (Some (Service.Proxy.make host port))
       (* Configuration with credentials was submitted *)
       | Some host, Some port, Some user, password ->
         return (Some (Service.Proxy.make ~user:user ~password:(Option.value ~default:"" password) host port))
-      (* Configuration without credentials was submitted *)
-      | Some host, Some port, None, _ ->
-        return (Some (Service.Proxy.make host port))
+      (* Configuration without user but with password was submitted *)
+      | _, _, None, Some _ ->
+        fail_with "A user is required if a password is provided"
       (* Incomplete server information *)
       | _ ->
         fail_with "A host and port are required to configure a proxy server"

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -258,25 +258,9 @@ module NetworkGui = struct
         form_data |> List.assoc "proxy_password" |> List.hd |> non_empty
       in
       match host_input, port_input, user_input, password_input with
-      (* Complete configuration was submitted *)
-      | Some host, Some port, Some user, Some password ->
-        return (Some (Service.Proxy.make ~user:user ~password:password host port))
-      (* Configuration was submitted without password, check whether it is
-         safe to refill from stored value *)
-      | Some host, Some port, Some user, None ->
-        (match current_proxy_opt with
-          | Some ({ credentials = Some { password } } as current_proxy) ->
-              let restored_proxy = Service.Proxy.make ~user:user ~password:password host port in
-              if current_proxy = restored_proxy then
-                (* Proxy configuration has not been touched *)
-                return (Some current_proxy)
-              else
-                (* Proxy configuration has been touched, it's unsafe to restore password *)
-                return (Some (Service.Proxy.make ~user:user ~password:"" host port))
-          | _ ->
-              (* No existing proxy credentials, use empty password *)
-              return (Some (Service.Proxy.make ~user:user ~password:"" host port))
-        )
+      (* Configuration with credentials was submitted *)
+      | Some host, Some port, Some user, password ->
+        return (Some (Service.Proxy.make ~user:user ~password:(Option.value ~default:"" password) host port))
       (* Configuration without credentials was submitted *)
       | Some host, Some port, None, _ ->
         return (Some (Service.Proxy.make host port))

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -169,7 +169,8 @@ let toggle_group ~is_enabled ~legend_text ~toggle_field contents =
       legend
         [ checked_input
             is_enabled
-            [ a_input_type `Checkbox
+            [ a_class [ "d-Checkbox" ]
+            ; a_input_type `Checkbox
             ; a_name toggle_field
             ; a_id toggle_field
             ; a_onclick "this.closest('.d-Network__ToggleGroup').classList.toggle('d-Network__ToggleGroup--Enabled', this.checked)"

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -48,16 +48,27 @@ let proxy_form proxy =
            )
        ]
        ()
-    ; div ~a:[ a_class [ "d-Network__Label" ] ] [ label ~a:[ a_label_for "proxy_password" ] [ txt "Password (optional)" ] ]
-     ; input
-       ~a:[ a_input_type `Password
-       ; a_class [ "d-Input"; "d-Network__Input" ]
-       ; a_name "proxy_password"
-       ; a_value ""
-       ; Unsafe.string_attrib "is" "show-password"
-       ]
-       ()
-     ]
+    ; div
+        ~a:(match proxy with
+            | Some { credentials = Some { password } } ->
+                if password <> "" then
+                    [ Unsafe.string_attrib "is" "keep-previous-password" ]
+                else
+                    []
+            | _ -> [])
+        [ div 
+            ~a:[ a_class [ "d-Network__Label" ] ] 
+            [ label ~a:[ a_label_for "proxy_password" ] [ txt "Password (optional)" ] ]
+        ; input
+            ~a:[ a_input_type `Password
+            ; a_class [ "d-Input"; "d-Network__Input" ]
+            ; a_name "proxy_password"
+            ; a_value ""
+            ; Unsafe.string_attrib "is" "show-password"
+            ]
+            ()
+        ]
+    ]
 
 let not_connected_form service =
   let passphrase_id = "passphrase-" ^ service.id in


### PR DESCRIPTION
With the previous mechanism, one scenario was not possible: delete a password while keeping the same configuration otherwise. Moreover, I find it to be working out too implicitly.

This introduces a “Keep previously defined password” checkbox if a password has already been defined.

If it is checked, this means we keep the previously defined password. Otherwise, a password input is showed and we can type a new password, or none if we want to reset it.

## Screenshots

![image](https://user-images.githubusercontent.com/6768842/163128642-7c564a8d-e306-4757-a9e0-0866f5d86a22.png)

![image](https://user-images.githubusercontent.com/6768842/163128710-153fc4a6-6789-4f58-a9da-8d3c83b7f49f.png)

## Checklist

-   ~~[ ] Changelog updated~~
-   [x] Code documented
-   ~~[ ] User manual updated~~ (Will be done before releasing)