### PR TITLE
Pin only major version of Python to use binary cache

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -95,7 +95,7 @@ with pkgs; stdenv.mkDerivation {
 
   buildInputs = [
     rauc
-    (python39.withPackages(ps: with ps; [pyparted]))
+    (python3.withPackages(ps: with ps; [pyparted]))
     components.install-playos
   ];
 

--- a/deployment/deploy-update/default.nix
+++ b/deployment/deploy-update/default.nix
@@ -1,12 +1,12 @@
 { substituteAll
 , application, updateCert, unsignedRaucBundle, docs, installer, live
 , deployUrl, updateUrl, kioskUrl
-, rauc, awscli, python39
+, rauc, awscli, python3
 }:
 substituteAll {
   src = ./deploy-update.py;
   dummyBuildCert = ../../pki/dummy/cert.pem;
   inherit updateCert unsignedRaucBundle docs installer live deployUrl updateUrl kioskUrl;
-  inherit rauc awscli python39;
+  inherit rauc awscli python3;
   inherit (application) fullProductName safeProductName version;
 }

--- a/deployment/deploy-update/deploy-update.py
+++ b/deployment/deploy-update/deploy-update.py
@@ -1,4 +1,4 @@
-#!@python39@/bin/python
+#!@python3@/bin/python
 
 import argparse
 import hashlib

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeFontsConf, pandoc, python39Packages, ibm-plex, version }:
+{ stdenv, makeFontsConf, pandoc, python3Packages, ibm-plex, version }:
 let
   fontsConf = makeFontsConf {
     fontDirectories = [ ibm-plex ];
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
       # Workaround to allow setting custom fontconfig file.
       # Should be fixed in next version of Nixpkgs, so the regular package
       # can again be used (https://github.com/NixOS/nixpkgs/pull/254239).
-      weasyprint = python39Packages.weasyprint.overrideAttrs (o: {
+      weasyprint = python3Packages.weasyprint.overrideAttrs (o: {
         makeWrapperArgs = [ "--set-default FONTCONFIG_FILE ${o.FONTCONFIG_FILE}" ];
       });
     in

--- a/installer/install-playos/default.nix
+++ b/installer/install-playos/default.nix
@@ -5,7 +5,7 @@
 , e2fsprogs
 , dosfstools
 , utillinux
-, python39
+, python3
 , pv
 , closureInfo
 
@@ -19,7 +19,7 @@
 let
   systemClosureInfo = closureInfo { rootPaths = [ systemImage ]; };
 
-  python = python39.withPackages(ps: with ps; [pyparted]);
+  python = python3.withPackages(ps: with ps; [pyparted]);
 in
 stdenv.mkDerivation {
   name = "install-playos-${version}";

--- a/testing/run-in-vm/default.nix
+++ b/testing/run-in-vm/default.nix
@@ -1,10 +1,10 @@
 { substituteAll
 , version, disk, testingToplevel
-, bindfs, qemu, OVMF, python39
+, bindfs, qemu, OVMF, python3
 }:
 substituteAll {
   src = ./run-in-vm.py;
   inherit version disk testingToplevel;
-  inherit bindfs qemu python39;
+  inherit bindfs qemu python3;
   ovmf = "${OVMF.fd}/FV/OVMF.fd";
 }

--- a/testing/run-in-vm/run-in-vm.py
+++ b/testing/run-in-vm/run-in-vm.py
@@ -1,4 +1,4 @@
-#!@python39@/bin/python
+#!@python3@/bin/python
 
 import tempfile
 from contextlib import contextmanager


### PR DESCRIPTION
Not all Python versions' packages are cached by Hydra, so using packages specifically from `python39` often means laboriously rebuilding packages with native extensions.

We can specify only that we want Python 3, the specific version this resolves to is going to be fixed as long as we are on the same nixpkgs pin.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
