### PR TITLE
Accessible captive portal when settings are open

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -10,6 +10,7 @@
 - os: Include live system ISO in deployed outputs
 - os: Update nixpkgs channel to 23.05
 - status screen: Display persistent storage usage statistics
+- controller: Allow opening captive portal when settings are open
 
 # [2023.2.0] - 2023-03-06
 

--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -1,8 +1,17 @@
 from PyQt5 import QtWidgets, QtCore
+from enum import Enum, auto
 
 from kiosk_browser import browser_widget, captive_portal
 from kiosk_browser import proxy as proxy_module
 from kiosk_browser import webview_dialog
+
+"""
+Dialog View being open
+"""
+class DialogView(Enum):
+    CLOSED = auto()
+    SETTINGS = auto()
+    CAPTIVE_PORTAL = auto()
 
 class MainWidget(QtWidgets.QWidget):
 
@@ -27,14 +36,16 @@ class MainWidget(QtWidgets.QWidget):
         self._layout.setSpacing(0)
         self._layout.addWidget(self._browser_widget)
 
+        # Dialog
+        self._dialog_view = DialogView.CLOSED
+
         # Captive portal
-        self._is_captive_portal_dialog_open = False
         self._captive_portal_url = ''
         self._captive_portal_message = captive_portal.open_message(self._show_captive_portal)
         self._captive_portal = captive_portal.CaptivePortal(proxy.get_current, self._show_captive_portal_message)
         self._captive_portal.start_monitoring_daemon()
 
-        QtWidgets.QShortcut(toggle_settings_key, self).activated.connect(self._show_settings)
+        QtWidgets.QShortcut(toggle_settings_key, self).activated.connect(self._toggle_settings)
 
         self.setLayout(self._layout)
         self.show()
@@ -43,31 +54,46 @@ class MainWidget(QtWidgets.QWidget):
 
     def _show_captive_portal_message(self, url):
         self._captive_portal_url = QtCore.QUrl(url)
-        if self._captive_portal_message.parentWidget() == None and not self._is_captive_portal_dialog_open:
+        if self._captive_portal_message.parentWidget() == None and not self._dialog_view == DialogView.CAPTIVE_PORTAL:
             self._layout.addWidget(self._captive_portal_message)
+
+    def _toggle_settings(self):
+        if self._dialog_view == DialogView.CLOSED:
+            self._show_settings()
+        else:
+            self._on_dialog_close()
 
     def _show_settings(self):
         self._browser_widget.show_overlay()
-        webview_dialog.widget(
+        self._dialog = webview_dialog.widget(
                 parent = self, 
                 title = "System Settings", 
                 url = self._settings_url, 
                 additional_close_keys = [self._toggle_settings_key],
-                on_close = self._browser_widget.reload
-            ).exec_()
+                on_close = self._on_dialog_close
+            )
+        # Open modeless to allow accessing captive portal message banner
+        # https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QDialog.html#modeless-dialogs
+        self._dialog.show()
+        self._dialog_view = DialogView.SETTINGS
 
     def _show_captive_portal(self):
+        if not self._dialog_view == DialogView.CLOSED:
+            self._dialog.close()
         self._browser_widget.show_overlay()
         self._is_captive_portal_dialog_open = True
         self._captive_portal_message.setParent(None)
-        webview_dialog.widget(
+        self._dialog = webview_dialog.widget(
                 parent = self, 
                 title = "Network Login", 
                 url = self._captive_portal_url,
-                additional_close_keys = [],
-                on_close = self._on_captive_portal_dialog_close
-            ).exec_()
+                additional_close_keys = [self._toggle_settings_key],
+                on_close = self._on_dialog_close
+            )
+        self._dialog.show()
+        self._dialog_view = DialogView.CAPTIVE_PORTAL
 
-    def _on_captive_portal_dialog_close(self):
-        self._is_captive_portal_dialog_open = False
+    def _on_dialog_close(self):
+        self._dialog_view = DialogView.CLOSED
         self._browser_widget.reload()
+        self._dialog.close()

--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -81,7 +81,6 @@ class MainWidget(QtWidgets.QWidget):
         if not self._dialog_view == DialogView.CLOSED:
             self._dialog.close()
         self._browser_widget.show_overlay()
-        self._is_captive_portal_dialog_open = True
         self._captive_portal_message.setParent(None)
         self._dialog = webview_dialog.widget(
                 parent = self, 

--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -1,6 +1,5 @@
 from PyQt5 import QtWidgets, QtCore
 from dataclasses import dataclass
-from enum import Enum, auto
 
 from kiosk_browser import browser_widget, captive_portal
 from kiosk_browser import proxy as proxy_module

--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -81,10 +81,13 @@ class MainWidget(QtWidgets.QWidget):
                 additional_close_keys = [self._toggle_settings_key],
                 on_close = lambda: self._close_dialog()
             )
+        self._dialog = Settings(dialog)
         # Open modeless to allow accessing captive portal message banner
         # https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QDialog.html#modeless-dialogs
+        # Focus directly to allow tabbing
         dialog.show()
-        self._dialog = Settings(dialog)
+        dialog.raise_()
+        dialog.activateWindow()
 
     def _show_captive_portal(self):
         self._close_dialog(reload_browser_widget = False)
@@ -97,8 +100,8 @@ class MainWidget(QtWidgets.QWidget):
                 additional_close_keys = [self._toggle_settings_key],
                 on_close = lambda: self._close_dialog()
             )
-        dialog.show()
         self._dialog = CaptivePortal(dialog)
+        dialog.exec_()
 
     def _close_dialog(self, reload_browser_widget = True):
         match self._dialog:

--- a/kiosk/kiosk_browser/webview_dialog.py
+++ b/kiosk/kiosk_browser/webview_dialog.py
@@ -21,17 +21,14 @@ def widget(parent, title, url, additional_close_keys, on_close):
                        int(w * dialog_ratio),
                        int(h * dialog_ratio))
 
-    show_webview_window(dialog, title, url)
+    show_webview_window(dialog, title, url, lambda: focus_parent_then_close(parent, on_close))
 
     for key in set(['ESC', *additional_close_keys]):
-        QtWidgets.QShortcut(key, dialog).activated.connect(dialog.close)
-
-    # Finish after close
-    dialog.finished.connect(lambda: finish(parent, dialog, on_close))
+        QtWidgets.QShortcut(key, dialog).activated.connect(lambda: focus_parent_then_close(parent, on_close))
 
     return dialog
 
-def show_webview_window(dialog, title, url):
+def show_webview_window(dialog, title, url, on_close):
     """ Show webview window with decorations.
     """
 
@@ -43,13 +40,13 @@ def show_webview_window(dialog, title, url):
     layout.setContentsMargins(window_border, 0, window_border, window_border) # left, top, right, bottom
     widget.setLayout(layout)
 
-    layout.addWidget(title_line(dialog, title))
+    layout.addWidget(title_line(dialog, title, on_close))
 
     webview = QtWebEngineWidgets.QWebEngineView(dialog)
     webview.page().setUrl(url)
     layout.addWidget(webview)
 
-def title_line(dialog, title):
+def title_line(dialog, title, on_close):
     """ Title and close button.
     """
 
@@ -79,7 +76,7 @@ def title_line(dialog, title):
             background-color: rgba(255, 255, 255, 0.3);
         }
     """)
-    button.clicked.connect(dialog.close)
+    button.clicked.connect(on_close)
 
     layout = QtWidgets.QHBoxLayout()
     layout.setContentsMargins(5, 5, 5, 0) # left, top, right, bottom
@@ -90,8 +87,8 @@ def title_line(dialog, title):
 
     return line
 
-def finish(parent, dialog, on_close):
-    """ Give back the focus to the parent.
+def focus_parent_then_close(parent, on_close):
+    """ Give back the focus to the parent, then close.
     """
 
     parent.activateWindow()


### PR DESCRIPTION
Previously, when the settings modal was open, when a captive portal was detected, we showed a header with a button, but it could not be interacted with, because the modal didn’t allow to access the parent window.

Setup the settings modal to be modeless, so that the button to open the captive portal is still accessible.

Also better represent the dialog state with an enumeration.

See https://trello.com/c/wcIrvEau/1445-captive-portal-prompt-pops-up-beneath-controller-modal

## Testing

- [x] Test dialogs in VM or live.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   ~~[ ] User manual updated~~