### PR TITLE
Improve install device selection in installer

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -3,6 +3,7 @@
 ## Added
 
 - controller: Enable spatial navigation using the arrow keys
+- os: Improve installation device selection
 
 ## Removed
 


### PR DESCRIPTION
- Look for "/iso" mount not only in children of blockdevices, but top-level devices too (e.g. this happens when running qemu with `-cdrom playos-installer-<..>.iso`)
- Eliminate devices that are too small or read-only from potential installation targets.

cc @knuton 

## Checklist

-   [X] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
