### PR TITLE
Improve font size coherence

### DIFF
--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -50,7 +50,7 @@ customElements.define(
         position: absolute;
         top: 50%;
         right: calc(${rightMargin}px + 0.5rem);
-        font-size: 50%;
+        font-size: 65%;
         transform: translateY(-50%);
         cursor: pointer;
       `
@@ -154,6 +154,7 @@ customElements.define(
       input.className = 'd-Checkbox'
       input.checked = true
       const label = document.createElement('label')
+      label.className = 'd-CheckboxLabel'
       label.appendChild(input)
       label.appendChild(document.createTextNode('Keep previously defined password'))
       root.prepend(label)

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -27,7 +27,7 @@
 .d-Content {
     grid-area: content;
     place-self: center;
-    font-size: 2em;
+    font-size: 1.5rem;
     width: 90%;
     height: 90%;
     overflow: auto;
@@ -185,13 +185,8 @@
     margin: 1rem 0;
 }
 
-.d-Network__Label {
-    padding-bottom: 0.5rem;
-}
-
 .d-Network__Input {
     width: 400px;
-    margin-bottom: 1rem;
 }
 
 /* Toggle Group */
@@ -277,11 +272,21 @@
 /* Form */
 
 :root {
+    --form-label-font-size: 1.3rem;
     --form-component-height: 2.5rem;
-    --form-component-font-size: 70%;
+    --form-component-font-size: 1.2rem;
     --form-border-color: #DDDDDD;
     --form-border-color-hover: #888888;
     --form-input-border: 0.15rem solid var(--form-border-color);
+}
+
+.d-Label {
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.4rem;
+    font-size: var(--form-label-font-size);
+    width: fit-content;
+    margin-bottom: 1rem;
 }
 
 .d-Input {
@@ -330,6 +335,10 @@
 
 .d-Checkbox {
     margin-right: 0.5rem;
+}
+
+.d-CheckboxLabel {
+    font-size: var(--form-component-font-size);
 }
 
 /* Definitions */

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -5,49 +5,55 @@ open Tyxml.Html
 let proxy_form proxy =
   let open Proxy in
   div
-    [ div ~a:[ a_class [ "d-Network__Label" ] ] [ txt "Server" ]
-    ; div
-       [ input
-         ~a:[ a_input_type `Text
-         ; a_class [ "d-Input"; "d-Network__Input" ]
-         ; a_name "proxy_host"
-         ; a_value
-             (match proxy with 
-             | Some { host } -> host
-             | _ -> ""
-             )
-         ; a_placeholder "Host"
-         ; a_pattern {|[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*|}
-         ]
-         ()
-       ; txt ":"
-       ; input
-         ~a:[ a_input_type `Number
-         ; a_class [ "d-Input" ]
-         ; a_name "proxy_port"
-         ; a_size 5
-         ; a_step (Some 1.0)
-         ; a_value
-             (match proxy with 
-             | Some { port } -> string_of_int port
-             | _ -> ""
-             )
-         ; a_placeholder "Port"
-         ]
-         ()
-       ]
-    ; div ~a:[ a_class [ "d-Network__Label" ] ] [ label ~a:[ a_label_for "proxy_user" ] [ txt "Username (optional)" ] ]
-    ; input
-       ~a:[ a_input_type `Text
-       ; a_class [ "d-Input"; "d-Network__Input" ]
-       ; a_name "proxy_user"
-       ; a_value
-           (match proxy with 
-           | Some { credentials = Some { user } } -> user
-           | _ -> ""
-           )
-       ]
-       ()
+    [ label 
+        ~a:[ a_class [ "d-Label" ] ]
+        [ txt "Server"
+        ; span
+            [ input
+                ~a:[ a_input_type `Text
+                ; a_class [ "d-Input"; "d-Network__Input" ]
+                ; a_name "proxy_host"
+                ; a_value
+                    (match proxy with 
+                    | Some { host } -> host
+                    | _ -> ""
+                    )
+                ; a_placeholder "Host"
+                ; a_pattern {|[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*|}
+                ]
+                ()
+            ; txt ":"
+            ; input
+                ~a:[ a_input_type `Number
+                ; a_class [ "d-Input" ]
+                ; a_name "proxy_port"
+                ; a_size 10
+                ; a_step (Some 1.0)
+                ; a_value
+                    (match proxy with 
+                    | Some { port } -> string_of_int port
+                    | _ -> ""
+                    )
+                ; a_placeholder "Port"
+                ]
+                ()
+            ]
+        ]
+    ; label 
+        ~a:[ a_class [ "d-Label" ] ] 
+        [ txt "Username (optional)" 
+        ; input
+           ~a:[ a_input_type `Text
+           ; a_class [ "d-Input"; "d-Network__Input" ]
+           ; a_name "proxy_user"
+           ; a_value
+               (match proxy with 
+               | Some { credentials = Some { user } } -> user
+               | _ -> ""
+               )
+           ]
+           ()
+        ]
     ; div
         ~a:(match proxy with
             | Some { credentials = Some { password } } ->
@@ -56,42 +62,39 @@ let proxy_form proxy =
                 else
                     []
             | _ -> [])
-        [ div 
-            ~a:[ a_class [ "d-Network__Label" ] ] 
-            [ label ~a:[ a_label_for "proxy_password" ] [ txt "Password (optional)" ] ]
-        ; input
-            ~a:[ a_input_type `Password
-            ; a_class [ "d-Input"; "d-Network__Input" ]
-            ; a_name "proxy_password"
-            ; a_value ""
-            ; Unsafe.string_attrib "is" "show-password"
+        [ label
+            ~a:[ a_class [ "d-Label" ] ]
+            [ txt "Password (optional)"
+            ; input
+                ~a:[ a_input_type `Password
+                ; a_class [ "d-Input"; "d-Network__Input" ]
+                ; a_name "proxy_password"
+                ; a_value ""
+                ; Unsafe.string_attrib "is" "show-password"
+                ]
+                ()
             ]
-            ()
         ]
     ]
 
 let not_connected_form service =
-  let passphrase_id = "passphrase-" ^ service.id in
   form
       ~a:[ a_action ("/network/" ^ service.id ^ "/connect")
       ; a_method `Post
       ; a_class [ "d-Network__Form" ]
       ; Unsafe.string_attrib "is" "disable-after-submit"
       ]
-      [ div
-          ~a:[ a_class [ "d-Network__Label" ] ]
-          [ label
-              ~a:[ a_label_for passphrase_id ]
-              [ txt "Passphrase" ]
+      [ label
+          ~a:[ a_class [ "d-Label" ] ]
+          [ txt "Passphrase" 
+          ; input
+              ~a:[ a_input_type `Password
+              ; a_class [ "d-Input"; "d-Network__Input" ]
+              ; a_name "passphrase"
+              ; Unsafe.string_attrib "is" "show-password"
+              ]
+              ()
           ]
-      ; input
-          ~a:[ a_input_type `Password
-          ; a_class [ "d-Input"; "d-Network__Input" ]
-          ; a_id passphrase_id
-          ; a_name "passphrase"
-          ; Unsafe.string_attrib "is" "show-password"
-          ]
-          ()
       ; p
           [ input
               ~a:[ a_input_type `Submit
@@ -117,15 +120,19 @@ let is_static service =
   |> Option.value ~default:false
 
 let static_ip_form service =
-  let ip_input ~id ~labelTxt ~value ~pattern =
-    [ div ~a:[ a_class [ "d-Network__Label" ] ] [ label ~a:[ a_label_for id ] [ txt labelTxt ] ]
-    ; input ~a:[ a_id id
-               ; a_value value
+  let ip_input ~name ~labelTxt ~value ~pattern =
+      [ label 
+          ~a:[ a_class [ "d-Label" ] ] 
+          [ txt labelTxt
+          ; input 
+              ~a:[ a_value value
                ; a_class [ "d-Input"; "d-Network__Input" ]
-               ; a_name id
+               ; a_name name
                ; a_pattern pattern
-               ]()
-    ]
+               ]
+               ()
+          ]
+      ]
   in
   let ipv4_value f =
     if is_static service then
@@ -142,22 +149,22 @@ let static_ip_form service =
         ; txt "where n is a number in the range of 0-255."
         ]
     ; div ( ip_input
-                  ~id:"static_ip_address"
+                  ~name:"static_ip_address"
                   ~labelTxt:"Address"
                   ~value:(ipv4_value(fun ipv4 -> ipv4.address))
                   ~pattern:ip_address_regex_pattern
                 @ ip_input
-                  ~id:"static_ip_netmask"
+                  ~name:"static_ip_netmask"
                   ~labelTxt:"Netmask"
                   ~value:(ipv4_value(fun ipv4 -> ipv4.netmask))
                   ~pattern:ip_address_regex_pattern
                 @ ip_input
-                  ~id:"static_ip_gateway"
+                  ~name:"static_ip_gateway"
                   ~labelTxt:"Gateway"
                   ~value:(ipv4_value(fun ipv4 -> ipv4.gateway |> Option.value ~default:""))
                   ~pattern:ip_address_regex_pattern
                 @ ip_input
-                  ~id:"static_ip_nameservers"
+                  ~name:"static_ip_nameservers"
                   ~labelTxt:"Nameservers"
                   ~value:(if is_static service then String.concat ", " service.nameservers else "")
                   ~pattern:multi_ip_address_regex_pattern
@@ -178,17 +185,17 @@ let toggle_group ~is_enabled ~legend_text ~toggle_field contents =
     ~a:[ a_class ([ "d-Network__ToggleGroup" ] @ if is_enabled then [ "d-Network__ToggleGroup--Enabled" ] else []) ]
     ~legend:(
       legend
-        [ checked_input
-            is_enabled
-            [ a_class [ "d-Checkbox" ]
-            ; a_input_type `Checkbox
-            ; a_name toggle_field
-            ; a_id toggle_field
-            ; a_onclick "this.closest('.d-Network__ToggleGroup').classList.toggle('d-Network__ToggleGroup--Enabled', this.checked)"
+        [ label
+            ~a:[ a_class [ "d-CheckboxLabel" ] ]
+            [ checked_input
+                is_enabled
+                [ a_class [ "d-Checkbox" ]
+                ; a_input_type `Checkbox
+                ; a_name toggle_field
+                ; a_onclick "this.closest('.d-Network__ToggleGroup').classList.toggle('d-Network__ToggleGroup--Enabled', this.checked)"
+                ]
+            ; txt legend_text 
             ]
-        ; label
-            ~a:[ a_label_for toggle_field ]
-            [ txt legend_text ]
         ]
     )
     [ fieldset contents ]
@@ -201,9 +208,15 @@ let connected_form service =
         ; a_class [ "d-Network__Form" ]
         ; Unsafe.string_attrib "is" "disable-after-submit"
         ]
-        [ toggle_group ~is_enabled:(Option.is_some service.proxy) ~legend_text:"HTTP Proxy" ~toggle_field:"proxy_enabled"
+        [ toggle_group 
+            ~is_enabled:(Option.is_some service.proxy) 
+            ~legend_text:"HTTP Proxy" 
+            ~toggle_field:"proxy_enabled"
             [ proxy_form service.proxy ]
-        ; toggle_group ~is_enabled:(is_static service) ~legend_text:"Static IP" ~toggle_field:"static_ip_enabled"
+        ; toggle_group 
+            ~is_enabled:(is_static service) 
+            ~legend_text:"Static IP" 
+            ~toggle_field:"static_ip_enabled"
             [ static_ip_form service ]
         ; input
             ~a:[ a_input_type `Submit


### PR DESCRIPTION
This particularly improves the readability of proxy forms. Also remove some identifiers and wrap inside a label instead.

**Tip:** hide whitespaces to simplify the diff.

## Before

![image](https://user-images.githubusercontent.com/6768842/164267831-2a43dfd9-b118-4844-ba64-7df562f2c9ee.png)

## After

![2022-04-20_17-31-42](https://user-images.githubusercontent.com/6768842/164267846-256cb0d4-08c7-4edd-a221-8eb3a02bcee6.png)

## Checklist

-   ~~[ ] Changelog updated~~
-   ~~[ ] Code documented~~
-   ~~[ ] User manual updated~~