### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/base/self-update/default.nix
+++ b/base/self-update/default.nix
@@ -23,8 +23,12 @@ in
 
     systemd.services.rauc = {
       description = "RAUC Update Service";
-      serviceConfig.ExecStart = "${pkgs.rauc}/bin/rauc service";
-      serviceConfig.User = "root";
+      serviceConfig = {
+        Type = "dbus";
+        BusName= "de.pengutronix.rauc";
+        ExecStart = "${pkgs.rauc}/bin/rauc service";
+        User = "root";
+      };
       wantedBy = [ "multi-user.target" ];
     };
 

--- a/testing/end-to-end/tests/application/kiosk-persistence.nix
+++ b/testing/end-to-end/tests/application/kiosk-persistence.nix
@@ -134,6 +134,11 @@ def get_booted_slot():
     rauc_status = json.loads(playos.succeed("rauc status --output-format=json"))
     return rauc_status['booted']
 
+def wait_for_dm_restart():
+    wait_for_logs(playos, "display-manager.service: Scheduled restart job")
+    playos.wait_for_unit("graphical-session.target")
+
+
 # ===== Test scenario
 
 aio = asyncio.Runner()
@@ -167,6 +172,7 @@ with TestCase("Kiosk's debug port open, web storage is persisted") as t:
 
     # check if data is persisted after kiosk is restarted
     playos.succeed("pkill -f kiosk-browser")
+    wait_for_dm_restart()
 
     new_page = aio.run(connect_and_get_kiosk_page())
     aio.run(check_web_storages_after_restart(new_page, t))

--- a/testing/end-to-end/tests/application/kiosk-persistence.nix
+++ b/testing/end-to-end/tests/application/kiosk-persistence.nix
@@ -136,7 +136,7 @@ def get_booted_slot():
 
 def wait_for_dm_restart():
     wait_for_logs(playos, "display-manager.service: Scheduled restart job")
-    playos.wait_for_unit("graphical-session.target")
+    playos.wait_for_x()
 
 
 # ===== Test scenario


### PR DESCRIPTION
This combines the kiosk-oriented fixes from https://github.com/dividat/playos/pull/191 with a change to the rauc service definition that ensures proper interaction with D-Bus.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
