### PR TITLE
Fix focus after reload

### DIFF
--- a/kiosk/kiosk_browser/browser_widget.py
+++ b/kiosk/kiosk_browser/browser_widget.py
@@ -137,6 +137,8 @@ class BrowserWidget(QtWidgets.QWidget):
             self._loading_page.hide()
             self._network_error_page.hide()
             self._webview.show()
+            # Set focus by clearing first, otherwise focus is lost after using CTRL+R
+            self._webview.clearFocus()
             self._webview.setFocus()
 
 def user_agent_with_system(user_agent, system_name, system_version):


### PR DESCRIPTION
Since the migration to Qt6, reloading the browser, either using CTRL+R, or CTRL+SHIFT+R, the focus is lost on the webview.

By clearing the focus, it’s properly set afterward, after a reload.

I also tried to play with focus policy, and setting focus after a bit with a timer, but without success.

## Tests

- [x] Local kiosk
- [x] QEMU Vm