### PR TITLE
Focus webview when page is loaded

### DIFF
--- a/kiosk/kiosk_browser/browser_widget.py
+++ b/kiosk/kiosk_browser/browser_widget.py
@@ -136,6 +136,7 @@ class BrowserWidget(QtWidgets.QWidget):
             self._loading_page.hide()
             self._network_error_page.hide()
             self._webview.show()
+            self._webview.setFocus()
 
 def user_agent_with_system(user_agent, system_name, system_version):
     """Inject a specific system into a user agent string"""


### PR DESCRIPTION
Tested on the kiosk only, when starting and already logged in, before the page has no focus, and with this change, it has focus.