### PR TITLE
Update driver for app-triggered firmware update support

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -118,6 +118,17 @@ rec {
         };
       };
 
+      # Firewall configuration
+      networking.firewall = {
+        enable = true;
+
+        # Allow use of TFTP client for Senso firmware update
+        connectionTrackingModules = [ "tftp" ];
+        extraCommands = ''
+          iptables -t raw -A OUTPUT -p udp --dport 69 -j CT --helper tftp
+        '';
+      };
+
       # Driver service
       systemd.services."dividat-driver" = {
         description = "Dividat Driver";

--- a/application.nix
+++ b/application.nix
@@ -132,7 +132,10 @@ rec {
       # Driver service
       systemd.services."dividat-driver" = {
         description = "Dividat Driver";
-        serviceConfig.ExecStart = "${pkgs.dividat-driver}/bin/dividat-driver";
+        # Run driver with permissible origin limited to the origin of the kiosk URL
+        serviceConfig.ExecStart = ''
+          ${pkgs.dividat-driver}/bin/dividat-driver --permissible-origin $(echo "${config.playos.kioskUrl}" | grep -oP '^[^:]+://[^/]+')
+        '';
         serviceConfig.User = "play";
         wantedBy = [ "multi-user.target" ];
       };

--- a/application/overlays/dividat-driver/default.nix
+++ b/application/overlays/dividat-driver/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.3.0";
+  version = "2.3.0-105-g36e3e91";
 
 in buildGoModule rec {
 
@@ -12,11 +12,11 @@ in buildGoModule rec {
   src = fetchFromGitHub {
     owner = "dividat";
     repo = "driver";
-    rev = version;
-    sha256 = "sha256-OLSd+q5oe5Fd7GtKsJkkpTiEndpt/x1X0xdzGzZ7Zpg=";
+    rev = "36e3e91529c27e47fde9033f44154e22f2960b40";
+    sha256 = "sha256-uYCPBllDYCynPvekP6siop5u6uXY/0Kd4enL2/0nmcU=";
   };
 
-  vendorHash = "sha256-oL7upl231aWbkBfybmP5fSTySFJkEI3vGKaWJu+Q30Q=";
+  vendorHash = "sha256-Jj6aI85hZXGeWhJ8wq9MgI9uTm11tJZUdVwI90Pio4s=";
 
   nativeBuildInputs = with pkgs; [ pkg-config pcsclite ];
   buildInputs = with pkgs; [ pcsclite ];


### PR DESCRIPTION
Update the driver to a new version supporting app-triggered firmware updates for Sensos.

The firewall is configured to allow the driver to act as a TFTP client, and the driver is configured to only allow requests from the kiosk URL's origin.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
