### PR TITLE
Make Full HD the default mode for PlayOS

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -70,11 +70,18 @@ rec {
                 setxkbmap $(cat /var/lib/gui-localization/keymap) || true
               fi
 
-              # force resolution
-              scaling_pref=/var/lib/gui-localization/screen-scaling
-              if [ -f "$scaling_pref" ] && [ $(cat "$scaling_pref") = "full-hd" ]; then
-                 xrandr --size 1920x1080
-              fi
+              # Set preferred screen resolution
+              scaling_pref=$(cat /var/lib/gui-localization/screen-scaling 2>/dev/null || echo "default")
+              case "$scaling_pref" in
+                "default" | "full-hd")
+                  xrandr --size 1920x1080;;
+                "native")
+                  # Nothing to do, let system decide.
+                  ;;
+                *)
+                  echo "Unknown scaling preference '$scaling_pref'. Ignoring."
+                  ;;
+              esac
 
               # We want to avoid making the user configure audio outputs, but
               # instead route audio to both the standard output and any connected

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Changed
 
+- os: Make Full HD the default screen resolution
 - os: Widen rules for captive portal detection
 - os: Split system definition into base and application layers
 - os: Make build outputs and displayed system name configurable through application layer


### PR DESCRIPTION
In the context of Play installations, PlayOS is almost always configured to run in "Full HD" mode, _especially_ on UHD screens.

We therefore change the default to enter Full HD mode. If a preference is set, it will continue to be used as before.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
