### PR TITLE
Fix controller dev-server

### DIFF
--- a/controller/bin/dev-server
+++ b/controller/bin/dev-server
@@ -4,17 +4,4 @@ cd $(dirname "$0")/..
 
 trap bin/stop-server EXIT
 
-bin/watch-command || true
-
-watchman-make \
-  --pattern \
-    'server/**' \
-    'bindings/**' \
-    'gui/**' \
-    'proxy/**' \
-    dune \
-    Changelog.md \
-  --settle \
-    0.5 \
-  --run \
-    "bin/watch-command"
+watchexec --clear --restart "bin/watch-command"

--- a/controller/shell.nix
+++ b/controller/shell.nix
@@ -8,8 +8,10 @@ let
     kioskUrl = "https://dev-play.dividat.com/";
   };
 in
-  playos-controller.overrideAttrs(oldAttrs: {
-    buildInputs = oldAttrs.buildInputs ++ (with pkgs; [
-      python37Packages.pywatchman
-    ]);
-  })
+pkgs.mkShell {
+  packages =
+    playos-controller.buildInputs
+      ++ playos-controller.nativeBuildInputs
+      ++ playos-controller.propagatedBuildInputs
+      ++ [ pkgs.watchexec ];
+}


### PR DESCRIPTION
`python37Packages` is no longer defined in today's Nixpkgs, pywatchman does not work with Python 3.10[^1],

Use `watchexec`, that we already use in other places, which is simpler to use.

Additionally, we need to be more explicit about which inputs we need as packages in the shell.

[^1]: https://github.com/facebook/watchman/issues/970