### PR TITLE
Display monitor hotplugging v2 

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -159,7 +159,6 @@ rec {
           User = "play";
         };
         environment = {
-          # TODO: is this needed?
           XAUTHORITY = "${config.users.users.play.home}/.Xauthority";
           DISPLAY = ":0";
         };

--- a/application.nix
+++ b/application.nix
@@ -21,7 +21,19 @@ rec {
       (import ./application/overlays version)
     ];
 
-    module = { config, lib, pkgs, ... }: {
+    module = { config, lib, pkgs, ... }:
+    let
+      selectDisplay = pkgs.writeShellApplication {
+        name = "select-display";
+        runtimeInputs = with pkgs; [
+          gnugrep
+          gawk
+          xorg.xrandr
+          bash
+        ];
+        text = (builtins.readFile ./application/select-display.sh);
+      };
+    in {
 
       imports = [
         ./application/playos-status.nix
@@ -67,6 +79,9 @@ rec {
               xset s noblank
               xset -dpms
 
+              # Select best display to output to
+              ${selectDisplay}/bin/select-display || true
+
               # Localization for xsession
               if [ -f /var/lib/gui-localization/lang ]; then
                 export LANG=$(cat /var/lib/gui-localization/lang)
@@ -74,19 +89,6 @@ rec {
               if [ -f /var/lib/gui-localization/keymap ]; then
                 setxkbmap $(cat /var/lib/gui-localization/keymap) || true
               fi
-
-              # Set preferred screen resolution
-              scaling_pref=$(cat /var/lib/gui-localization/screen-scaling 2>/dev/null || echo "default")
-              case "$scaling_pref" in
-                "default" | "full-hd")
-                  xrandr --size 1920x1080;;
-                "native")
-                  # Nothing to do, let system decide.
-                  ;;
-                *)
-                  echo "Unknown scaling preference '$scaling_pref'. Ignoring."
-                  ;;
-              esac
 
               # Enable Qt WebEngine Developer Tools (https://doc.qt.io/qt-6/qtwebengine-debugging.html)
               export QTWEBENGINE_REMOTE_DEBUGGING="127.0.0.1:3355"
@@ -143,6 +145,25 @@ rec {
         '';
         serviceConfig.User = "play";
         wantedBy = [ "multi-user.target" ];
+      };
+
+      # Monitor hotplugging
+      services.udev.extraRules = ''
+        ACTION=="change", SUBSYSTEM=="drm", RUN+="${pkgs.systemd}/bin/systemctl start select-display.service"
+      '';
+      systemd.services."select-display" = {
+        description = "Select best display to output to";
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${selectDisplay}/bin/select-display";
+          User = "play";
+        };
+        environment = {
+          # TODO: is this needed?
+          XAUTHORITY = "${config.users.users.play.home}/.Xauthority";
+          DISPLAY = ":0";
+        };
+        after = [ "graphical.target" ];
       };
 
       # Audio

--- a/application/select-display.sh
+++ b/application/select-display.sh
@@ -1,0 +1,35 @@
+set -euo pipefail
+
+SCALING_PREF=$(cat /var/lib/gui-localization/screen-scaling 2>/dev/null || echo "default")
+readonly SCALING_PREF
+echo "Using scaling preference '$SCALING_PREF'"
+
+CONNECTED_OUTPUTS=$(xrandr | grep ' connected' | awk '{ print $1 }')
+readonly CONNECTED_OUTPUTS
+echo -e "Connected outputs:\n$CONNECTED_OUTPUTS\n"
+
+if [ -z "$CONNECTED_OUTPUTS" ]; then
+
+  echo "No connected outputs found. Apply xrandr globally."
+  xrandr --auto
+
+else
+
+  case "$SCALING_PREF" in
+    "default" | "full-hd")
+      for output in $CONNECTED_OUTPUTS; do
+        echo "Applying full-hd to output '$output'"
+        xrandr --auto --output "$output" --mode 1920x1080
+      done
+      ;;
+    "native")
+      echo "Native scaling preference. Applying auto."
+      xrandr --auto
+      ;;
+    *)
+      echo "Unknown scaling preference '$SCALING_PREF'. Applying auto."
+      xrandr --auto
+      ;;
+  esac
+
+fi

--- a/application/select-display.sh
+++ b/application/select-display.sh
@@ -2,34 +2,47 @@ set -euo pipefail
 
 SCALING_PREF=$(cat /var/lib/gui-localization/screen-scaling 2>/dev/null || echo "default")
 readonly SCALING_PREF
-echo "Using scaling preference '$SCALING_PREF'"
 
 CONNECTED_OUTPUTS=$(xrandr | grep ' connected' | awk '{ print $1 }')
 readonly CONNECTED_OUTPUTS
+
 echo -e "Connected outputs:\n$CONNECTED_OUTPUTS\n"
+
+scaling_pref_params=""
+
+echo "Using scaling preference '$SCALING_PREF'"
+
+case "$SCALING_PREF" in
+    "default" | "full-hd")
+        scaling_pref_params=(--mode 1920x1080)
+        ;;
+    "native")
+        scaling_pref_params=(--auto)
+        ;;
+    *)
+        scaling_pref_params=(--auto)
+        ;;
+esac
 
 if [ -z "$CONNECTED_OUTPUTS" ]; then
 
-  echo "No connected outputs found. Apply xrandr globally."
-  xrandr --auto
+    echo "No connected outputs found. Attempting to apply xrandr globally."
+    xrandr "${scaling_pref_params[@]}"
 
 else
 
-  case "$SCALING_PREF" in
-    "default" | "full-hd")
-      for output in $CONNECTED_OUTPUTS; do
-        echo "Applying full-hd to output '$output'"
-        xrandr --auto --output "$output" --mode 1920x1080
-      done
-      ;;
-    "native")
-      echo "Native scaling preference. Applying auto."
-      xrandr --auto
-      ;;
-    *)
-      echo "Unknown scaling preference '$SCALING_PREF'. Applying auto."
-      xrandr --auto
-      ;;
-  esac
+    first_output=""
+    for output in $CONNECTED_OUTPUTS; do
+        if [ -z "$first_output" ]; then
+            first_output=$output
+            xrandr --output "$output" \
+                --primary \
+                "${scaling_pref_params[@]}"
+        else
+            xrandr --output "$output" \
+                --same-as "$first_output" \
+                "${scaling_pref_params[@]}"
+        fi
+    done
 
 fi

--- a/application/select-display.sh
+++ b/application/select-display.sh
@@ -27,22 +27,24 @@ esac
 if [ -z "$CONNECTED_OUTPUTS" ]; then
 
     echo "No connected outputs found. Attempting to apply xrandr globally."
-    xrandr "${scaling_pref_params[@]}"
+    xrandr --auto # this is kind of useless?
 
 else
 
-    first_output=""
+
+    first_functional_output=""
     for output in $CONNECTED_OUTPUTS; do
-        if [ -z "$first_output" ]; then
-            first_output=$output
-            xrandr --output "$output" \
-                --primary \
-                "${scaling_pref_params[@]}"
+        if [ -z "$first_functional_output" ]; then
+            if xrandr --output "$output" --primary "${scaling_pref_params[@]}"; then
+                first_functional_output=$output
+                echo "Configured display $output as primary"
+            else
+                echo "Failed to configure display $output"
+            fi
         else
             xrandr --output "$output" \
-                --same-as "$first_output" \
-                "${scaling_pref_params[@]}"
+                --same-as "$first_functional_output" \
+                "${scaling_pref_params[@]}" || echo "Failed to configure display $output"
         fi
     done
-
 fi


### PR DESCRIPTION
A revamped version of #155.

I tested the following:
- `./build vm` with QEMU options modified to `-device vga,max_outputs=2` displays output on both monitors
- Hotplugging works with a PlayOS live USB on my laptop+external screen

What I didn't manage to test:
- QEMU graphics drivers do not offer a way to modify the number of display outputs at run time, so cannot test hotplugging with QEMU.
- I can't figure out a way to make xrandr work from a virtual console neither on PlayOS, nor on my own laptop. E.g. if I run `DISPLAY=:0 XAUTHORITY=<..> xrandr --output <secondary> --off` from the xsession, it works, but if I Ctrl+Alt+F1 and run the same command from the virtual console it errors out with `Configure crtc 0 failed`. This would be critical for testing how the kiosk responds to screen resolution changes.

Some discussion points:
- What is the reason for the full HD (i.e. `--mode 1920x1080`) default in the scaling preferences? If the screen doesn't support it, xrandr will fail without a fallback, which is not great. Is it to scale down 4K screens down to 1080p?
- If there are multiple screens with different available modes/resolutions, then using identical scaling preferences / modes for all screens is problematic since they might be incompatible. Perhaps there should be a fallback to `--auto` or at least a check that 1080p is actually a supported mode.
- No idea how to perform kiosk-level testing for this, due to the `xrandr` issues mentioned above. 

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
