### PR TITLE
Fix or suppress ocamlc unused variable/binding warnings

### DIFF
--- a/controller/Readme.md
+++ b/controller/Readme.md
@@ -10,7 +10,6 @@ PlayOS controller is an OCaml application that manages various system tasks for 
 
 - `bindings/`: bindings to various things
 - `gui/`: static gui assets
-- `nix/`: nix stuff
 - `server/`: main application code
 - `bin/`: binaries to start a dev server
 

--- a/controller/bindings/connman/dune
+++ b/controller/bindings/connman/dune
@@ -1,3 +1,5 @@
+(include ../disable-unused-warnings.dune)
+
 (library
  (name connman)
  (modules connman connman_interfaces)

--- a/controller/bindings/curl/curl.ml
+++ b/controller/bindings/curl/curl.ml
@@ -112,10 +112,10 @@ let request ?proxy ?(headers = []) ?data ?(options = []) url =
   | Ok (Unix.WEXITED n, _, stderr) ->
     Lwt.return (RequestFailure (ProcessExit (n, stderr)))
 
-  | Ok (Unix.WSIGNALED signal, _, stderr) ->
+  | Ok (Unix.WSIGNALED signal, _, _stderr) ->
     Lwt.return (RequestFailure (ProcessKill signal))
 
-  | Ok (Unix.WSTOPPED signal, _, stderr) ->
+  | Ok (Unix.WSTOPPED signal, _, _stderr) ->
     Lwt.return (RequestFailure (ProcessStop signal))
 
   | Error (Unix.Unix_error (err, _, _)) ->

--- a/controller/bindings/disable-unused-warnings.dune
+++ b/controller/bindings/disable-unused-warnings.dune
@@ -1,4 +1,6 @@
-; obus generates bindings that contains a lot of unused variables/bindings
-; and dune treats these as errors, so we disable them here
+; OBus generates bindings that contains a lot of unused variables/bindings
+; and dune treats these as errors, so we disable them here.
+; Refer to ocamlc man pages or `ocamlc -warn-help` for descriptions of
+; the warning numbers.
 (env (dev (flags :standard -w -27-32-33)))
 

--- a/controller/bindings/disable-unused-warnings.dune
+++ b/controller/bindings/disable-unused-warnings.dune
@@ -1,0 +1,4 @@
+; obus generates bindings that contains a lot of unused variables/bindings
+; and dune treats these as errors, so we disable them here
+(env (dev (flags :standard -w -27-32-33)))
+

--- a/controller/bindings/rauc/dune
+++ b/controller/bindings/rauc/dune
@@ -1,3 +1,5 @@
+(include ../disable-unused-warnings.dune)
+
 (library
  (name rauc)
  (modules rauc rauc_interfaces)

--- a/controller/bindings/systemd/dune
+++ b/controller/bindings/systemd/dune
@@ -1,3 +1,5 @@
+(include ../disable-unused-warnings.dune)
+
 (library
  (name systemd)
  (modules systemd systemd_interfaces)

--- a/controller/bindings/timedate/dune
+++ b/controller/bindings/timedate/dune
@@ -1,3 +1,5 @@
+(include ../disable-unused-warnings.dune)
+
 (library
  (name timedate)
  (modules timedate timedate_interfaces)

--- a/controller/bindings/util/util.ml
+++ b/controller/bindings/util/util.ml
@@ -9,7 +9,7 @@ let read_from_file log_src path =
       let%lwt () = Lwt_io.close in_chan in
       return contents
     with
-    | (Unix.Unix_error (err, fn, _)) as exn ->
+    | (Unix.Unix_error (err, _fn, _)) as exn ->
       let%lwt () = Logs_lwt.err ~src:log_src
         (fun m -> m "failed to read from %s: %s" path (Unix.error_message err))
       in
@@ -27,12 +27,12 @@ let write_to_file log_src path str =
     let%lwt fd =
       Lwt_unix.openfile path [ O_WRONLY; O_CREAT; O_TRUNC ] 0o755
     in
-    let%lwt bytes_written =
+    let%lwt _bytes_written =
       Lwt_unix.write_string fd str 0 (String.length str)
     in
     Lwt_unix.close fd
   with
-  | (Unix.Unix_error (err, fn, _)) as exn ->
+  | (Unix.Unix_error (err, _fn, _)) as exn ->
     let%lwt () = Logs_lwt.err ~src:log_src
       (fun m -> m "failed to write to %s: %s" path (Unix.error_message err))
     in

--- a/controller/dune
+++ b/controller/dune
@@ -6,6 +6,7 @@
   (gui/style.css as static/style.css)
   (gui/client.js as static/client.js)))
 
-; disable missing-record-field-pattern warnings (partial matching),
-; because they are kind of useless
+; Disable missing-record-field-pattern warnings (partial matching),
+; because they are kind of useless.
+; See https://ocaml.org/manual/4.14/comp.html#ss:warn9 for details.
 (env (dev (flags :standard -w -9)))

--- a/controller/dune
+++ b/controller/dune
@@ -5,3 +5,7 @@
   (gui/reset.css as static/reset.css)
   (gui/style.css as static/style.css)
   (gui/client.js as static/client.js)))
+
+; disable missing-record-field-pattern warnings (partial matching),
+; because they are kind of useless
+(env (dev (flags :standard -w -9)))

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -315,7 +315,7 @@ module NetworkGui = struct
         fail_with "A host and port are required to configure a proxy server"
 
   (** Set static IP configuration on a service *)
-  let update_static_ip ~(connman: Connman.Manager.t) service form_data =
+  let update_static_ip service form_data =
         let get_prop s =
           form_data
           |> List.assoc s
@@ -362,7 +362,7 @@ module NetworkGui = struct
     let%lwt service = with_service ~connman (param req "id") in
 
     (* Static IP *)
-    let%lwt () = update_static_ip ~connman service form_data in
+    let%lwt () = update_static_ip service form_data in
 
     (* Proxy *)
     let%lwt current_proxy = Manager.get_default_proxy connman in

--- a/controller/server/network.ml
+++ b/controller/server/network.ml
@@ -1,7 +1,7 @@
 open Lwt
 open Sexplib.Std
 
-let log_src = Logs.Src.create "network"
+let _log_src = Logs.Src.create "network"
 
 let enable_and_scan_wifi_devices ~connman =
   Lwt_result.catch

--- a/controller/server/network.ml
+++ b/controller/server/network.ml
@@ -1,7 +1,7 @@
 open Lwt
 open Sexplib.Std
 
-let _log_src = Logs.Src.create "network"
+let log_src = Logs.Src.create "network"
 
 let enable_and_scan_wifi_devices ~connman =
   Lwt_result.catch
@@ -36,7 +36,8 @@ let enable_and_scan_wifi_devices ~connman =
 
 
 let init ~connman =
-  let%lwt () = Logs_lwt.info (fun m -> m "initializing network connections") in
+  let%lwt () = Logs_lwt.info ~src:log_src
+    (fun m -> m "initializing network connections") in
 
   match%lwt enable_and_scan_wifi_devices ~connman with
 
@@ -44,7 +45,7 @@ let init ~connman =
     Lwt_result.return ()
 
   | Error exn ->
-    let%lwt () = Logs_lwt.warn
+    let%lwt () = Logs_lwt.warn ~src:log_src
         (fun m -> m "enabling and scanning wifi failed: %s, %s"
             (OBus_error.name exn)
             (Printexc.to_string exn))

--- a/controller/server/server.ml
+++ b/controller/server/server.ml
@@ -1,5 +1,4 @@
 open Lwt
-open Sexplib.Std
 
 let shutdown () =
   match%lwt

--- a/controller/server/update.ml
+++ b/controller/server/update.ml
@@ -1,5 +1,4 @@
 open Lwt
-open Sexplib.Std
 open Sexplib.Conv
 
 let log_src = Logs.Src.create "update"


### PR DESCRIPTION
`dune` treats warnings-as-errors by default, so these changes ensure `dune build` works without
`--profile release` (used in [controller/bin/build](https://github.com/dividat/playos/blob/main/controller/bin/build#L7-L9)) i.e. there are no more warnings raised by ocamlc.

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
