### PR TITLE
Reduce bundle size by removing qt6.full dependency

### DIFF
--- a/kiosk/default.nix
+++ b/kiosk/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, system_name, system_version }:
+{ pkgs, system_name, system_version, additional_inputs ? [] }:
 
 with pkgs;
 
@@ -30,11 +30,10 @@ python3Packages.buildPythonApplication rec {
     pygobject3
     pyqt6-webengine
     pytest
-    qt6.full
     qt6.qtbase
     requests
     types-requests
-  ];
+  ] ++ additional_inputs;
 
   postInstall = ''
     cp -r images/ $out/images

--- a/kiosk/shell.nix
+++ b/kiosk/shell.nix
@@ -5,5 +5,6 @@ in
     pkgs = pkgs;
     system_name = "PlayOS";
     system_version = "1.0.0-dev";
+    # Provides qtwayland only for testing
+    additional_inputs = [ pkgs.qt6.qtwayland ];
   }
-


### PR DESCRIPTION
$ ls -lh /nix/store/nhiah2jcdin8q9jrb28l7cdx82x04l6q-playos-installer-2023.9.1.iso/iso/playos-installer-2023.9.1.iso -r--r--r-- 1 root root 2.2G Jan  1  1970 /nix/store/nhiah2jcdin8q9jrb28l7cdx82x04l6q-playos-installer-2023.9.1.iso/iso/playos-installer-2023.9.1.iso

$ ls -lh /nix/store/r0j40bnkj4nzyy19fm3bfa685zgc90wq-bundle-2023.9.1.raucb -r--r--r-- 1 root root 1.4G Jan  1  1970 /nix/store/r0j40bnkj4nzyy19fm3bfa685zgc90wq-bundle-2023.9.1.raucb

$ ls -lh /nix/store/7b8s8s83babc5m35xnwg24ndz5yfyp96-playos-live-2023.9.1.iso/iso/playos-live-2023.9.1.iso -r--r--r-- 1 root root 1.5G Jan  1  1970 /nix/store/7b8s8s83babc5m35xnwg24ndz5yfyp96-playos-live-2023.9.1.iso/iso/playos-live-2023.9.1.iso
