### PR TITLE
Revert "Remove sleep after updating network configuration"

### DIFF
--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -348,6 +348,8 @@ module NetworkGui = struct
       | Some proxy -> Connman.Service.set_manual_proxy service proxy
     in
 
+    (* Grant time for changes to take effect and return to overview *)
+    let%lwt () = Lwt_unix.sleep 0.5 in
     redirect' (Uri.of_string "/network")
 
   (** Remove a service **)


### PR DESCRIPTION
This reverts commit 7f8acee0f6586003f2a1a45211c9eaf301cb8361.

Without this sleep, I am consistently observing a misleading "Not Connected" and missing IPv4 in service list, even though the connection is fully functional just milliseconds later. Leave some time for configuration to be applied.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
