### PR TITLE
Disable bundling of documentation

### DIFF
--- a/base/default.nix
+++ b/base/default.nix
@@ -37,15 +37,20 @@ with lib;
     # disable installation of bootloader
     boot.loader.grub.enable = false;
 
-    # disable installation of inaccessible documentation
-    documentation.enable = false;
+    # disable inaccessible documentation
+    documentation = {
+      enable = false;
+      doc.enable = false;
+      info.enable = false;
+      man.enable = false;
+      nixos.enable = false;
+    };
 
     playos = { inherit version kioskUrl; };
 
     # 'Welcome Screen'
     services.getty = {
       greetingLine = greeting "${fullProductName} (${version})";
-      helpLine = "";
     };
 
     # Start controller

--- a/installer/configuration.nix
+++ b/installer/configuration.nix
@@ -14,6 +14,15 @@ with lib;
     install-playos
   ];
 
+  # Disable documentation
+  documentation = {
+    enable = false;
+    doc.enable = false;
+    info.enable = false;
+    man.enable = false;
+    nixos.enable = false;
+  };
+
   # Disable some other stuff we don't need.
   security.sudo.enable = mkDefault false;
   services.udisks2.enable = mkDefault false;


### PR DESCRIPTION
This documentation is not needed in the context of a PlayOS system, neither during installation nor a booted system.

This also removes an irrelevant help prompt from the installer system, which can be seen in this screenshot from #129:

![image](https://github.com/dividat/playos/assets/47458/1648286d-3e1f-4ec1-8a97-14c9bced65ab)


## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
