### PR TITLE
Ensure KVM is usable and add e2e tests in GH workflow 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,30 @@ jobs:
           system-features = nixos-test benchmark big-parallel kvm
     - uses: DeterminateSystems/magic-nix-cache-action@v8
     - run: NIXPKGS_ALLOW_UNFREE=1 ./build vm
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Make more space available on the runner
+      run: |
+        sudo rm -rf /usr/share/dotnet \
+                    /usr/local/lib/android \
+                    /opt/ghc \
+                    /opt/hostedtoolcache/CodeQL
+
+    - name: Ensure KVM is usable by nix-build
+      run: sudo chmod a+rwx /dev/kvm
+
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          system-features = nixos-test benchmark big-parallel kvm
+    - uses: DeterminateSystems/magic-nix-cache-action@v8
+      with:
+        # disables _uploading_ to GHA cache - necessary because
+        # the cache has a quota of 10 GB, while the built disk
+        # is ~7GB
+        use-gha-cache: false
+    - run: ./build test-e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
           system-features = nixos-test benchmark big-parallel kvm
-    - uses: DeterminateSystems/magic-nix-cache-action@v4
+    - uses: DeterminateSystems/magic-nix-cache-action@v8
     - run: NIXPKGS_ALLOW_UNFREE=1 nix-build ${{ matrix.file }}
 
   kiosk-tests:
@@ -42,7 +42,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
           system-features = nixos-test benchmark big-parallel kvm
-    - uses: DeterminateSystems/magic-nix-cache-action@v4
+    - uses: DeterminateSystems/magic-nix-cache-action@v8
     - run: cd kiosk && nix-shell --run bin/test
 
   build-vm:
@@ -54,5 +54,5 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
           system-features = nixos-test benchmark big-parallel kvm
-    - uses: DeterminateSystems/magic-nix-cache-action@v4
+    - uses: DeterminateSystems/magic-nix-cache-action@v8
     - run: NIXPKGS_ALLOW_UNFREE=1 ./build vm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         file: ${{fromJson(needs.prepare-matrix.outputs.integration_tests)}}
     steps:
+    - name: Ensure KVM is usable by nix-build
+      run: sudo chmod a+rwx /dev/kvm
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18
       with:

--- a/testing/end-to-end/tests/application/kiosk-persistence.nix
+++ b/testing/end-to-end/tests/application/kiosk-persistence.nix
@@ -185,6 +185,7 @@ playos.shutdown()
 playos.start()
 
 with TestPrecondition("Booted into slot b") as t:
+    playos.wait_for_unit("rauc.service")
     t.assertEqual(get_booted_slot(), "b")
     rauc_status = json.loads(playos.succeed("rauc status --output-format=json"))
     t.assertEqual(


### PR DESCRIPTION
This is a PoC that e2e tests can be made to run as part of GH workflow, but:
- It cannot be cached, because it will evict everything else from the GH action cache which [has a quota of 10GB](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy).
- We cannot use a matrix workflow, because each runner will have to rebuild the disk, so tests will take forever. 
- It kinda pushes the GH runner storage to the limit.

@knuton thoughts?

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
