### PR TITLE
Patch ppx_protocol_conv_jsonm to not have a dependency on ppxlib

### DIFF
--- a/pkgs/ocaml-modules/ppx_protocol_conv_jsonm/default.nix
+++ b/pkgs/ocaml-modules/ppx_protocol_conv_jsonm/default.nix
@@ -23,6 +23,10 @@ buildDunePackage rec {
 
   useDune2 = true;
 
+  patches = [
+    ./remove-runtime-dependency-from-ppxlib.patch
+  ];
+
   propagatedBuildInputs = [
     ppx_protocol_conv
     ezjsonm

--- a/pkgs/ocaml-modules/ppx_protocol_conv_jsonm/remove-runtime-dependency-from-ppxlib.patch
+++ b/pkgs/ocaml-modules/ppx_protocol_conv_jsonm/remove-runtime-dependency-from-ppxlib.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/jsonm/dune b/drivers/jsonm/dune
+index fb0bc81..554241f 100644
+--- a/drivers/jsonm/dune
++++ b/drivers/jsonm/dune
+@@ -1,6 +1,6 @@
+ (library
+  (name protocol_conv_jsonm)
+  (public_name ppx_protocol_conv_jsonm)
+- (libraries ppx_protocol_conv ppx_protocol_conv.runtime ppx_protocol_conv.driver ezjsonm)
++ (libraries ppx_protocol_conv.runtime ppx_protocol_conv.driver ezjsonm)
+  (synopsis "jsonm (de)serialization driver for ppx_protocol_conv based on ezjsonm")
+ )
+


### PR DESCRIPTION
See the following commit upstream for a similar change to the (yo)json driver:
https://github.com/andersfugmann/ppx_protocol_conv/commit/1be9d66f8f1ef60089d8c8f10b7135cc83fea40b

This avoids pulling in all of ppxlib (which is a good thing in general) and in particular does not pollute the global namespace with `compiler-lib` modules (which fixes the issues I was having with rebasing #194 onto `main`).

Will submit a patch upstream as well.

Side-note: it might make be useful at some point to review the current dependencies in general, because e.g. we link to `Base`, but the way it is used is redundant.