### PR TITLE
Enable read-only usage of magic-nix-cache in e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,6 @@ jobs:
         extra_nix_config: |
           system-features = nixos-test benchmark big-parallel kvm
     - uses: DeterminateSystems/magic-nix-cache-action@v8
-      with:
-        # disables _uploading_ to GHA cache - necessary because
-        # the cache has a quota of 10 GB, while the built disk
-        # is ~7GB
-        use-gha-cache: false
+    - name: Make magic-nix-cache read-only by removing post-build-hook
+      run: sed -i '/post-build-hook = magic-nix-cache-build-hook/d' $HOME/.config/nix/nix.conf
     - run: ./build test-e2e


### PR DESCRIPTION
Contrary to the documentation, turns out `use-gha-cache: false` completely disabled the GHA, i.e. everything.

Since we don't use `diff-store: true`, by removing the post-build-hook this makes the magic nix cache think that nothing was built (and hence there's nothing new to cache).

Verified nothing was added by [inspecting the Action Cache](https://github.com/dividat/playos/actions/caches?query=sort%3Asize-desc).
