### PR TITLE
Add MAC addresses on PlayOS status screen

### DIFF
--- a/application/playos-status.nix
+++ b/application/playos-status.nix
@@ -10,6 +10,8 @@ let
       while :; do
         screen=$(xrandr --current | grep '*' | awk '{print $1}')
         networkCount=$(connmanctl services | grep wifi | wc -l)
+        ethernetMacs=$(cat /sys/class/net/e*/address 2>/dev/null | grep -v '^$' | awk '{print "Ethernet " $0}' | tr '\n' '  ')
+        wlanMacs=$(cat /sys/class/net/wl*/address 2>/dev/null | grep -v '^$' | awk '{print "WLAN " $0}' | tr '\n' '  ')
         rfid=$(opensc-tool --list-readers | pr -T -o 2)
         dataDiskFree=$(df -h /mnt/data | pr -T -o 2)
         controller=$(systemctl is-active playos-controller)
@@ -23,8 +25,11 @@ let
           "Persistent storage:" \
           "$dataDiskFree" \
           "Controller: $controller" \
-          "Updated at: $time" \
+          "Network interfaces: $ethernetMacs  $wlanMacs" \
           > ${ttyPath}
+        qrencode -m 2 -t utf8 <<< "$ethernetMacs  $wlanMacs" \
+          > ${ttyPath}
+        printf "\n%s" "Updated at: $time" > ${ttyPath}
         sleep 5
       done
     '';
@@ -43,6 +48,7 @@ in
         xorg.xrandr
         opensc
         coreutils
+        qrencode
       ];
       description = "PlayOS status";
       wantedBy = [ "multi-user.target" ];

--- a/application/playos-status.nix
+++ b/application/playos-status.nix
@@ -25,9 +25,11 @@ let
           "Persistent storage:" \
           "$dataDiskFree" \
           "Controller: $controller" \
-          "Network interfaces: $ethernetMacs  $wlanMacs" \
+          "Network interfaces:" \
+          "  $ethernetMacs  $wlanMacs" \
           > ${ttyPath}
         qrencode -m 2 -t utf8 <<< "$ethernetMacs  $wlanMacs" \
+          | pr -T -o 2 \
           > ${ttyPath}
         printf "\n%s" "Updated at: $time" > ${ttyPath}
         sleep 5

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -5,6 +5,7 @@
 - kiosk: Add a key combination to perform hard refresh (Ctrl-Shift-R)
 - os: Added localization options for Polish and Czech
 - controller: Add licensing page in System Settings
+- status screen: Display MAC addresses in text and QR code
 
 ## Changed
 


### PR DESCRIPTION
This adds the PC's MAC addresses in text and QR encoding to the status console, which may be used during initial provisioning to print labels to place on the device packaging.

![image](https://github.com/dividat/playos/assets/47458/79cdec40-29de-4916-8153-aca0f25581db)

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
