### PR TITLE
Use version 2.3.0 of Dividat driver

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,5 +1,9 @@
 # [UNRELEASED]
 
+## Changed
+
+- driver: Upgrade to 2.3.0 for recent versions of Senso Flex
+
 # [2022.4.0] - 2022-07-06
 
 # [2022.4.0-VALIDATION.1] - 2022-06-22

--- a/pkgs/dividat-driver/default.nix
+++ b/pkgs/dividat-driver/default.nix
@@ -2,11 +2,7 @@
 
 let
 
-  channel = "develop";
-
-  version = "2.2.0-rc2";
-
-  releaseUrl = "https://dist.dividat.com/releases/driver2/";
+  version = "2.3.0";
 
 in buildGoModule rec {
 
@@ -16,19 +12,17 @@ in buildGoModule rec {
   src = fetchFromGitHub {
     owner = "dividat";
     repo = "driver";
-    rev = "9146cbf2f540cd5aa9cea5828f83993c8629657b";
-    sha256 = "1lsh0lyjwdhk24zrryaqszl1k3356yzckzx32q7mbcvvkh17hs9q";
+    rev = version;
+    sha256 = "sha256-OLSd+q5oe5Fd7GtKsJkkpTiEndpt/x1X0xdzGzZ7Zpg=";
   };
 
-  vendorSha256 = "1lvgp9q3g3mpmj6khbg6f1z9zgdlmwgf65rqx4d7v50a1m7g9a0m";
+  vendorSha256 = "sha256-oL7upl231aWbkBfybmP5fSTySFJkEI3vGKaWJu+Q30Q=";
 
   nativeBuildInputs = with pkgs; [ pkgconfig pcsclite ];
   buildInputs = with pkgs; [ pcsclite ];
 
   ldflags = [
-    "-X github.com/dividat/driver/src/dividat-driver/server.channel=${channel}"
     "-X github.com/dividat/driver/src/dividat-driver/server.version=${version}"
-    "-X github.com/dividat/driver/src/dividat-driver/update.releaseUrl=${releaseUrl}"
   ];
 
 }


### PR DESCRIPTION
Use 2.3.0 of the Dividat driver, which supports the v4 versions of the Senso Flex, modernizes CORS headers for granting loopback-address access to web apps, and removes various self-update related features that are obsolete when deployment is always via PlayOS in customer scenarios.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
