### PR TITLE
Rename "passphrase" to "password" in GUI

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -4,15 +4,18 @@
 
 - kiosk: Migrate to Qt6
 - kiosk: Open settings with a long press on the Menu key
-- controller: Enable spatial navigation using the arrow keys
 - os: Improve installation device selection
 - os: Add end-to-end system tests
+- controller: Enable spatial navigation using the arrow keys
 - controller: Add factory reset button to System Status page
 - controller: Add system switch calls to System Status page
 
 ## Changed
 
 - driver: Bump to 2.5.0 for extended discovery time in firmware updates
+- controller: Suppress password prompt for open WiFi networks
+- controller: Explicitly mark WiFi networks with unsupported authentication methods
+- controller: Improve error messages when connecting to WiFi networks fails
 
 ## Removed
 

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -89,7 +89,7 @@ let not_connected_form service =
       (Option.to_list (maybe_elem requires_passphrase (
           label
               ~a:[ a_class [ "d-Label" ] ]
-              [ txt "Passphrase"
+              [ txt "Password"
               ; input
                   ~a:[ a_input_type `Password
                   ; a_class [ "d-Input"; "d-Network__Input" ]


### PR DESCRIPTION
I had been under the impression we already used "password". We didn't, but we should.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
