### PR TITLE
Fix a file descriptor leak in curl.ml

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -4,6 +4,10 @@
 
 - driver: Upgrade to 2.3.0 for recent versions of Senso Flex
 
+## Fixed
+
+- controller: Fix a file descriptor leak that could lead to the controller interface becoming unusable
+
 # [2022.4.0] - 2022-07-06
 
 # [2022.4.0-VALIDATION.1] - 2022-06-22

--- a/controller/bindings/curl/curl.ml
+++ b/controller/bindings/curl/curl.ml
@@ -54,7 +54,9 @@ let exec cmd =
   let stdout_input = Lwt_io.of_unix_fd ~mode:Lwt_io.input stdout_r in
   let stderr_input = Lwt_io.of_unix_fd ~mode:Lwt_io.input stderr_r in
   let%lwt stdout = Lwt_io.read stdout_input in
+  let%lwt () = Lwt_io.close stdout_input in
   let%lwt stderr = Lwt_io.read stderr_input in
+  let%lwt () = Lwt_io.close stderr_input in
   Lwt.return (result, stdout, stderr)
 
 let safe_int_of_string str =


### PR DESCRIPTION
The `exec` helper in `curl.ml` opens two Unix pipes, but did not close the channels/file descriptors for the read end. This lead to the controller process accumulating open file descriptors, until it could no longer open files.

This most typically became visible through an EMFILE error being thrown for `/etc/machine-id` when a user opened the controller interface.

The issue arose after a large number of `curl` calls, either if the PC had a high uptime, or if requests were made in quick succession.

When running the controller with a given PID, the leak could be observed with

    while true; do date +"%T"; lsof -a -p $PID | grep pipe | wc -l; sleep 30; done

and in the case of failing self-update check requests the number could be seen to grow by 2 every 30 seconds.

The write end is already being closed as `FD_move` is used.

For input channels created with `Lwt_io.of_unix_fd` the file descriptor is closed if the channel is closed:

https://ocsigen.org/lwt/5.5.0/api/Lwt_io#VALof_fd

We did not close the channels, and so would expect 2 file descriptors to be leaked on each call to curl. This is what we observed above.

The fix is to manually close the input channels.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
