### PR TITLE
Move all controller deps to buildInputs, remove utop, nodejs

### DIFF
--- a/controller/default.nix
+++ b/controller/default.nix
@@ -32,11 +32,6 @@ ocamlPackages.buildDunePackage rec {
   ];
 
   buildInputs = with ocamlPackages; [
-    nodejs
-    utop
-  ];
-
-  propagatedBuildInputs = with ocamlPackages; [
     opium
     ocaml_lwt
     logs

--- a/controller/shell.nix
+++ b/controller/shell.nix
@@ -12,6 +12,5 @@ pkgs.mkShell {
   packages =
     playos-controller.buildInputs
       ++ playos-controller.nativeBuildInputs
-      ++ playos-controller.propagatedBuildInputs
       ++ [ pkgs.watchexec ];
 }


### PR DESCRIPTION
Having them in `propagatedBuildInputs` resulted in ocaml being included in the system image and bloated it by an extra 500 MB.

cc @knuton 

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
