### PR TITLE
Add live ISO to deployed artifacts

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -5,6 +5,7 @@
 - os: Widen rules for captive portal detection
 - os: Split system definition into base and application layers
 - os: Make build outputs and displayed system name configurable through application layer
+- os: Include live system ISO in deployed outputs
 
 # [2023.2.0] - 2023-03-06
 

--- a/deployment/deploy-update/default.nix
+++ b/deployment/deploy-update/default.nix
@@ -1,12 +1,12 @@
 { substituteAll
-, application, updateCert, unsignedRaucBundle, docs, installer
+, application, updateCert, unsignedRaucBundle, docs, installer, live
 , deployUrl, updateUrl, kioskUrl
 , rauc, awscli, python39
 }:
 substituteAll {
   src = ./deploy-update.py;
   dummyBuildCert = ../../pki/dummy/cert.pem;
-  inherit updateCert unsignedRaucBundle docs installer deployUrl updateUrl kioskUrl;
+  inherit updateCert unsignedRaucBundle docs installer live deployUrl updateUrl kioskUrl;
   inherit rauc awscli python39;
   inherit (application) fullProductName safeProductName version;
 }

--- a/deployment/deploy-update/deploy-update.py
+++ b/deployment/deploy-update/deploy-update.py
@@ -10,6 +10,7 @@ import sys
 
 UNSIGNED_RAUC_BUNDLE = "@unsignedRaucBundle@"
 INSTALLER_ISO = "@installer@"
+LIVE_ISO = "@live@"
 DOCS = "@docs@"
 VERSION = "@version@"
 FULL_PRODUCT_NAME = "@fullProductName@"
@@ -121,6 +122,13 @@ def _main(opts):
         installer_iso_src = os.path.join(INSTALLER_ISO, "iso", installer_iso_filename)
         installer_iso_dst = os.path.join(version_dir, installer_iso_filename)
         subprocess.run(["cp", installer_iso_src, installer_iso_dst],
+            check=True)
+
+        # Write live system ISO
+        live_iso_filename = f"{SAFE_PRODUCT_NAME}-live-{VERSION}.iso"
+        live_iso_src = os.path.join(LIVE_ISO, "iso", live_iso_filename)
+        live_iso_dst = os.path.join(version_dir, live_iso_filename)
+        subprocess.run(["cp", live_iso_src, live_iso_dst],
             check=True)
 
         # Write PDF manual


### PR DESCRIPTION
Make the live ISO available as part of the regular uploaded artifacts. It was already being build for our channel configurations.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
