### PR TITLE
Exclude installer medium as target

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -5,6 +5,7 @@
 - os: Widen rules for captive portal detection
 - os: Split system definition into base and application layers
 - os: Make build outputs and displayed system name configurable through application layer
+- os: Change installer script to exclude installer medium from installation targets
 - os: Include live system ISO in deployed outputs
 
 # [2023.2.0] - 2023-03-06

--- a/installer/install-playos/install-playos.py
+++ b/installer/install-playos/install-playos.py
@@ -30,9 +30,9 @@ def find_device(device_path):
     """Return suitable device to install PlayOS on"""
     all_devices = parted.getAllDevices()
 
-    print(f"Found {len(all_devices)} devices:")
+    print(f"Found {len(all_devices)} disk devices:")
     for device in all_devices:
-        print(f"\t{device.path}")
+        print(f'\t{device_info(device)}')
 
     # We want to avoid installing to the installer medium, so we filter out
     # devices from the boot disk. We use the fact that we mount from the
@@ -44,9 +44,9 @@ def find_device(device_path):
     else:
         available_devices = [device for device in all_devices if not device.path.startswith(boot_device)]
 
-    print(f"Found {len(available_devices)} installation targets:")
+    print(f"Found {len(available_devices)} possible installation targets:")
     for device in available_devices:
-        print(f"\t{device.path}")
+        print(f'\t{device_info(device)}')
 
     device = None
     if device_path is None:
@@ -82,6 +82,11 @@ def get_blockdevice(mount_path):
                 if 'mountpoints' in child and mount_path in child['mountpoints']:
                     return '/dev/' + device['name']
     return None
+
+
+def device_info(device):
+    gb_size = int((device.sectorSize * device.length) / (10**9))
+    return f'{device.path} ({device.model} - {gb_size} GB)'
 
 
 def commit(disk):
@@ -344,13 +349,8 @@ def _get_grubenv_entry(entry_name, device):
             stderr=subprocess.DEVNULL)
 
 
-def _device_size_in_gb(device):
-    return (device.sectorSize * device.length) / (10**9)
-
-
 def confirm(device, machine_id, no_confirm):
-    print('\n\nInstalling PlayOS ({}) to {} ({} - {:n}GB)'.format(
-        VERSION, device.path, device.model, _device_size_in_gb(device)))
+    print('\n\nInstalling PlayOS ({}) to {}'.format(VERSION, device_info(device)))
     print('  Machine ID: {}'.format(machine_id.hex))
     print('  Update URL: {}'.format(PLAYOS_UPDATE_URL))
     print('  Kiosk URL: {}\n'.format(PLAYOS_KIOSK_URL))

--- a/installer/install-playos/install-playos.py
+++ b/installer/install-playos/install-playos.py
@@ -64,10 +64,8 @@ def find_device(device_path):
                 device for device in all_devices if device.path == device_path)
         except StopIteration:
             pass
-    if device == None:
-        raise ValueError('No suitable device to install on found.')
-    else:
-        return device
+
+    return device
 
 
 def get_blockdevice(mount_path):
@@ -360,6 +358,9 @@ def confirm(device, machine_id, no_confirm):
 def _main(opts):
     # Detect device to install to
     device = find_device(opts.device)
+    if device is None:
+        print('\nNo suitable device to install on found.')
+        exit(1)
 
     # Ensure machine-id exists and is valid
     machine_id = _ensure_machine_id(opts.machine_id, device)
@@ -383,7 +384,7 @@ def _main(opts):
         if opts.reboot:
             subprocess.run(['reboot'])
         else:
-            print("Done. Please remove install medium and reboot.")
+            print('\nDone. Please remove install medium and reboot.')
 
         exit(0)
 

--- a/installer/install-playos/install-playos.py
+++ b/installer/install-playos/install-playos.py
@@ -286,11 +286,11 @@ def _suppress_unless_fails(completed_process):
 # from http://code.activestate.com/recipes/577058/
 def _query_continue(question, default=False):
     valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
-    if default == None:
+    if default is None:
         prompt = " [y/n] "
-    elif default == True:
+    elif default is True:
         prompt = " [Y/n] "
-    elif default == False:
+    elif default is False:
         prompt = " [y/N] "
     else:
         raise ValueError("invalid default answer: '%s'" % default)
@@ -306,9 +306,9 @@ def _query_continue(question, default=False):
 
 
 def _ensure_machine_id(passed_machine_id, device):
-    if passed_machine_id == None:
+    if passed_machine_id is None:
         previous_machine_id = _get_grubenv_entry('machine_id', device)
-        if previous_machine_id == None:
+        if previous_machine_id is None:
             return uuid.uuid4()
         else:
             return uuid.UUID(previous_machine_id)
@@ -335,7 +335,7 @@ def _get_grubenv_entry(entry_name, device):
             universal_newlines=True)
         entry_match = re.search("^" + entry_name + "=(.+)$", grub_list.stdout,
                                 re.MULTILINE)
-        if entry_match == None:
+        if entry_match is None:
             return None
         else:
             return entry_match.group(1)


### PR DESCRIPTION
Adds automatic exclusion of the installer medium from installation targets.

This helps prevent mysterious issues in cases such as

- atypically large USB drive as installer medium,
- missing or undetected HDD due to misconfiguration,

in which case the installer previously could end up trying to install to the USB stick it was booted from. This is bad in two ways, 1) it messes up the installer medium which needs to be re-flashed, 2) it is confusing and hides the issue as installation seems to work initially, but no system is installed upon reboot.

This also changes the script to list all devices it finds, as well as the devices it considers for installation. This should help understand issues with disks more quickly.

## Examples

Good disk found:

![image](https://github.com/dividat/playos/assets/47458/3c89ad68-571c-406b-9a92-3c407c3e040d)

No good disk found (misconfigured BIOS):

![image](https://github.com/dividat/playos/assets/47458/51b36554-ace4-44f0-b9b0-6d188fb0d1cd)

In the latter case the installer would have previously installed to the USB drive.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
