### PR TITLE
Use 5 s timeout for entering GRUB menu

### DIFF
--- a/bootloader/grub.cfg
+++ b/bootloader/grub.cfg
@@ -44,14 +44,14 @@ for SLOT in $ORDER; do
     if [ "$SLOT" == "a" -a "$a_TRY" -lt 3 -a "$a_OK" -ne 0 ]; then
         set default="system.a"
         increment_a_TRY
-        set timeout=3
+        set timeout=5
         set timeout_style="hidden"
         break
     fi
     if [ "$SLOT" == "b" -a "$b_TRY" -lt 3 -a "$b_OK" -ne 0 ]; then
         set default="system.b"
         increment_b_TRY
-        set timeout=3
+        set timeout=5
         set timeout_style="hidden"
         break
     fi


### PR DESCRIPTION
Allowing only 3 seconds to press Esc/F4 to enter the GRUB menu is very tight, especially when trying to assist someone via a phone or video call.

Bump up to 5 seconds, which is also GRUB's default value for the timeout.

This is only going to take effect in new installations, as boot partition is not normally touched by rolling updates.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
