### PR TITLE
Fix fontconfig for weasyprint

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -9,11 +9,16 @@ stdenv.mkDerivation {
 
   src = ./.;
 
-  buildInputs = [ pandoc python39Packages.weasyprint ];
+  buildInputs =
+    let
+      weasyprint = python39Packages.weasyprint.overrideAttrs {
+        makeWrapperArgs = [ "--set FONTCONFIG_FILE ${fontsConf}" ];
+      };
+    in
+    [ pandoc weasyprint ];
 
   installPhase = ''
     DATE=$(date -I)
-    export FONTCONFIG_FILE="${fontsConf}"
 
     mkdir -p $out
 


### PR DESCRIPTION
Override the weasyprint wrapper args to set our custom fontconfig again, adjusting for https://github.com/NixOS/nixpkgs/pull/207348.

## Checklist

-   [x] Changelog updated (fixes an unreleased issue with manual PDFs)
-   [x] Code documented
-   [x] User manual updated
