### PR TITLE
Allow using the kiosk on platforms without DBus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,21 @@ jobs:
     - uses: DeterminateSystems/magic-nix-cache-action@v4
     - run: cd kiosk && nix-shell --run bin/test
 
+  kiosk-platform-smoke-test:
+    # While the smoke test should run on other platforms, it does not currently
+    # run on GitHub's Ubuntu runners, as they don't support GUI applications.
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - uses: cachix/install-nix-action@v18
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: Smoke Test
+      run: cd kiosk && nix-shell --run "python test/platform-smoke.py"
+
   build-vm:
     runs-on: ubuntu-latest
     steps:

--- a/kiosk/Readme.md
+++ b/kiosk/Readme.md
@@ -28,3 +28,9 @@ Then, point a Chromium-based browser to `http://127.0.0.1:3355`.
 
 Additional documentation is available at:
 https://doc.qt.io/qt-6/qtwebengine-debugging.html
+
+## Supported platforms
+
+The kiosk is written with use within PlayOS in mind (implying connman and DBus as part of the system). To allow for testing web pages in the kiosk on developer machines, macOS is also supported, with the following limitations:
+
+- No proxy server support

--- a/kiosk/default.nix
+++ b/kiosk/default.nix
@@ -42,10 +42,5 @@ python3Packages.buildPythonApplication rec {
   shellHook = ''
     # Give access to kiosk_browser module
     export PYTHONPATH=./:$PYTHONPATH
-
-    # Setup Qt environment
-    bashdir=$(mktemp -d)
-    makeWrapper "$(type -p bash)" "$bashdir/bash" "''${qtWrapperArgs[@]}"
-    exec "$bashdir/bash"
   '';
 }

--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -14,7 +14,7 @@ class MainWidget(QtWidgets.QWidget):
         super(MainWidget, self).__init__()
 
         # Proxy
-        proxy = proxy_module.Proxy()
+        proxy = proxy_module.init()
         proxy.start_monitoring_daemon()
 
         # Browser widget

--- a/kiosk/test/platform-smoke.py
+++ b/kiosk/test/platform-smoke.py
@@ -1,0 +1,65 @@
+import http.server
+import socket
+import socketserver
+import threading
+import subprocess
+import time
+
+PORT = 45678
+request_count = 0
+
+def main():
+    """Checks that the kiosk-browser does not crash immediately on start and makes a request to the provided URL.
+
+    This serves as a minimal test to make sure the kiosk can run on different platforms.
+    """
+
+    # Start dummy web server in thread, with signal to stop
+    keep_running = threading.Event()
+    keep_running.set()
+    server_thread = threading.Thread(target=run_server, args=(keep_running,))
+    server_thread.start()
+    time.sleep(1)
+
+    try:
+        browser_process = subprocess.Popen(['bin/kiosk-browser', f'http://localhost:{PORT}', f'http://localhost:{PORT}'])
+        time.sleep(5)
+
+        # Minimal expectations
+        assert browser_process.poll() is None, "Browser process has crashed."
+        assert request_count >= 1, "No requests were made to the server."
+        
+        print("Smoke test passed successfully.")
+
+    finally:
+        # Send signal to stop web server and wait for completion
+        keep_running.clear()
+        server_thread.join()
+
+        # Terminate the browser process
+        browser_process.terminate()
+
+class RequestHandler(http.server.SimpleHTTPRequestHandler):
+    """Default request handler with added counter."""
+    def do_GET(self):
+        global request_count
+        request_count += 1
+        # Call superclass method to actually serve the request
+        super().do_GET()
+
+def run_server(keep_running):
+    """Run the web server, checking whether to keep running frequently."""
+    with socketserver.TCPServer(("", PORT), RequestHandler, bind_and_activate=False) as httpd:
+        # Let address be reused to avoid failure on repeated runs
+        httpd.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        httpd.server_bind()
+        httpd.server_activate()
+        # Timeout frequently to check if killed
+        httpd.timeout = 0.5
+        try:
+            while keep_running.is_set():
+                httpd.handle_request()
+        finally:
+            httpd.server_close()
+
+main()


### PR DESCRIPTION
We previously added support for using the kiosk without connman installed, but it still crashed when started on systems without DBus (i.e. any non-Linux platform).

With this change we add a stub implementation of the core proxy abstraction, which is going to provide safe no-op responses on non-Linux platforms, allowing to use the kiosk, albeit without proxy support.

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
