### PR TITLE
Map most system control keys to poweroff

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -118,6 +118,18 @@ rec {
         };
       };
 
+      # Ignore system control keys that do not make sense for kiosk applications
+      services.logind.extraConfig = ''
+        HandleSuspendKey=ignore
+        HandleRebootKey=ignore
+        HandleHibernateKey=ignore
+        HandlePowerKey=poweroff
+        HandlePowerKeyLongPress=poweroff
+        HandleRebootKeyLongPress=poweroff
+        HandleSuspendKeyLongPress=poweroff
+        HandleHibernateKeyLongPress=poweroff
+      '';
+
       # Driver service
       systemd.services."dividat-driver" = {
         description = "Dividat Driver";

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -5,6 +5,10 @@
 - kiosk: Add a key combination to perform hard refresh (Ctrl-Shift-R)
 - os: Added localization options for Polish and Czech
 
+## Changed
+
+- os: Ignore suspend and hibernation key presses, but interpret as poweroff when long-pressed
+
 # [2023.9.1] - 2024-03-15
 
 # [2023.9.1-VALIDATION] - 2024-03-12

--- a/docs/user-manual/Readme.org
+++ b/docs/user-manual/Readme.org
@@ -29,6 +29,8 @@ Connection to an attached Dividat Senso will automatically be configured. To man
 
 The system may be shut down by pressing the power button on the computer or alternatively from the administrator menu.
 
+When a remote control with a power button is connected, the system may be shut down by long-pressing the power button.
+
 * Administration
 
 <<administration>>A menu for system administration may be accessed with the key combination ~Ctrl-Shift-F12~.


### PR DESCRIPTION
With the typical use of the kiosk system there is little point to suspending the machine, and it is more likely to confuse users than help. With this change we set most simple key presses to ignored and map all long presses to poweroff, which is the sensible action.

Because at this level both keyboard power keys and "regular" on-device power keys are handled, we can not disable the power key completely.

When expected remote control devices have been clarified, we may want to go back and handle all simple presses in the UI instead of ignoring or immediately action on them, asking for a second press to confirm poweroff. In this case logind can be told to hold off via DBUS locks.

As an alternative I tried resetting the key mappings via `xmodmap`, but found that the keys still seemd to be handled at the low level.

https://www.freedesktop.org/software/systemd/man/latest/logind.conf.html#HandlePowerKey=

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
