### PR TITLE
Screen scaling preferences

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,5 +1,9 @@
 # [UNRELEASED]
 
+## Added
+
+- controller: Add option to limit screen resolution to Full HD
+
 # [2022.4.0-VALIDATION] - 2022-04-29
 
 ## Added

--- a/controller/bindings/screen-settings/dune
+++ b/controller/bindings/screen-settings/dune
@@ -1,0 +1,5 @@
+(library
+ (name screen_settings)
+ (modules screen_settings)
+ (libraries lwt logs logs.fmt logs.lwt lwt.unix util base)
+ (preprocess (pps lwt_ppx)))

--- a/controller/bindings/screen-settings/screen_settings.ml
+++ b/controller/bindings/screen-settings/screen_settings.ml
@@ -1,0 +1,61 @@
+open Lwt
+
+let log_src = Logs.Src.create "screen-scaling"
+let settings_file = "/var/lib/gui-localization/screen-scaling"
+
+(* Scaling options *)
+type scaling =
+  (* No config file
+     xsession script decides behaviour
+  *)
+  | Default
+  (* Config file with keyword: "scaled"
+     Explicitly opt-in to scaling to FullHD
+  *)
+  | Scaled
+  (* Config file with keyword: "native"
+     Explicitly opt-out of scaling to FullHD
+  *)
+  | Native
+
+let scaling_of_string = function
+  | "default" -> Some Default
+  | "scaled" -> Some Scaled
+  | "native" -> Some Native
+  | _ -> None
+
+let string_of_scaling = function
+  | Default -> "default"
+  | Scaled -> "scaled"
+  | Native -> "native"
+
+(* Used for representing options in the UI, ie. in dropdown. *)
+let label_of_scaling = function
+  | Default -> "Default"
+  | Scaled -> "Full HD"
+  | Native -> "Native"
+
+let set_scaling scaling =
+  match scaling with
+    | Default ->
+       Lwt_unix.file_exists settings_file
+         >>= (fun exists ->
+                if exists then Lwt_unix.unlink settings_file
+                else  return ()
+             )
+    | _ ->
+       Util.write_to_file log_src settings_file (string_of_scaling scaling)
+
+let get_scaling () =
+  Lwt_unix.file_exists settings_file
+    >>= (fun exists ->
+            if exists then
+               Util.read_from_file log_src settings_file
+                 >|= (fun s ->
+                        s
+                          |> scaling_of_string
+                          |> Option.value ~default:Default
+                     )
+             else
+               return Default
+        )

--- a/controller/bindings/screen-settings/screen_settings.ml
+++ b/controller/bindings/screen-settings/screen_settings.ml
@@ -9,10 +9,10 @@ type scaling =
      xsession script decides behaviour
   *)
   | Default
-  (* Config file with keyword: "scaled"
+  (* Config file with keyword: "full-hd"
      Explicitly opt-in to scaling to FullHD
   *)
-  | Scaled
+  | FullHD
   (* Config file with keyword: "native"
      Explicitly opt-out of scaling to FullHD
   *)
@@ -20,19 +20,19 @@ type scaling =
 
 let scaling_of_string = function
   | "default" -> Some Default
-  | "scaled" -> Some Scaled
+  | "full-hd" -> Some FullHD
   | "native" -> Some Native
   | _ -> None
 
 let string_of_scaling = function
   | Default -> "default"
-  | Scaled -> "scaled"
+  | FullHD -> "full-hd"
   | Native -> "native"
 
 (* Used for representing options in the UI, ie. in dropdown. *)
 let label_of_scaling = function
   | Default -> "Default"
-  | Scaled -> "Full HD"
+  | FullHD -> "Full HD"
   | Native -> "Native"
 
 let set_scaling scaling =

--- a/controller/bindings/screen-settings/screen_settings.mli
+++ b/controller/bindings/screen-settings/screen_settings.mli
@@ -1,0 +1,12 @@
+
+type scaling =
+  | Default
+  | Scaled
+  | Native
+
+val string_of_scaling : scaling -> string
+val label_of_scaling : scaling -> string
+val scaling_of_string : string -> scaling option
+
+val get_scaling : unit -> scaling Lwt.t
+val set_scaling : scaling -> unit Lwt.t

--- a/controller/bindings/screen-settings/screen_settings.mli
+++ b/controller/bindings/screen-settings/screen_settings.mli
@@ -1,7 +1,7 @@
 
 type scaling =
   | Default
-  | Scaled
+  | FullHD
   | Native
 
 val string_of_scaling : scaling -> string

--- a/controller/server/dune
+++ b/controller/server/dune
@@ -9,7 +9,7 @@
    page definition icon)
  (libraries lwt logs logs.fmt logs.lwt fpath cohttp-lwt-unix logging
   opium tyxml rauc zerotier connman locale network timedate systemd
-  label_printer semver2 fieldslib)
+  label_printer semver2 fieldslib screen_settings)
  (preprocess (pps lwt_ppx ppx_sexp_conv)))
 
 (library

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -70,8 +70,6 @@ end
 
 (** Localization GUI *)
 module LocalizationGui = struct
-  let scaling_file = "/home/play/.limit-resolution"
-
   let overview req =
     let%lwt td_daemon = Timedate.daemon () in
     let%lwt current_timezone = Timedate.get_configured_timezone () in

--- a/controller/server/view/common/page.ml
+++ b/controller/server/view/common/page.ml
@@ -30,7 +30,7 @@ let menu_label page =
   match page with
   | Info -> "Information"
   | Network -> "Network"
-  | Localization -> "Localization"
+  | Localization -> "Localization & Display"
   | SystemStatus -> "System Status"
   | Changelog -> "Changelog"
   | Shutdown -> "Shutdown"

--- a/controller/server/view/localization_page.ml
+++ b/controller/server/view/localization_page.ml
@@ -111,7 +111,7 @@ type params =
 let html params =
   Page.html 
     ~current_page:Page.Localization 
-    ~header:(Page.header_title ~icon:Icon.letter [ txt "Localization" ])
+    ~header:(Page.header_title ~icon:Icon.letter [ txt "Localization & Display" ])
     (div
       [ timezone_form params.timezone_groups params.current_timezone
       ; language_form params.langs params.current_lang

--- a/controller/server/view/localization_page.ml
+++ b/controller/server/view/localization_page.ml
@@ -84,16 +84,19 @@ let keyboard_form keymaps current_keymap =
     }
     (List.map (select_option current_keymap) keymaps)
 
-let scaling_form opt_in_scaling =
-  select_form
-    { action_url = "/localization/scaling"
-    ; legend = "Resolution"
-    ; select_name = "scaling"
-    ; placeholder = None
-    }
-    [ select_option (if opt_in_scaling then Some "y" else None) ("y", "Force 1080p")
-      ; select_option (if not opt_in_scaling then Some "n" else None) ("n", "Do not scale")
-    ]
+let scaling_form current_scaling =
+  [ Screen_settings.Default; Screen_settings.Scaled; Screen_settings.Native ]
+    |> List.map (fun s ->
+                  select_option
+                     (Some (Screen_settings.string_of_scaling current_scaling))
+                     (Screen_settings.string_of_scaling s, Screen_settings.label_of_scaling s)
+                 )
+    |> select_form
+      { action_url = "/localization/scaling"
+      ; legend = "Display resolution"
+      ; select_name = "scaling"
+      ; placeholder = None
+      }
 
 type params =
   { timezone_groups: (string * ((string * string) list)) list
@@ -102,7 +105,7 @@ type params =
   ; current_lang: string option
   ; keymaps: (string * string) list
   ; current_keymap: string option
-  ; opt_in_scaling: bool
+  ; current_scaling: Screen_settings.scaling
   }
 
 let html params =
@@ -113,7 +116,7 @@ let html params =
       [ timezone_form params.timezone_groups params.current_timezone
       ; language_form params.langs params.current_lang
       ; keyboard_form params.keymaps params.current_keymap
-      ; scaling_form params.opt_in_scaling
+      ; scaling_form params.current_scaling
       ; aside
           ~a:[ a_class [ "d-Localization__Note" ] ]
           [ txt "Note that keyboard and language changes require a restart." ]

--- a/controller/server/view/localization_page.ml
+++ b/controller/server/view/localization_page.ml
@@ -84,6 +84,17 @@ let keyboard_form keymaps current_keymap =
     }
     (List.map (select_option current_keymap) keymaps)
 
+let scaling_form opt_in_scaling =
+  select_form
+    { action_url = "/localization/scaling"
+    ; legend = "Resolution"
+    ; select_name = "scaling"
+    ; placeholder = None
+    }
+    [ select_option (if opt_in_scaling then Some "y" else None) ("y", "Force 1080p")
+      ; select_option (if not opt_in_scaling then Some "n" else None) ("n", "Do not scale")
+    ]
+
 type params =
   { timezone_groups: (string * ((string * string) list)) list
   ; current_timezone: string option
@@ -91,6 +102,7 @@ type params =
   ; current_lang: string option
   ; keymaps: (string * string) list
   ; current_keymap: string option
+  ; opt_in_scaling: bool
   }
 
 let html params =
@@ -101,6 +113,7 @@ let html params =
       [ timezone_form params.timezone_groups params.current_timezone
       ; language_form params.langs params.current_lang
       ; keyboard_form params.keymaps params.current_keymap
+      ; scaling_form params.opt_in_scaling
       ; aside
           ~a:[ a_class [ "d-Localization__Note" ] ]
           [ txt "Note that keyboard and language changes require a restart." ]

--- a/controller/server/view/localization_page.ml
+++ b/controller/server/view/localization_page.ml
@@ -119,5 +119,5 @@ let html params =
       ; scaling_form params.current_scaling
       ; aside
           ~a:[ a_class [ "d-Localization__Note" ] ]
-          [ txt "Note that keyboard and language changes require a restart." ]
+          [ txt "Note that changes to the keyboard, language and display settings require a restart." ]
       ])

--- a/controller/server/view/localization_page.ml
+++ b/controller/server/view/localization_page.ml
@@ -85,7 +85,7 @@ let keyboard_form keymaps current_keymap =
     (List.map (select_option current_keymap) keymaps)
 
 let scaling_form current_scaling =
-  [ Screen_settings.Default; Screen_settings.Scaled; Screen_settings.Native ]
+  [ Screen_settings.Default; Screen_settings.FullHD; Screen_settings.Native ]
     |> List.map (fun s ->
                   select_option
                      (Some (Screen_settings.string_of_scaling current_scaling))

--- a/controller/server/view/localization_page.mli
+++ b/controller/server/view/localization_page.mli
@@ -5,7 +5,7 @@ type params =
   ; current_lang: string option
   ; keymaps: (string * string) list
   ; current_keymap: string option
-  ; opt_in_scaling : bool
+  ; current_scaling : Screen_settings.scaling
   }
 
 val html :

--- a/controller/server/view/localization_page.mli
+++ b/controller/server/view/localization_page.mli
@@ -5,6 +5,7 @@ type params =
   ; current_lang: string option
   ; keymaps: (string * string) list
   ; current_keymap: string option
+  ; opt_in_scaling : bool
   }
 
 val html :

--- a/docs/user-manual/Readme.org
+++ b/docs/user-manual/Readme.org
@@ -155,14 +155,14 @@ A wireless service that is connected may be forgotten (disconnecting and resetti
 
 Ethernet connections are automatically configured using DHCP or link-local address autoconfiguration unless a static IP configuration is provided.
 
-** Localization
+** Localization & Display
 
-#+CAPTION: Localization
+#+CAPTION: Localization & Display
 #+NAME: fig:controller-localization
 #+attr_html: :width 800px
 [[../screenshots/controller-localization.png]]
 
-Setup timezone, language and keyboard layout of the system.
+Setup timezone, language, keyboard layout, and screen resolution preferences.
 
 ** Changelog
 

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -48,7 +48,7 @@
 
             # force resolution
             scaling_pref=/var/lib/gui-localization/screen-scaling
-            if [ -f "$scaling_pref" ] && [ $(cat "$scaling_pref") = "scaled" ]; then
+            if [ -f "$scaling_pref" ] && [ $(cat "$scaling_pref") = "full-hd" ]; then
                xrandr --size 1920x1080
             fi
 

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -46,6 +46,11 @@
               setxkbmap $(cat /var/lib/gui-localization/keymap) || true
             fi
 
+            # force resolution
+            if [ -f /home/play/.limit-resolution ]; then
+               xrandr --size 1920x1080
+            fi
+
             # Enable Qt WebEngine Developer Tools (https://doc.qt.io/qt-5/qtwebengine-debugging.html)
             export QTWEBENGINE_REMOTE_DEBUGGING="127.0.0.1:3355"
 

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -47,7 +47,8 @@
             fi
 
             # force resolution
-            if [ -f /home/play/.limit-resolution ]; then
+            scaling_pref=/var/lib/gui-localization/screen-scaling
+            if [ -f "$scaling_pref" ] && [ $(cat "$scaling_pref") = "scaled" ]; then
                xrandr --size 1920x1080
             fi
 


### PR DESCRIPTION
@knuton I know you're on holidays, but thought you'd be the most suitable reviewer as you have both a PlayOS machine and a 4k screen. And this can wait until you're back. Enjoy Rome!

-----------------------------------------------------------

Add option to limit resolution to Full HD. 

## Available settings 

1. **Default**
    No scaling is applied (for now).
    Marked by the absence of a configuration file.
    The purpose of this option is so we can easily change the default behavior between releases.
    To force scaling by default we just need to apply this change:
```diff
    diff --git a/system/play-kiosk.nix b/system/play-kiosk.nix
index f3deb77..fd572ed 100644
--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -48,7 +48,7 @@
 
             # force resolution
             scaling_pref=/var/lib/gui-localization/screen-scaling
-            if [ -f "$scaling_pref" ] && [ $(cat "$scaling_pref") = "scaled" ]; then
+            if [ ! -f "$scaling_pref" ] || [ $(cat "$scaling_pref") = "scaled" ]; then
                xrandr --size 1920x1080
             fi
 
```

2. **Full HD**
    Explicitly opt-in to limit resolution to Full HD.
    Marked by a configuration file containing the keyword "scaled".
   
3. **Native**
    Explicitly opt-out of limiting resolution to Full HD.
    Marked by a configuration file containing the keyword "native" .


## Ideas for further improvements
- Run `xrandr` as soon as the setting is updated, so people don't have to restart the machine.
- Use a radio button for the different settings and explain the meaning of the different options in a helper text.
- Do not assume aspect ratio. Scale to a max of 1080 pixels vertically keeping original aspect ratio of screen.

## Checklist

-   [X] Changelog updated
-   [X] Code documented
-   [X] User manual updated
