### PR TITLE
Move internet status check to the frontend

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -11,6 +11,7 @@
 - controller: Split proxy configuration form into multiple inputs for greater ease of use
 - controller: Provide a more helpful error message when network connection is failing
 - controller: Mark connected network services in service list
+- controller: Improve robustness of connectivity check in Network Settings
 - kiosk: Open System Settings (Ctrl+Shift+F12) and Network Login (behind captive portal) in a dialog
 
 ## Fixed

--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -104,6 +104,36 @@ customElements.define(
   { extends: 'form' }
 )
 
+/* Internet status web component.
+ *
+ * Ask HTTP server for current internet status, then show status.
+ */
+customElements.define(
+  'internet-status',
+  class extends HTMLDivElement {
+    constructor() {
+      super()
+
+      const div = this
+
+      const xhr = new XMLHttpRequest()
+      xhr.onload = function() {
+        div.className = '' // Remove loader
+        if (xhr.status >= 200 && xhr.status < 300) {
+          div.innerText = 'Connected'
+          div.style.color = 'green'
+        } else {
+          div.innerText = 'Not Connected'
+          div.style.color = 'red'
+        }
+      }
+      xhr.open( 'GET', '/internet/status')
+      xhr.send()
+    }
+  },
+  { extends: 'div' }
+)
+
 /* Place given node under a new parent node.
  *
  * Useful to extend nodes that can not have children in web components, for

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -210,17 +210,6 @@
     display: block;
 }
 
-/* Switch */
-
-.d-Switch--On {
-    color: green;
-}
-
-.d-Switch--Off {
-    color: red;
-}
-
-
 /* Side note */
 
 .d-Note {

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -485,7 +485,7 @@ module RemoteManagementGui = struct
           ; on_timeout = fun () ->
               let msg = "Timeout starting remote management service." in
               let%lwt () = Logs_lwt.err (fun m -> m "%s" msg) in
-              Lwt.return (success msg)
+              fail_with msg
           }
           wait_until_zerotier_is_on)
 

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -324,7 +324,7 @@ module NetworkGui = struct
     let%lwt service = with_service ~connman (param req "id") in
 
     let%lwt () = Connman.Service.connect ~input:passphrase service in
-    Lwt.return (success (Format.sprintf "Connected with %s." service.name))
+    redirect' (Uri.of_string "/network")
 
   (** Update a service *)
   let update ~(connman:Connman.Manager.t) req =
@@ -356,7 +356,7 @@ module NetworkGui = struct
     let%lwt () = Connman.Service.set_dhcp_ipv4 service in
 
     let%lwt () = Connman.Service.remove service in
-    Lwt.return (success (Format.sprintf "Forgot network %s." service.name))
+    redirect' (Uri.of_string "/network")
 
   let build ~(connman:Connman.Manager.t) app =
     app

--- a/controller/server/view/network_list_page.ml
+++ b/controller/server/view/network_list_page.ml
@@ -33,12 +33,11 @@ let service_item ({ id; name; strength; ipv4 } as service) =
 
 type params =
   { proxy: string option
-  ; is_internet_connected: bool
   ; services: Connman.Service.t list
   ; interfaces: string
   }
 
-let html { proxy; is_internet_connected; services; interfaces } =
+let html { proxy; services; interfaces } =
   let connected_services, available_services =
     List.partition Connman.Service.is_connected services
   in
@@ -75,15 +74,12 @@ let html { proxy; is_internet_connected; services; interfaces } =
               []
           ) @
           [ Definition.term [ txt "Internet" ]
-          ; Definition.description
-              [ if is_internet_connected then
-                  span
-                    ~a:[ a_class [ "d-Switch--On" ] ]
-                    [ txt "Connected" ]
-                else
-                  span
-                    ~a:[ a_class [ "d-Switch--Off" ] ]
-                    [ txt "Not connected" ]
+          ; Definition.description 
+              [ div 
+                  ~a:[ a_class [ "d-Spinner" ]
+                  ; Unsafe.string_attrib "is" "internet-status" 
+                  ]
+                  [] 
               ]
           ]
         )

--- a/controller/server/view/network_list_page.mli
+++ b/controller/server/view/network_list_page.mli
@@ -1,6 +1,5 @@
 type params =
   { proxy: string option
-  ; is_internet_connected: bool
   ; services: Connman.Service.t list
   ; interfaces: string
   }


### PR DESCRIPTION
The check was previously done in the backend. In order not to make the
client to wait for too long, we timed out the request after 0.2 seconds.
But in some cases, the request would have succeeded with just a few
extra time.

Instead, doing the request in the frontend, we don’t need a timeout. We
show a loader while the request is in progress. Then, we show
“Connected” if the result is success, “Not Connected” otherwise.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   ~~[ ] User manual updated~~
