### PR TITLE
Limit ToC depth in user manual to 2

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     cd ../user-manual
     pandoc \
         --template ../templates/default.html \
-        --toc --number-sections \
+        --toc --number-sections --toc-depth=2 \
         -V version=${version} -M date=$DATE \
         -t html5 \
         --standalone --self-contained -o $out/user-manual.html \


### PR DESCRIPTION
Keep the table of contents for the user manual high level.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
