### PR TITLE
Use actions/checkout@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       integration_tests: ${{ steps.set-matrix.outputs.integration_tests }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - id: set-matrix
       run: |
         FILES=$(find testing/integration -name '*.nix' -printf '"%p",')
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: Ensure KVM is usable by nix-build
       run: sudo chmod a+rwx /dev/kvm
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-unstable
@@ -36,7 +36,7 @@ jobs:
   kiosk-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-unstable
@@ -48,7 +48,7 @@ jobs:
   build-vm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-unstable
@@ -70,7 +70,7 @@ jobs:
     - name: Ensure KVM is usable by nix-build
       run: sudo chmod a+rwx /dev/kvm
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION
v3 uses Node 16, which is EOL and causes warnings on GH Actions.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
