### PR TITLE
Enable quiet boot in application level config

### DIFF
--- a/bootloader/grub.cfg
+++ b/bootloader/grub.cfg
@@ -64,7 +64,7 @@ save_env a_TRY b_TRY
 search --label system.a --set a_DISK
 search --label system.b --set b_DISK 
 
-set common_kernel_args="$machine_id_arg quiet panic=3 boot.panic_on_fail"
+set common_kernel_args="$machine_id_arg panic=3 boot.panic_on_fail quiet loglevel=3"
 
 menuentry "system.a (try=$a_TRY, ok=$a_OK)" --id system.a {
   set ORDER="a b"

--- a/bootloader/rescue/default.nix
+++ b/bootloader/rescue/default.nix
@@ -58,6 +58,9 @@ in
     # disable installation of bootloader
     boot.loader.grub.enable = false;
 
+    # Make sure we use a verbose loglevel in rescue mode
+    boot.consoleLogLevel = lib.mkForce 7;
+
     fileSystems = {
       "/" = {
         fsType = "tmpfs";

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -8,6 +8,7 @@
 
 - driver: Upgrade to 2.3.0 for recent versions of Senso Flex
 - os: Update nixpkgs channel to 22.11
+- os: Reduce loglevel for reduced business during system boot
 
 ## Fixed
 

--- a/docs/user-manual/Readme.org
+++ b/docs/user-manual/Readme.org
@@ -204,6 +204,8 @@ The rescue system will boot and display a menu:
 
 Select the entry "wipe-user-data" and press ~Enter~. This will delete all user data and reboot the computer.
 
+The rescue system's boot logs may also be useful when analysing potential hardware issues, as it is configured to reveal more logs from the Linux kernel.
+
 * Live System
 
 A live system build of PlayOS is available and can be pointed to experimental versions of Play or other web addresses to allow for easy evaluation. This version of PlayOS boots from removable media such as USB keys and has no persistent storage at all. Any configuration done when booted will be reset to defaults on next boot.

--- a/system/play-kiosk.nix
+++ b/system/play-kiosk.nix
@@ -11,6 +11,9 @@
     ];
   };
 
+  # Reduce warnings during boot to likely relevant level
+  boot.consoleLogLevel = pkgs.lib.mkForce 3;
+
   # Note that setting up "/home" as persistent fails due to https://github.com/NixOS/nixpkgs/issues/6481
   volatileRoot.persistentFolders."/home/play" = {
     mode = "0700";


### PR DESCRIPTION
NixOS uses a very high loglevel default of 7, causing a very chatty startup process. We can reduce this by picking a more end-user friendly (calmer) level.

If more detail is needed in some cases, the system may be booted in rescue mode with fully chatty startup.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
