### PR TITLE
Recovery mechanism for status.ini

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,4 +12,4 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
           system-features = nixos-test benchmark big-parallel kvm
-    - run: NIXPKGS_ALLOW_UNFREE=1 nix-build
+    - run: testing/run

--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,20 @@ See the output of `run-playos-in-vm --help` for more information.
 
 The default user-mode network stack is used to create a virtual Ethernet connection with bridged Internet access for the guest. If you find that the guest has a dysfunctional Internet connection, check your host's firewall settings. If using ConnMan, restart ConnMan service and try again.
 
+## Testing
+
+Subcomponent tests using the [NixOS test framework](https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests) may be added to `test/integration`.
+
+Run tests with
+
+    testing/run
+
+or individual tests with
+
+    nix-build testing/integration/EXAMPLE.nix
+
+Tests added to `test/integration` are executed via a GitHub Action when pushing or creating pull requests.
+
 ## Deployment
 
 Update bundles are hosted on Amazon S3. The script `bin/deploy-playos-update` will handle signing and uploading of bundle.

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -12,6 +12,7 @@
 ## Fixed
 
 - controller: Fix a file descriptor leak that could lead to the controller interface becoming unusable
+- os: Add a mechanism to recover from a status file corruption that could prevent systems from updating
 
 # [2022.4.0] - 2022-07-06
 

--- a/system/rauc/default.nix
+++ b/system/rauc/default.nix
@@ -12,6 +12,26 @@
     wantedBy = [ "multi-user.target" ];
   };
 
+  # This service adjusts for a known weakness of the update mechanism that is due to the
+  # use of the `/boot` partition for storing RAUC's statusfile. The `/boot` partition
+  # was chosen to use FAT32 in order to use it as EFI system partition. FAT32 has no
+  # journaling and so the atomicity guarantees RAUC tries to give for statusfile updates
+  # are diminished. This service looks for leftovers from interrupted statusfile updates
+  # and tries to recover.
+  # Note that as previous installations will keep their boot partition unchanged even
+  # after system updates, this or a similar recovery mechanism would be required even if
+  # we change partition layout for new systems going forward.
+  systemd.services.statusfile-recovery = {
+    description = "status.ini recovery";
+    serviceConfig.ExecStart = "${pkgs.bash}/bin/bash ${./recover-from-tmpfile} /boot/status.ini";
+    serviceConfig.Type = "oneshot";
+    serviceConfig.User = "root";
+    serviceConfig.StandardOutput = "syslog";
+    serviceConfig.SyslogIdentifier = "statusfile-recovery";
+    serviceConfig.RemainAfterExit = true;
+    wantedBy = [ "multi-user.target" ];
+  };
+
   environment.etc."rauc/system.conf" = {
     source = ./system.conf;
   };

--- a/system/rauc/recover-from-tmpfile
+++ b/system/rauc/recover-from-tmpfile
@@ -1,0 +1,46 @@
+#! /usr/bin/env bash
+
+# This script is designed to recover files written with glib's
+# g_file_set_contents function. On journaling filesystems this function
+# ensures atomic updates to the target file by writing to a temporary
+# file and moving that to the target destination in a second step.
+# On journal-less filesystems such as FAT, the moving may itself not be
+# atomic and we can end up with an empty target file and a complete
+# temporary file. This is the situation this script is designed to
+# detect and recover from, by repeating the moving from temp file to
+# target.
+
+FILE="$1"
+
+# Get absolute path for given file name
+TARGET="$(realpath --no-symlinks "$FILE")"
+
+if ! [ -s "$TARGET" ]; then
+  # We expect a random alnum suffix of "up to" 7 characters
+  # (https://docs.gtk.org/glib/func.file_set_contents_full.html).
+  # The ones actually observed were 6 characters long, and we want to
+  # ignore files that don't seem likely to be tempfile copies.
+  TMP_SUFFIX="\.\w{5,7}"
+
+  PARENT="$(dirname "$TARGET")"
+  # List temp files based off of the target's name, with newer files first
+  CANDIDATES=($(ls -t --time=birth -d "$PARENT/"* | grep -E "$TARGET$TMP_SUFFIX"))
+  GREP_EXIT="$?"
+
+  if [ "$GREP_EXIT" -eq 0 ] && [ "${#CANDIDATES[@]}" -ge 1 ]; then
+    # Use the first, i.e. newest alternative as replacement
+    REPLACEMENT="${CANDIDATES[0]}"
+    if [ -s "$REPLACEMENT" ]; then
+      mv "$REPLACEMENT" "$FILE"
+      echo "Detected missing or empty '$FILE' and replaced it with '$REPLACEMENT'."
+    else
+      # If the newest alternative is empty, we do not know what to do.
+      # Do not touch any evidence and abort.
+      echo "Both '$FILE' and recovery candidate '$REPLACEMENT' are empty. Aborting."
+    fi
+  else
+    echo "The file '$FILE' seems empty, but no alternatives were found. Aborting."
+  fi
+else
+  echo "The file '$FILE' seems OK. Nothing to do."
+fi

--- a/testing/integration/rauc-statusfile-recovery.nix
+++ b/testing/integration/rauc-statusfile-recovery.nix
@@ -1,0 +1,74 @@
+let
+  pkgs = import ../../pkgs {
+    version = "1.0.0";
+    updateUrl = "http://localhost/";
+    kioskUrl = "http://localhost/";
+  };
+in
+pkgs.nixosTest {
+  name = "rauc statusfile recovery";
+
+  nodes = {
+    client = { config, pkgs, ... }: {
+      imports = [ ../../system/rauc ];
+      config = {
+        playos.updateCert = pkgs.writeText "dummy.pem"  "";
+      };
+      options = with pkgs.lib; {
+        playos.updateCert = mkOption {
+          type = types.package;
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    import time
+
+    def reset():
+      client.execute("rm /boot/status.ini*")
+
+    client.start()
+
+    #
+    # Leave alone a good status.ini
+    #
+    client.succeed('printf "one\ntwo\n" > /boot/status.ini')
+    client.succeed('printf "three\nfour\n" > /boot/status.ini.ABCDEFG')
+    client.shutdown()
+    client.start()
+    client.wait_for_unit("statusfile-recovery.service")
+    client.succeed('grep two /boot/status.ini')
+    client.succeed('test -f /boot/status.ini.ABCDEFG')
+
+    #
+    # Replace an empty status.ini with latest alternative
+    #
+    reset()
+    client.succeed('touch /boot/status.ini')
+    client.succeed('printf "three\nfour\n" > /boot/status.ini.ABCDEFG')
+    time.sleep(1)
+    client.succeed('printf "five\nsix\n" > /boot/status.ini.9B8D7F6')
+    client.shutdown()
+    client.start()
+    client.wait_for_unit("statusfile-recovery.service")
+    client.succeed('grep five /boot/status.ini')
+    client.succeed('test -f /boot/status.ini.ABCDEFG')
+    client.fail('test -f /boot/status.ini.9B8D7F6')
+
+    #
+    # Leave alone an empty status.ini with no good alternative
+    #
+    reset()
+    client.succeed('touch /boot/status.ini')
+    client.succeed('touch /boot/status.ini.ABCDEFG')
+    time.sleep(1)
+    client.succeed('touch /boot/status.ini.9B8D7F6')
+    client.shutdown()
+    client.start()
+    client.wait_for_unit("statusfile-recovery.service")
+    client.succeed('test ! -s /boot/status.ini')
+    client.succeed('test -f /boot/status.ini.ABCDEFG')
+    client.succeed('test -f /boot/status.ini.9B8D7F6')
+  '';
+}

--- a/testing/run
+++ b/testing/run
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+INTEGRATION_TEST_DIR="$(dirname "$(realpath "$0")")/integration"
+
+for TEST_DEF in $(ls "$INTEGRATION_TEST_DIR"/*.nix); do
+  nix-build "$TEST_DEF"
+done


### PR DESCRIPTION
This adds a mechanism to recover from emptied RAUC `status.ini` files if there is a leftover temp copy.

It also adds simple integration tests and makes them run on GitHub Actions.

A later effort might revise the partitioning in the installation script to avoid the problem entirely in new machines.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
