### PR TITLE
WIP: refactor Update module to enable testing and add test prototype

### DIFF
--- a/controller/default.nix
+++ b/controller/default.nix
@@ -49,5 +49,7 @@ ocamlPackages.buildDunePackage rec {
     ezjsonm
     containers
     fieldslib
+    alcotest
+    alcotest-lwt
   ];
 }

--- a/controller/server/dune
+++ b/controller/server/dune
@@ -3,14 +3,27 @@
 (executable
  (name server)
  (public_name playos-controller)
- (modules server update info gui health
+ (modules server info gui health
    info_page localization_page status_page error_page label_page
    network_list_page network_details_page changelog_page
    page definition icon)
- (libraries lwt logs logs.fmt logs.lwt fpath cohttp-lwt-unix logging
+ (libraries update lwt logs logs.fmt logs.lwt fpath cohttp-lwt-unix logging
   opium tyxml rauc zerotier connman locale network timedate systemd
   label_printer semver2 fieldslib screen_settings)
  (preprocess (pps lwt_ppx ppx_sexp_conv)))
+
+(library
+ (name update)
+ (modules update)
+ (libraries update_deps lwt connman rauc curl semver2)
+ (preprocess (pps lwt_ppx ppx_sexp_conv)))
+
+;; TODO: can I keep `update_deps` as a (sub)module of `update` library?
+(library
+ (name update_deps)
+ (modules update_deps)
+ (modules_without_implementation update_deps)
+ (libraries lwt connman rauc curl semver2))
 
 (library
  (name logging)

--- a/controller/server/update.ml
+++ b/controller/server/update.ml
@@ -1,6 +1,8 @@
 open Lwt
 open Sexplib.Conv
 
+open Update_deps
+
 let log_src = Logs.Src.create "update"
 
 let bundle_name =
@@ -22,74 +24,6 @@ type version_info =
   }
 [@@deriving sexp]
 
-
-(** Helper to parse semver from string or fail *)
-let semver_of_string string =
-  let trimmed_string = String.trim string
-  in
-  match Semver.of_string trimmed_string with
-  | None ->
-    failwith
-      (Format.sprintf "could not parse version (version string: %s)" string)
-  | Some version ->
-    version, trimmed_string
-
-(** Get latest version available at [url] *)
-let get_latest_version ~proxy url =
-  match%lwt Curl.request ?proxy (Uri.of_string (url ^ "latest")) with
-  | RequestSuccess (_, body) ->
-      return (semver_of_string body)
-  | RequestFailure error ->
-      Lwt.fail_with (Printf.sprintf "could not get latest version (%s)" (Curl.pretty_print_error error))
-
-(** Get version information *)
-let get_version_info ~proxy url rauc =
-  Lwt_result.catch
-    (fun () ->
-      let%lwt latest = get_latest_version ~proxy url in
-      let%lwt rauc_status = Rauc.get_status rauc in
-
-      let system_a_version = rauc_status.a.version |> semver_of_string in
-      let system_b_version = rauc_status.b.version |> semver_of_string in
-
-      match%lwt Rauc.get_booted_slot rauc with
-      | SystemA ->
-        { latest = latest
-        ; booted = system_a_version
-        ; inactive = system_b_version
-        }
-        |> return
-      | SystemB ->
-        { latest = latest
-        ; booted = system_b_version
-        ; inactive = system_a_version
-        }
-        |> return
-    )
-
-let bundle_file_name version =
-  Format.sprintf "%s-%s.raucb" bundle_name version
-
-let latest_download_url ~update_url version_string =
-  Format.sprintf "%s%s/%s" update_url version_string (bundle_file_name version_string)
-
-(** download RAUC bundle *)
-let download ?proxy url version =
-  let bundle_path = Format.sprintf "/tmp/%s" (bundle_file_name version) in
-  let options =
-    [ "--continue-at"; "-" (* resume download *)
-    ; "--limit-rate"; "10M"
-    ; "--output"; bundle_path
-    ]
-  in
-  match%lwt Curl.request ?proxy ~options url with
-  | RequestSuccess _ ->
-      return bundle_path
-  | RequestFailure error ->
-      Lwt.fail_with (Printf.sprintf "could not download RAUC bundle (%s)" (Curl.pretty_print_error error))
-
-(* Update mechanism process *)
-
 type state =
   | GettingVersionInfo
   | ErrorGettingVersionInfo of string
@@ -106,149 +40,299 @@ type state =
   | ReinstallRequired
 [@@deriving sexp]
 
-
-(** Finite state machine handling updates *)
-let rec run ~connman ~update_url ~rauc ~set_state =
-  (* Helper to update state in signal and advance state machine *)
-  let set state =
-    set_state state; run ~connman ~update_url ~rauc ~set_state state
+(** Helper to parse semver from string or fail *)
+let semver_of_string string =
+  let trimmed_string = String.trim string
   in
-  let get_proxy_uri manager = 
-      Connman.Manager.get_default_proxy manager >|= Option.map (Connman.Service.Proxy.to_uri ~include_userinfo:true)
-  in
-  function
-  | GettingVersionInfo ->
-    (* get version information and decide what to do *)
-    let%lwt proxy = get_proxy_uri connman in
-    begin
-      match%lwt get_version_info ~proxy update_url rauc with
-      | Ok version_info ->
+  match Semver.of_string trimmed_string with
+  | None ->
+    failwith
+      (Format.sprintf "could not parse version (version string: %s)" string)
+  | Some version ->
+    version, trimmed_string
 
-        (* Compare latest available version to version booted. *)
-        let booted_version_compare = Semver.compare
-            (fst version_info.latest)
-            (fst version_info.booted) in
-        let booted_up_to_date = booted_version_compare = 0 in
 
-        (* Compare latest available version to version on inactive system partition. *)
-        let inactive_version_compare = Semver.compare
-            (fst version_info.latest)
-            (fst version_info.inactive) in
-        let inactive_up_to_date = inactive_version_compare = 0 in
-        let inactive_update_available = inactive_version_compare > 0 in
+let bundle_file_name version =
+  Format.sprintf "%s-%s.raucb" bundle_name version
 
-        if booted_up_to_date || inactive_up_to_date then
-          match%lwt Rauc.get_primary rauc with
-          | Some primary_slot ->
-            if booted_up_to_date then
-              (* Don't care if inactive can be updated. I.e. Only update the inactive partition once the booted partition is outdated. This results in always two versions being available on the machine. *)
-              UpToDate version_info |> set
+(* TODO: FIX: this will produce an invalid URL if ~update_url is missing a
+   trailing slash *)
+(* TODO: Should probably be moved to config too *)
+let latest_download_url ~update_url version_string =
+  Format.sprintf "%s%s/%s" update_url version_string (bundle_file_name version_string)
+
+
+module UpdateService(Deps : UpdateServiceDeps) = struct
+    open Deps
+
+    let sleep_error_backoff =
+        Lwt_unix.sleep ConfigI.error_backoff_duration
+
+    let sleep_update_check =
+        Lwt_unix.sleep ConfigI.check_for_updates_interval
+
+    (** Get latest version available at [url] *)
+    let get_latest_version url =
+      match%lwt CurlI.request (Uri.of_string (url ^ "latest")) with
+      | RequestSuccess (_, body) ->
+          return (semver_of_string body)
+      | RequestFailure error ->
+          Lwt.fail_with (Printf.sprintf "could not get latest version (%s)" (Curl.pretty_print_error error))
+
+    (** Get version information *)
+    let get_version_info url =
+      Lwt_result.catch
+        (fun () ->
+          let%lwt latest = get_latest_version url in
+          let%lwt rauc_status = RaucI.get_status in
+
+          let system_a_version = rauc_status.a.version |> semver_of_string in
+          let system_b_version = rauc_status.b.version |> semver_of_string in
+
+          match%lwt RaucI.get_booted_slot with
+          | SystemA ->
+            { latest = latest
+            ; booted = system_a_version
+            ; inactive = system_b_version
+            }
+            |> return
+          | SystemB ->
+            { latest = latest
+            ; booted = system_b_version
+            ; inactive = system_a_version
+            }
+            |> return
+        )
+
+    (** download RAUC bundle *)
+    let download url version =
+      let bundle_path = Format.sprintf "/tmp/%s" (bundle_file_name version) in
+      let options =
+        [ "--continue-at"; "-" (* resume download *)
+        ; "--limit-rate"; "10M"
+        ; "--output"; bundle_path
+        ]
+      in
+      match%lwt CurlI.request ~options url with
+      | RequestSuccess _ ->
+          return bundle_path
+      | RequestFailure error ->
+          Lwt.fail_with (Printf.sprintf "could not download RAUC bundle (%s)" (Curl.pretty_print_error error))
+
+(* Update mechanism process *)
+    (** perform a single state transition from given state *)
+    let run_step (state:state) : state Lwt.t =
+       let set = Lwt.return in
+       match (state) with
+      | GettingVersionInfo ->
+        (* get version information and decide what to do *)
+        begin
+          match%lwt get_version_info ConfigI.update_url with
+          | Ok version_info ->
+
+            (* Compare latest available version to version booted. *)
+            let booted_version_compare = Semver.compare
+                (fst version_info.latest)
+                (fst version_info.booted) in
+            let booted_up_to_date = booted_version_compare = 0 in
+
+            (* Compare latest available version to version on inactive system partition. *)
+            let inactive_version_compare = Semver.compare
+                (fst version_info.latest)
+                (fst version_info.inactive) in
+            let inactive_up_to_date = inactive_version_compare = 0 in
+            let inactive_update_available = inactive_version_compare > 0 in
+
+            if booted_up_to_date || inactive_up_to_date then
+              match%lwt RaucI.get_primary with
+              | Some primary_slot ->
+                if booted_up_to_date then
+                  (* Don't care if inactive can be updated. I.e. Only update the inactive partition once the booted partition is outdated. This results in always two versions being available on the machine. *)
+                  UpToDate version_info |> set
+                else
+                  let%lwt booted_slot = RaucI.get_booted_slot in
+                  if booted_slot = primary_slot then
+                    (* Inactive is up to date while booted is out of date, but booted was specifically selected for boot *)
+                    OutOfDateVersionSelected |> set
+                  else
+                    (* If booted is not up to date but inactive is both up to date and primary, we should reboot into the primary *)
+                    RebootRequired |> set
+              | None ->
+                (* All systems bad; suggest reinstallation *)
+                ReinstallRequired |> set
+
+            else if inactive_update_available then
+              (* Booted system is not up to date and there is an update available for inactive system. *)
+              let latest_version = version_info.latest |> snd in
+              let url = latest_download_url ~update_url:ConfigI.update_url latest_version in
+              Downloading {url = url; version = latest_version}
+              |> set
+
             else
-              let%lwt booted_slot = Rauc.get_booted_slot rauc in
-              if booted_slot = primary_slot then
-                (* Inactive is up to date while booted is out of date, but booted was specifically selected for boot *)
-                OutOfDateVersionSelected |> set
-              else
-                (* If booted is not up to date but inactive is both up to date and primary, we should reboot into the primary *)
-                RebootRequired |> set
-          | None ->
-            (* All systems bad; suggest reinstallation *)
-            ReinstallRequired |> set
+              let msg =
+                ("nonsensical version information: "
+                 ^ (version_info
+                    |> sexp_of_version_info
+                    |> Sexplib.Sexp.to_string_hum))
+              in
+              let%lwt () =
+                Logs_lwt.warn ~src:log_src
+                  (fun m -> m "%s" msg)
+              in
+              ErrorGettingVersionInfo msg |> set
 
-        else if inactive_update_available then
-          (* Booted system is not up to date and there is an update available for inactive system. *)
-          let latest_version = version_info.latest |> snd in
-          let url = latest_download_url ~update_url latest_version in
-          Downloading {url = url; version = latest_version}
-          |> set
+          | Error exn ->
+            ErrorGettingVersionInfo (Printexc.to_string exn)
+            |> set
+        end
 
-        else
-          let msg =
-            ("nonsensical version information: "
-             ^ (version_info
-                |> sexp_of_version_info
-                |> Sexplib.Sexp.to_string_hum))
-          in
-          let%lwt () =
-            Logs_lwt.warn ~src:log_src
-              (fun m -> m "%s" msg)
-          in
-          ErrorGettingVersionInfo msg |> set
+      | ErrorGettingVersionInfo msg ->
+        (* handle error while getting version information *)
+        let%lwt () =
+          Logs_lwt.err ~src:log_src
+            (fun m -> m "failed to get version information: %s" msg)
+        in
+        (* sleep and retry *)
+        let%lwt () = sleep_error_backoff in
+        set GettingVersionInfo
 
-      | Error exn ->
-        ErrorGettingVersionInfo (Printexc.to_string exn)
-        |> set
+      | Downloading {url; version} ->
+        (* download latest version *)
+        (match%lwt Lwt_result.catch (fun () -> download (Uri.of_string url) version) with
+         | Ok bundle_path ->
+           Installing bundle_path
+           |> set
+         | Error exn ->
+           ErrorDownloading (Printexc.to_string exn)
+           |> set
+        )
+
+      | ErrorDownloading msg ->
+        (* handle error while downloading bundle *)
+        let%lwt () =
+          Logs_lwt.err ~src:log_src
+            (fun m -> m "failed to download RAUC bundle: %s" msg)
+        in
+        (* sleep and retry *)
+        let%lwt () = sleep_error_backoff in
+        set GettingVersionInfo
+
+      | Installing bundle_path ->
+        (* install bundle via RAUC *)
+        (match%lwt Lwt_result.catch (fun () -> RaucI.install bundle_path) with
+         | Ok () ->
+           let%lwt () =
+             Logs_lwt.info (fun m -> m "succesfully installed update (%s)" bundle_path)
+           in
+           RebootRequired
+           |> set
+         | Error exn ->
+           let () = try Sys.remove bundle_path with
+             | _ -> ()
+           in
+           ErrorInstalling (Printexc.to_string exn)
+           |> set
+        )
+
+      | ErrorInstalling msg ->
+        (* handle installation error *)
+        let%lwt () =
+          Logs_lwt.err ~src:log_src
+            (fun m -> m "failed to install RAUC bundle: %s" msg)
+        in
+        (* sleep and retry *)
+        let%lwt () = sleep_error_backoff in
+        set GettingVersionInfo
+
+      | UpToDate _
+      | RebootRequired
+      | OutOfDateVersionSelected
+      | ReinstallRequired ->
+        (* sleep and recheck for new updates *)
+        let%lwt () = sleep_update_check in
+        set GettingVersionInfo
+
+    (** Finite state machine handling updates *)
+    let rec run ~set_state state =
+      let%lwt next_state = run_step state in
+        set_state state;
+        run ~set_state next_state
+
+    module Private = struct
+        let run_step = run_step
     end
+end
 
-  | ErrorGettingVersionInfo msg ->
-    (* handle error while getting version information *)
-    let%lwt () =
-      Logs_lwt.err ~src:log_src
-        (fun m -> m "failed to get version information: %s" msg)
-    in
-    (* wait for 30 seconds and retry *)
-    let%lwt () = Lwt_unix.sleep 30.0 in
-    set GettingVersionInfo
+(* Helpers for wrapping dependencies/interfaces *)
+(* TODO: could be moved to separate module *)
 
-  | Downloading {url; version} ->
-    (* download latest version *)
-    let%lwt proxy = get_proxy_uri connman in
-    (match%lwt Lwt_result.catch (fun () -> download ?proxy (Uri.of_string url) version) with
-     | Ok bundle_path ->
-       Installing bundle_path
-       |> set
-     | Error exn ->
-       ErrorDownloading (Printexc.to_string exn)
-       |> set
-    )
+module DefaultSleepConfig = struct
+    let error_backoff_duration = 30.0
+    let check_for_updates_interval = (1. *. 60. *. 60.)
+end
 
-  | ErrorDownloading msg ->
-    (* handle error while downloading bundle *)
-    let%lwt () =
-      Logs_lwt.err ~src:log_src
-        (fun m -> m "failed to download RAUC bundle: %s" msg)
-    in
-    (* Wait for 30 seconds and retry *)
-    let%lwt () = Lwt_unix.sleep 30.0 in
-    set GettingVersionInfo
+let get_proxy_uri connman =
+  Connman.Manager.get_default_proxy connman
+    >|= Option.map (Connman.Service.Proxy.to_uri ~include_userinfo:true)
 
-  | Installing bundle_path ->
-    (* install bundle via RAUC *)
-    (match%lwt Lwt_result.catch (fun () -> Rauc.install rauc bundle_path) with
-     | Ok () ->
-       let%lwt () =
-         Logs_lwt.info (fun m -> m "succesfully installed update (%s)" bundle_path)
-       in
-       RebootRequired
-       |> set
-     | Error exn ->
-       let () = try Sys.remove bundle_path with
-         | _ -> ()
-       in
-       ErrorInstalling (Printexc.to_string exn)
-       |> set
-    )
+module type OBusPeerRef = sig
+    val peer: OBus_peer.Private.t
+end
 
-  | ErrorInstalling msg ->
-    (* handle installation error *)
-    let%lwt () =
-      Logs_lwt.err ~src:log_src
-        (fun m -> m "failed to install RAUC bundle: %s" msg)
-    in
-    (* Wait for 30 seconds and retry *)
-    let%lwt () = Lwt_unix.sleep 30.0 in
-    set GettingVersionInfo
+module RaucOBus(OBusRef: OBusPeerRef): RaucInterface = struct
+    let t = OBusRef.peer
 
-  | UpToDate _
-  | RebootRequired
-  | OutOfDateVersionSelected
-  | ReinstallRequired ->
-    (* wait for an hour and recheck for new updates *)
-    let%lwt () = Lwt_unix.sleep (1. *. 60. *. 60.) in
-    set GettingVersionInfo
+    let get_status : Rauc.status Lwt.t =
+        Rauc.get_status t
 
+    let get_booted_slot : Rauc.Slot.t Lwt.t =
+        Rauc.get_booted_slot t
 
-let start ~connman ~(rauc:Rauc.t) ~(update_url:string) =
+    let get_primary : Rauc.Slot.t option Lwt.t =
+        Rauc.get_primary t
+
+    let install : string -> unit Lwt.t =
+        Rauc.install t
+end
+
+let build_deps ~connman ~(rauc : Rauc.t) ~(update_url : string) :
+    (module UpdateServiceDeps) Lwt.t =
+
+  let module ConfigI : ConfigInterface = struct
+    include DefaultSleepConfig
+    let update_url = update_url
+  end in
+
+  let module OBusRef = struct
+    let peer = rauc
+  end in
+  let module RaucI = RaucOBus (OBusRef) in
+
+  let%lwt proxy = get_proxy_uri connman in
+
+  let module CurlWrap : CurlProxyInterface = struct
+    let request = Curl.request ?proxy
+  end in
+
+  let module Deps = struct
+    module CurlI = CurlWrap
+    module ConfigI = ConfigI
+    module RaucI = RaucI
+  end in
+
+  Lwt.return (module Deps : UpdateServiceDeps)
+
+(* "legacy" entry point *)
+let start ~connman ~(rauc : Rauc.t) ~(update_url : string) =
   let state_s, set_state = Lwt_react.S.create GettingVersionInfo in
   let () = Logs.info ~src:log_src (fun m -> m "update URL: %s" update_url) in
-  state_s, run ~connman ~update_url ~rauc ~set_state GettingVersionInfo
+
+  let service = begin
+      let%lwt deps = build_deps ~connman ~rauc ~update_url in
+      let module Deps = (val deps : UpdateServiceDeps) in
+      let module UpdateServiceI = UpdateService(Deps) in
+      UpdateServiceI.run ~set_state GettingVersionInfo
+  end in
+
+  let () = Logs.info ~src:log_src (fun m -> m "Started") in
+  (state_s, service)

--- a/controller/server/update.mli
+++ b/controller/server/update.mli
@@ -26,4 +26,14 @@ type state =
   | ReinstallRequired
 [@@deriving sexp]
 
+module UpdateService : functor (_ : Update_deps.UpdateServiceDeps) -> sig
+  val run : set_state:(state -> unit) -> state -> unit Lwt.t
+
+  (* private functions used in testing *)
+  module Private : sig
+    val run_step : state -> state Lwt.t
+  end
+end
+
+(* maintaining the original entrypoint for backwards compatibility *)
 val start : connman:Connman.Manager.t -> rauc:Rauc.t -> update_url:string -> state Lwt_react.signal * unit Lwt.t

--- a/controller/server/update_deps.mli
+++ b/controller/server/update_deps.mli
@@ -1,0 +1,41 @@
+module type CurlProxyInterface = sig
+    val request
+      :  ?headers:(string * string) list
+      -> ?data:string
+      -> ?options:string list
+      -> Uri.t
+      -> Curl.result Lwt.t
+end
+
+type sleep_duration = float (* seconds *)
+
+module type ConfigInterface = sig
+    (* time to sleep in seconds until retrying after a (Curl/HTTP) error *)
+    val error_backoff_duration: sleep_duration
+
+    (* time to sleep in seconds between checking for available updates *)
+    val check_for_updates_interval: sleep_duration
+
+    (* where to fetch updates from *)
+    val update_url: string
+end
+
+module type RaucInterface = sig
+    (** [get_status rauc] returns current RAUC status *)
+    val get_status : Rauc.status Lwt.t
+
+    (** [get_booted_slot rauc] returns the currently booted slot *)
+    val get_booted_slot : Rauc.Slot.t Lwt.t
+
+    (** [get_primary rauc] returns current primary slot, if any *)
+    val get_primary : Rauc.Slot.t option Lwt.t
+
+    (** [install rauc source] install the bundle at path [source] *)
+    val install : string -> unit Lwt.t
+end
+
+module type UpdateServiceDeps = sig
+    module CurlI: CurlProxyInterface
+    module ConfigI: ConfigInterface
+    module RaucI: RaucInterface
+end

--- a/controller/tests/dune
+++ b/controller/tests/dune
@@ -1,0 +1,8 @@
+(test
+ (name update_tests)
+ (libraries update alcotest alcotest-lwt)
+ (modules update_tests)
+ (preprocess (pps lwt_ppx ppx_sexp_conv))
+)
+
+(env (dev (flags :standard -warn-error -A -w -8-27-32-33)))

--- a/controller/tests/update_tests.ml
+++ b/controller/tests/update_tests.ml
@@ -1,0 +1,155 @@
+open Update
+open Update_deps
+open Lwt
+
+let current_version = "10.0.1"
+let next_version = "10.0.2"
+
+module TestCurl = struct
+  (* Need to figure out a more generic way to make mock implementations for
+     tests, might need some PPX magic? *)
+  let calls = Queue.create ()
+  let clear = Queue.clear calls
+
+  let request ?headers ?data ?options url =
+    Queue.push (headers, data, options, url) calls;
+    Curl.RequestSuccess (200, next_version) |> Lwt.return
+end
+
+module TestConfig : ConfigInterface = struct
+  let error_backoff_duration = 0.01
+  let check_for_updates_interval = 0.05
+  let update_url = "https://localhost:9999/"
+end
+
+module TestRauc : RaucInterface = struct
+  let get_status : Rauc.status Lwt.t =
+    let some_status : Rauc.Slot.status =
+      {
+        device = "Device";
+        state = "Good";
+        class' = "class";
+        version = current_version;
+        installed_timestamp = "2023-01-01T00:00:00Z";
+      }
+    in
+    let full_status : Rauc.status = { a = some_status; b = some_status } in
+    full_status |> Lwt.return
+
+  let get_primary : Rauc.Slot.t option Lwt.t =
+    Some Rauc.Slot.SystemA |> Lwt.return
+
+  let get_booted_slot : Rauc.Slot.t Lwt.t = Lwt.return Rauc.Slot.SystemA
+  let install (_ : string) : unit Lwt.t = Lwt.return ()
+end
+
+module TestUpdateServiceDeps = struct
+  module CurlI = TestCurl
+  module ConfigI = TestConfig
+  module RaucI = TestRauc
+end
+
+module TestUpdateService = UpdateService (TestUpdateServiceDeps)
+
+type action_descr = string
+type action_check = unit -> bool
+type mock_update = unit -> unit
+
+type scenario_spec =
+  | StateReached of Update.state
+  | ActionDone of action_descr * action_check
+  (* TODO *)
+  | UpdateMock of mock_update
+
+let statefmt (state : Update.state) : string =
+  state |> Update.sexp_of_state |> Sexplib.Sexp.to_string_hum
+
+let state_formatter out inp = Format.fprintf out "%s" (statefmt inp)
+let t_state = Alcotest.testable state_formatter ( = )
+
+let interp_spec (state : Update.state) (spec : scenario_spec) =
+  match spec with
+  | StateReached s -> Alcotest.check t_state "State reached" s state
+  | ActionDone (descr, f) ->
+      Alcotest.(check bool) ("Action done: " ^ descr) true (f ())
+  | UpdateMock f -> f ()
+
+let is_state_spec s = match s with StateReached _ -> true | _ -> false
+
+let check_state expected_state_sequence prev_state cur_state =
+  let spec = Queue.pop expected_state_sequence in
+  (* after a callback first spec should always be the next state we expect
+       *)
+  if not (is_state_spec spec) then
+    failwith "Expected a state spec, but got something else - bad spec?";
+
+  interp_spec prev_state spec;
+  (* progress forward until we either reach the end or we hit a state
+     assertion, which means we have to progress the state machine *)
+  while
+    (not (Queue.is_empty expected_state_sequence))
+    && not (is_state_spec @@ Queue.peek expected_state_sequence)
+  do
+    let next_spec = Queue.pop expected_state_sequence in
+    interp_spec prev_state next_spec
+  done
+
+let rec run_test_scenario expected_state_sequence cur_state =
+  (* is there an equivalent of Haskell's whileM ? *)
+  if not (Queue.is_empty expected_state_sequence) then (
+    let%lwt next_state = TestUpdateService.Private.run_step cur_state in
+    check_state expected_state_sequence cur_state next_state;
+    run_test_scenario expected_state_sequence next_state)
+  else Lwt.return ()
+
+let happy_flow_test () =
+  let init_state = GettingVersionInfo in
+  let expected_bundle_name =
+    "@PLAYOS_BUNDLE_NAME@-" ^ next_version ^ ".raucb"
+  in
+  let expected_url =
+    TestConfig.update_url ^ next_version ^ "/" ^ expected_bundle_name
+  in
+
+  let expected_state_sequence =
+    Queue.of_seq
+      (List.to_seq
+         [
+           StateReached GettingVersionInfo;
+           ActionDone
+             ( "curl was called",
+               fun () ->
+                 Alcotest.(check int)
+                   "Curl was called once" 1
+                   (Queue.length TestCurl.calls);
+                 let _ = Queue.pop TestCurl.calls in
+                 true );
+           StateReached
+             (Downloading { url = expected_url; version = next_version });
+           ActionDone
+             ( "curl was called",
+               fun () ->
+                 match Queue.take_opt TestCurl.calls with
+                 | Some (_, _, _, url) ->
+                     Alcotest.(check string)
+                       "Curl was called with the right parameters" expected_url
+                       (Uri.to_string url);
+                     true
+                 | _ -> Alcotest.fail "Curl was not called" );
+           StateReached (Installing ("/tmp/" ^ expected_bundle_name));
+           StateReached RebootRequired;
+           StateReached GettingVersionInfo;
+         ])
+  in
+  run_test_scenario expected_state_sequence init_state
+
+let () =
+  Lwt_main.run
+  @@ Alcotest_lwt.run "Basic tests"
+       [
+         ( "all",
+           [
+             Alcotest_lwt.test_case "Happy flow" `Quick (fun _ () ->
+                 happy_flow_test ());
+           ] );
+       ]


### PR DESCRIPTION
This is in an unfinished state (esp. the test part), but pushing this out for early review/feedback.

This PR does the following:
- Refactors the core of `Update` module to use abstract interfaces for its external dependencies (RAUC, Curl/Connman, runtime configuration) rather than direct bindings / values.
- Splits the `Update.run` function into a separate single transition function (`run_step`) and the infinite recursive process (`run`). 
- Exposes an alternative interface to the Update process as a functor over the external dependencies.
- Adds a prototype test "framework" and a sample unit test for the `Update` module.

Some of the code is shifted around/generalized as a side-effect of the changes, but this PR should (hopefully!) not introduce any logical / semantic changes, it only creates new ways for interacting with the code and the sample tests.

This is WIP since several things need to be worked out in more detail:
- The dependency interfaces are just straightforward wrappers around the functions used in the original code, but more thought could be put into this to figure out what exactly are we abstracting over.
- The code split into the `update_deps` module/file is rather ad-hoc
- The test "framework" is now quite basic in terms of what it can test, but my ocaml skills are too limited to figure out how to create mock interfaces neatly[^1].
- Other server modules should probably share (at least) the RAUC abstract interfaces too? 

I also left some TODOs as inline comments. 

@knuton let me know of what you think about this "direction" and specific things that you think need to be done differently. If the general direction seems reasonable, I would attempt to flesh out the test framework and add more complex tests cases. Any ocaml-foo tips are also very welcome.

Apologies for the huge diff, the process was very unlinear, so did not produce structured git commits.

P.S. Is there a specific ocaml style used at Dividat? Maybe we could adopt one of the standard ocamlformat profiles?

[^1]: I want to be able to record every mock call and update the mocked responses at run time. I have an idea how to do this with a simple PPX "decorator", but no idea how to do it otherwise. There's [ocaml-mock](https://github.com/cryptosense/ocaml-mock), but it's very primitive / requires lots of boilreplate.

