### PR TITLE
Attempt to eliminate kiosk persistence e2e test flakiness

### DIFF
--- a/testing/end-to-end/tests/application/kiosk-persistence.nix
+++ b/testing/end-to-end/tests/application/kiosk-persistence.nix
@@ -130,9 +130,15 @@ async def check_web_storages_after_restart(page, t):
             "TEST_VALUE cookie was not persisted"
         )
 
-def get_booted_slot():
+def get_booted_slot(retries=3):
     rauc_status = json.loads(playos.succeed("rauc status --output-format=json"))
-    return rauc_status['booted']
+    booted = rauc_status['booted']
+    # RAUC sometimes returns `null`, not sure why
+    if (booted is None) and retries > 0:
+        time.sleep(2)
+        return get_booted_slot(retries=retries-1)
+    else:
+        return booted
 
 # ===== Test scenario
 

--- a/testing/end-to-end/tests/application/kiosk-persistence.nix
+++ b/testing/end-to-end/tests/application/kiosk-persistence.nix
@@ -140,6 +140,11 @@ def get_booted_slot(retries=3):
     else:
         return booted
 
+def wait_for_dm_restart():
+    wait_for_logs(playos, "display-manager.service: Scheduled restart job")
+    playos.wait_for_unit("graphical-session.target")
+
+
 # ===== Test scenario
 
 aio = asyncio.Runner()
@@ -173,6 +178,7 @@ with TestCase("Kiosk's debug port open, web storage is persisted") as t:
 
     # check if data is persisted after kiosk is restarted
     playos.succeed("pkill -f kiosk-browser")
+    wait_for_dm_restart()
 
     new_page = aio.run(connect_and_get_kiosk_page())
     aio.run(check_web_storages_after_restart(new_page, t))

--- a/testing/end-to-end/tests/application/kiosk-persistence.nix
+++ b/testing/end-to-end/tests/application/kiosk-persistence.nix
@@ -145,7 +145,7 @@ def get_booted_slot():
 
 def wait_for_dm_restart():
     wait_for_logs(playos, "display-manager.service: Scheduled restart job")
-    playos.wait_for_unit("graphical-session.target")
+    playos.wait_for_x()
 
 
 # ===== Test scenario


### PR DESCRIPTION
Two sources of flakiness:
- `rauc status` reporting `booted` as `null` and `rauc status` randomly crashing with a core dump. Always [on this line](https://github.com/yfyf/playos/blob/bc94691f30b99790b6879de2d090fba5be663855/testing/end-to-end/tests/application/kiosk-persistence.nix#L195). No idea why it happens, probably some uninitialized state, because it never crashes on the earlier calls? It might be related to the fact that the RAUC systemd service confiuration is incomplete, because it is missing [DBus activation specs](https://rauc.readthedocs.io/en/latest/integration.html#d-bus-integration).  Attempting to overcome this with a retry, adding the [necessary DBus service](https://github.com/ejoerns/rauc/blob/master/data/de.pengutronix.rauc.service.in) might be a good idea in general though.
- kiosk reporting that it has a `:` as the open page after being killed. Again no clue why it happens, but I am guessing we are attempting to interact with too early. Attempting to fix it by giving time to start before attempting to connect to the debug port.

Ran the test locally more than 10 times without failures. Before these changes would trigger both failures after ~5 runs.

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
