### PR TITLE
Ignore suspend and hibernation key presses, but interpret as poweroff when long-pressed

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -26,7 +26,10 @@ rec {
 
     module = { config, lib, pkgs, ... }: {
 
-      imports = [ ./application/playos-status.nix ];
+      imports = [
+        ./application/playos-status.nix
+        ./application/power-management/default.nix
+      ];
 
       # Kiosk runs as a non-privileged user
       users.users.play = {
@@ -117,18 +120,6 @@ rec {
           '';
         };
       };
-
-      # Ignore system control keys that do not make sense for kiosk applications
-      services.logind.extraConfig = ''
-        HandleSuspendKey=ignore
-        HandleRebootKey=ignore
-        HandleHibernateKey=ignore
-        HandlePowerKey=poweroff
-        HandlePowerKeyLongPress=poweroff
-        HandleRebootKeyLongPress=poweroff
-        HandleSuspendKeyLongPress=poweroff
-        HandleHibernateKeyLongPress=poweroff
-      '';
 
       # Driver service
       systemd.services."dividat-driver" = {

--- a/application.nix
+++ b/application.nix
@@ -118,6 +118,18 @@ rec {
         };
       };
 
+      # Ignore system control keys that do not make sense for kiosk applications
+      services.logind.extraConfig = ''
+        HandleSuspendKey=ignore
+        HandleRebootKey=ignore
+        HandleHibernateKey=ignore
+        HandlePowerKey=poweroff
+        HandlePowerKeyLongPress=poweroff
+        HandleRebootKeyLongPress=poweroff
+        HandleSuspendKeyLongPress=poweroff
+        HandleHibernateKeyLongPress=poweroff
+      '';
+
       # Driver service
       systemd.services."dividat-driver" = {
         description = "Dividat Driver";

--- a/application/power-management/default.nix
+++ b/application/power-management/default.nix
@@ -1,0 +1,73 @@
+{ pkgs, config, lib, ... }:
+
+let
+
+  power-button-shutdown = pkgs.stdenv.mkDerivation {
+    name = "power-button-shutdown";
+    propagatedBuildInputs = [
+      (pkgs.python3.withPackages (pythonPackages: with pythonPackages; [
+        evdev
+      ]))
+    ];
+    dontUnpack = true;
+    installPhase = "install -Dm755 ${./power-button-shutdown.py} $out/bin/power-button-shutdown";
+  };
+
+in {
+
+  # Ignore system control keys that do not make sense for kiosk applications
+  services.logind.extraConfig = ''
+    HandleSuspendKey=ignore
+    HandleRebootKey=ignore
+    HandleHibernateKey=ignore
+    HandlePowerKey=ignore
+    HandlePowerKeyLongPress=poweroff
+    HandleRebootKeyLongPress=poweroff
+    HandleSuspendKeyLongPress=poweroff
+    HandleHibernateKeyLongPress=poweroff
+  '';
+
+  hardware.uinput.enable = lib.mkDefault true;
+
+  systemd.services.power-button-shutdown = {
+    enable = true;
+    description = "Detect power off key press, by power button device only, then shutdown computer";
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      ExecStart = "${power-button-shutdown}/bin/power-button-shutdown";
+      Restart = "always";
+
+      # Access to input devices without being root
+      # DynamicUser = true; # Currently prevent to shutdown the system
+      SupplementaryGroups = with config.users.groups; [ input.name uinput.name ];
+
+      # Hardening, see https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/hardware/kanata.nix#L117
+      # Not using DeviceAllow and DevicePolicy, as I couldn’t get access to device list with that.
+      CapabilityBoundingSet = [ "" ];
+      IPAddressDeny = [ "any" ];
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      PrivateNetwork = true;
+      PrivateUsers = true;
+      ProcSubset = "pid";
+      ProtectClock = true;
+      ProtectControlGroups = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectProc = "invisible";
+      RestrictAddressFamilies = [ "AF_UNIX" ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      SystemCallArchitectures = [ "native" ];
+      SystemCallFilter = [
+        "@system-service"
+        "~@privileged"
+        "~@resources"
+      ];
+      UMask = "0077";
+    };
+  };
+}

--- a/application/power-management/default.nix
+++ b/application/power-management/default.nix
@@ -42,8 +42,6 @@ in {
     groups.${group} = {};
   };
 
-  hardware.uinput.enable = lib.mkDefault true;
-
   # Allow user of power-button-shutdown.service to shutdown the service
   security.polkit = {
     enable = true;
@@ -70,7 +68,7 @@ in {
 
       User = user;
       Group = group;
-      SupplementaryGroups = with config.users.groups; [ input.name uinput.name ];
+      SupplementaryGroups = with config.users.groups; [ input.name ];
 
       # Hardening, see https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/hardware/kanata.nix#L117 for inspiration.
       # Not using DeviceAllow and DevicePolicy, as this prevent listing devices otherwise.

--- a/application/power-management/power-button-shutdown.py
+++ b/application/power-management/power-button-shutdown.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import evdev
+import logging
+import os
+import sys
+
+logging.basicConfig(level=logging.INFO)
+
+devices = [evdev.InputDevice(path) for path in evdev.list_devices()]
+device_names = ', '.join([d.name for d in devices])
+logging.info(f'Found devices: {device_names}')
+
+power_off_device = next((d for d in devices if d.name == 'Power Button'), None)
+if power_off_device is None:
+  logging.error(f'Power Off device not found')
+  sys.exit(1)
+
+logging.info(f'Listenning to Power Off on device {power_off_device.path}')
+for event in power_off_device.read_loop():
+  if event.type == evdev.ecodes.EV_KEY and evdev.ecodes.KEY[event.code] == 'KEY_POWER' and event.value:
+    logging.info('KEY_POWER detected on Power Off device, shutting down')
+    os.system('shutdown now')

--- a/application/power-management/power-button-shutdown.py
+++ b/application/power-management/power-button-shutdown.py
@@ -16,7 +16,7 @@ if power_off_device is None:
   logging.error(f'Power Button device not found')
   sys.exit(1)
 
-logging.info(f'Listenning to Power Button on device {power_off_device.path}')
+logging.info(f'Listening to Power Button on device {power_off_device.path}')
 for event in power_off_device.read_loop():
   if event.type == evdev.ecodes.EV_KEY and evdev.ecodes.KEY[event.code] == 'KEY_POWER' and event.value:
     logging.info('KEY_POWER detected on Power Button device, shutting down')

--- a/application/power-management/power-button-shutdown.py
+++ b/application/power-management/power-button-shutdown.py
@@ -13,11 +13,11 @@ logging.info(f'Found devices: {device_names}')
 
 power_off_device = next((d for d in devices if d.name == 'Power Button'), None)
 if power_off_device is None:
-  logging.error(f'Power Off device not found')
+  logging.error(f'Power Button device not found')
   sys.exit(1)
 
-logging.info(f'Listenning to Power Off on device {power_off_device.path}')
+logging.info(f'Listenning to Power Button on device {power_off_device.path}')
 for event in power_off_device.read_loop():
   if event.type == evdev.ecodes.EV_KEY and evdev.ecodes.KEY[event.code] == 'KEY_POWER' and event.value:
-    logging.info('KEY_POWER detected on Power Off device, shutting down')
-    os.system('shutdown now')
+    logging.info('KEY_POWER detected on Power Button device, shutting down')
+    os.system('systemctl start poweroff.target')

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -5,6 +5,10 @@
 - kiosk: Add a key combination to perform hard refresh (Ctrl-Shift-R)
 - os: Added localization options for Polish and Czech
 
+## Changed
+
+- os: Ignore suspend and hibernation key presses, but interpret as poweroff when long-pressed
+
 # [2023.9.1] - 2024-03-15
 
 # [2023.9.1-VALIDATION] - 2024-03-12

--- a/docs/user-manual/Readme.org
+++ b/docs/user-manual/Readme.org
@@ -29,6 +29,8 @@ Connection to an attached Dividat Senso will automatically be configured. To man
 
 The system may be shut down by pressing the power button on the computer or alternatively from the administrator menu.
 
+When a remote control with a power button is connected, the system may be shut down by long-pressing the power button.
+
 * Administration
 
 <<administration>>A menu for system administration may be accessed with the key combination ~Ctrl-Shift-F12~.


### PR DESCRIPTION
Superseeds https://github.com/dividat/playos/pull/152.

## Tests

-  [x] Short press on a live stick shut downs the system

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
