### PR TITLE
Wifi GUI improvements

### DIFF
--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -77,24 +77,29 @@ let proxy_form proxy =
         ]
     ]
 
+let maybe_elem cond elem = if cond then Some elem else None
+
 let not_connected_form service =
+  let requires_passphrase =  service.security <> [ None ] in
   form
       ~a:[ a_action ("/network/" ^ service.id ^ "/connect")
       ; a_method `Post
       ; Unsafe.string_attrib "is" "disable-after-submit"
       ]
-      [ label
-          ~a:[ a_class [ "d-Label" ] ]
-          [ txt "Passphrase" 
-          ; input
-              ~a:[ a_input_type `Password
-              ; a_class [ "d-Input"; "d-Network__Input" ]
-              ; a_name "passphrase"
-              ; Unsafe.string_attrib "is" "show-password"
+      (Option.to_list (maybe_elem requires_passphrase (
+          label
+              ~a:[ a_class [ "d-Label" ] ]
+              [ txt "Passphrase"
+              ; input
+                  ~a:[ a_input_type `Password
+                  ; a_class [ "d-Input"; "d-Network__Input" ]
+                  ; a_name "passphrase"
+                  ; Unsafe.string_attrib "is" "show-password"
+                  ]
+                  ()
               ]
-              ()
-          ]
-      ; p
+      )) @
+      [ p
           [ input
               ~a:[ a_input_type `Submit
               ; a_class [ "d-Button" ]
@@ -102,7 +107,7 @@ let not_connected_form service =
               ]
               ()
           ]
-      ]
+      ])
 
 (* Regex pattern to validate IP addresses
  * From: https://stackoverflow.com/a/36760050 *)

--- a/testing/system/default.nix
+++ b/testing/system/default.nix
@@ -16,6 +16,7 @@ let nixos = pkgs.importFromNixos ""; in
 
     # Testing machinery
     (import ./testing.nix { inherit lib pkgs; })
+    ./testing-wifi.nix # comment out to disable simulated wifi APs
   ];
   };
   system = "x86_64-linux";

--- a/testing/system/testing-wifi.nix
+++ b/testing/system/testing-wifi.nix
@@ -1,0 +1,67 @@
+# Simulated wireless access points (via mac80211_hwsim + hostapd) for VM /
+# testing purposes. Currently provided without DHCP and NAT, so the VM
+# will loose internet connectivity if you connect to any of them.
+#
+# Note: it will take around a minute to connect to these APs because connman
+# will wait for a (non-existent) DHCP response.
+{lib, pkgs, config, ...}:
+with lib;
+let
+  simulatedAPInterfaces = concatMap (radio: attrNames radio.networks)
+    (attrValues config.services.hostapd.radios);
+in
+{ config = {
+    networking.wireless.enable = true;
+    services.connman.enable = true;
+
+    # wlan1 is the client interface, wlan0* are the simulated APs
+    networking.wireless.interfaces = [ "wlan1" ];
+
+    # tell connman not to touch the simulated APs
+    services.connman.networkInterfaceBlacklist = simulatedAPInterfaces;
+
+    systemd.services."connman".after = [ "hostapd.service" ];
+
+    # enable 802.11 simulation
+    boot.kernelModules = [ "mac80211_hwsim" ];
+
+    services.hostapd = {
+      enable = true;
+      radios.wlan0 = {
+        band = "2g";
+        countryCode = "US";
+        # wireless access points
+        networks = {
+          wlan0 = {
+            ssid = "wpa3-wifi";
+            bssid = "02:00:00:00:00:00";
+            authentication = {
+              mode = "wpa3-sae";
+              saePasswords = [ { password = "wpa3-wifi"; } ];
+            };
+          };
+          wlan0-1 = {
+            ssid = "open-wifi";
+            bssid = "02:00:00:00:00:01";
+            authentication.mode = "none";
+          };
+          wlan0-2 = {
+            ssid = "enterprise-wifi";
+            bssid = "02:00:00:00:00:02";
+            authentication.mode = "none"; # overridden by settings below
+            settings = {
+                wpa = 3;
+                wpa_key_mgmt = "WPA-EAP";
+                auth_algs = 3;
+
+                ieee8021x = 1;
+                eap_server = 0;
+                auth_server_addr = "127.0.0.1";
+                auth_server_port = 1812;
+                auth_server_shared_secret = "secret";
+            };
+          };
+        };
+      };
+    };
+};}


### PR DESCRIPTION
1. No passphrase prompt for open wifi APs
2. Prevent users from connecting to wifi APs with unsupported protocols

Tested manually by copying the setup from `testing/integration/controller-wifi.nix` in ./build vm.

## Checklist

-   [ ] Changelog updated
-   [x] Code documented
-   [x] User manual updated
