### PR TITLE
Add check to avoid disclosing proxy passwords

### DIFF
--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -262,7 +262,14 @@ module NetworkGui = struct
       in
       let password = 
         match (keep_password, current_proxy_opt) with
-        | (true, Some ({ credentials = Some { password } })) -> Ok (Some password)
+        | (true, Some ({ host; port; credentials = Some { user; password } })) ->
+          if host_input = Some host && port_input = Some port && user_input = Some user then
+            (* Proxy configuration wasn't touched, password may be preserved. *)
+            Ok (Some password)
+          else
+            (* Proxy configuration was touched, demand new password to avoid
+               disclosing to untrusted server. *)
+            Error "Password needs to be provided when changing proxy configuration."
         | (true, _) -> Error "Failure to retrieve proxy password. Please re-submit the form."
         | _ -> Ok password_input
       in


### PR DESCRIPTION
As PlayOS systems are often semi-public, secrets entrusted to the system should be protected from unwarranted access.

We should not allow users to keep the same proxy password when changing the rest of the proxy configuration, as this could be used to reveal the password to untrusted proxy servers on the same network or Internet.

This adds a check to fail update if keeping password was requested but other proxy fields were changed.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
