### PR TITLE
Use lists for systemd services' ExecStart

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -126,7 +126,7 @@ rec {
       # Driver service
       systemd.services."dividat-driver" = {
         description = "Dividat Driver";
-        serviceConfig.ExecStart = "${pkgs.dividat-driver}/bin/dividat-driver";
+        serviceConfig.ExecStart = [ "${pkgs.dividat-driver}/bin/dividat-driver" ];
         serviceConfig.User = "play";
         wantedBy = [ "multi-user.target" ];
       };

--- a/application/playos-status.nix
+++ b/application/playos-status.nix
@@ -45,7 +45,7 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "playos-controller.service" ];
       serviceConfig = {
-        ExecStart = "${script}/bin/print-status";
+        ExecStart = [ "${script}/bin/print-status" ];
         User = "root";
         StandardOutput = "tty";
         TTYPath = ttyPath;

--- a/base/default.nix
+++ b/base/default.nix
@@ -53,7 +53,7 @@ with lib;
     systemd.services.playos-controller = {
       description = "PlayOS Controller";
       serviceConfig = {
-        ExecStart = "${playos-controller}/bin/playos-controller";
+        ExecStart = [ "${playos-controller}/bin/playos-controller" ];
         User = "root";
         RestartSec = "10s";
         Restart = "always";

--- a/base/self-update/default.nix
+++ b/base/self-update/default.nix
@@ -23,7 +23,7 @@ in
 
     systemd.services.rauc = {
       description = "RAUC Update Service";
-      serviceConfig.ExecStart = "${pkgs.rauc}/bin/rauc service";
+      serviceConfig.ExecStart = [ "${pkgs.rauc}/bin/rauc service" ];
       serviceConfig.User = "root";
       wantedBy = [ "multi-user.target" ];
     };


### PR DESCRIPTION
By using lists for the `ExecStart` value we can use `lib.mkBefore` and `lib.mkAfter` to specialize the service definitions (likely in application modules).

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
