### PR TITLE
Fix permissible origin param for driver

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -137,7 +137,7 @@ rec {
         description = "Dividat Driver";
         # Run driver with permissible origin limited to the origin of the kiosk URL
         serviceConfig.ExecStart = ''
-          ${pkgs.dividat-driver}/bin/dividat-driver --permissible-origin $(echo "${config.playos.kioskUrl}" | grep -oP '^[^:]+://[^/]+')
+          /bin/sh -c '${pkgs.dividat-driver}/bin/dividat-driver --permissible-origin $(echo "${config.playos.kioskUrl}" | grep -oP "^[^:]+://[^/]+")'
         '';
         serviceConfig.User = "play";
         wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
`ExecStart` may not use shell syntax, we need to invoke a shell in order to process the URL.

This was done incorrectly when added in
https://github.com/dividat/playos/pull/157, there must have been some confusion in our testing?

With the code as in #157, the driver runs, but does not accept requests from the Play application.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
