### PR TITLE
Add persistent storage stats in status console

### DIFF
--- a/application/playos-status.nix
+++ b/application/playos-status.nix
@@ -11,6 +11,7 @@ let
         screen=$(xrandr --current | grep '*' | awk '{print $1}')
         networkCount=$(connmanctl services | grep wifi | wc -l)
         rfid=$(opensc-tool --list-readers | pr -T -o 2)
+        dataDiskFree=$(df -h /mnt/data | pr -T -o 2)
         controller=$(systemctl is-active playos-controller)
         time=$(date +'%T %Z')
         printf "\033c"
@@ -19,6 +20,8 @@ let
           "Wi-Fi networks found: $networkCount" \
           "RFID readers connected:" \
           "$rfid" \
+          "Persistent storage:" \
+          "$dataDiskFree" \
           "Controller: $controller" \
           "Updated at: $time" \
           > ${ttyPath}

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -6,6 +6,7 @@
 - os: Split system definition into base and application layers
 - os: Make build outputs and displayed system name configurable through application layer
 - os: Include live system ISO in deployed outputs
+- status screen: Display persistent storage usage statistics
 
 # [2023.2.0] - 2023-03-06
 


### PR DESCRIPTION
This allows to inspect the usage of the persistent partition, which is otherwise not inspectable without remote access. Other partitions are not included on the assumption that a reboot would fix everything due to their volatile state of being.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
