### PR TITLE
Replace use of deprecated set-output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       run: |
         FILES=$(find testing/integration -name '*.nix' -printf '"%p",')
         FILES_JSON="[${FILES%,}]"
-        echo "::set-output name=integration_tests::${FILES_JSON}"
+        echo "integration_tests=${FILES_JSON}" >> $GITHUB_OUTPUT
 
   integration-tests:
     needs: prepare-matrix


### PR DESCRIPTION
Another GitHub Actions deprecation to address:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
