### PR TITLE
Add content-type to controller responses

### DIFF
--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -21,8 +21,9 @@ let static () =
   Opium.Middleware.static ~local_path:static_dir ~uri_prefix:"/static" ()
 
 let page html =
+  let headers = Cohttp.Header.init_with "content-type" "text/html" in
   Format.asprintf "%a" (Tyxml.Html.pp ()) html
-  |> Response.of_string_body
+  |> Response.of_string_body ~headers
 
 let success content =
   page (Page.html (Tyxml.Html.txt content))


### PR DESCRIPTION
Include the content-type header to let sensitive clients (most TUI browsers) know what to do with the response.

I noticed this was missing while checking whether w3m/lynx etc. could be a lightweight option for using the controller in text-only systems.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
