### PR TITLE
Add l10n options for Czech and Polish

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,5 +1,9 @@
 # [UNRELEASED]
 
+## Added
+
+- os: Added localization options for Polish and Czech
+
 # [2023.9.0] - 2023-09-12
 
 # [2023.9.0-VALIDATION] - 2023-09-11

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -101,19 +101,22 @@ module LocalizationGui = struct
     in
     let%lwt current_lang = Locale.get_lang () in
     let langs =
-      [ "nl_NL.UTF-8", "Dutch"
+      [ "cs_CZ.UTF-8", "Czech"
+      ; "nl_NL.UTF-8", "Dutch"
       ; "en_UK.UTF-8", "English (UK)"
       ; "en_US.UTF-8", "English (US)"
       ; "fi_FI.UTF-8", "Finnish"
       ; "fr_FR.UTF-8", "French"
       ; "de_DE.UTF-8", "German"
       ; "it_IT.UTF-8", "Italian"
+      ; "pl_PL.UTF-8", "Polish"
       ; "es_ES.UTF-8", "Spanish"
       ]
     in
     let%lwt current_keymap = Locale.get_keymap () in
     let keymaps =
-      [ "nl", "Dutch"
+      [ "cz", "Czech"
+      ; "nl", "Dutch"
       ; "gb", "English (UK)"
       ; "us", "English (US)"
       ; "fi", "Finnish"
@@ -121,6 +124,7 @@ module LocalizationGui = struct
       ; "de", "German"
       ; "ch", "German (Switzerland)"
       ; "it", "Italian"
+      ; "pl", "Polish"
       ; "es", "Spanish"
       ]
     in


### PR DESCRIPTION
This uses the Polish Programmers keyboard, as it seems to be the most commonly used keymap despite its name[^1][^2].

I could not find as clear of an indication for Czech keyboard use. It might be there is a trend towards a QWERTY layout[^3], but overall the QWERTZ layout still seems more officially established.

[^1]: https://pl.wikipedia.org/wiki/Klawiatura_programisty
[^2]: https://en.wikipedia.org/wiki/List_of_QWERTY_keyboard_language_variants#Polish
[^3]: https://en.wikipedia.org/wiki/QWERTZ#Czech_(QWERTZ)

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
