### PR TITLE
Split Update state into version info, system status and process state

### DIFF
--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -424,12 +424,12 @@ module StatusGui = struct
     ) in
     reboot ()
 
-  let get_status ~health_s ~update_s ~rauc =
+  let get_status ~health_s ~(update_s:Update.state React.signal) ~rauc =
         let health_state = health_s |> Lwt_react.S.value in
         let update_state = update_s |> Lwt_react.S.value in
         let%lwt booted_slot = Rauc.get_booted_slot rauc in
         let%lwt rauc =
-          match update_state with
+          match update_state.process_state with
           (* RAUC status is not meaningful while installing
              https://github.com/rauc/rauc/issues/416
           *)

--- a/controller/tests/server/update/outcome.ml
+++ b/controller/tests/server/update/outcome.ml
@@ -35,11 +35,11 @@ let state_matches_expected_outcome state outcome =
     | (DoNothingOrProduceWarning, UpToDate, Sleeping _) -> true
     | (DoNothingOrProduceWarning, OutOfDateVersionSelected, Sleeping _) -> true
     | (DoNothingOrProduceWarning, RebootRequired, Sleeping _) -> true
-    | (DoNothingOrProduceWarning, ReinstallRequired, Sleeping _) ->true
+    | (DoNothingOrProduceWarning, ReinstallRequired, Sleeping _) -> true
     (* should not _directly_ return to GettingVersionInfo state *) (*TODO: redundant now *)
     | (DoNothingOrProduceWarning, _, Update.GettingVersionInfo) -> false
     (* all the other state combos are treated as errors *)
-    | (DoNothingOrProduceWarning, _, _) ->false
+    | (DoNothingOrProduceWarning, _, _) -> false
 
 (** Tests if the input UpdateService run with the given [Helpers.system_slot_spec]
     [case] scenario produces the expected outcome state (defined by

--- a/controller/tests/server/update/outcome.ml
+++ b/controller/tests/server/update/outcome.ml
@@ -36,8 +36,6 @@ let state_matches_expected_outcome state outcome =
     | (DoNothingOrProduceWarning, OutOfDateVersionSelected, Sleeping _) -> true
     | (DoNothingOrProduceWarning, RebootRequired, Sleeping _) -> true
     | (DoNothingOrProduceWarning, ReinstallRequired, Sleeping _) -> true
-    (* should not _directly_ return to GettingVersionInfo state *) (*TODO: redundant now *)
-    | (DoNothingOrProduceWarning, _, Update.GettingVersionInfo) -> false
     (* all the other state combos are treated as errors *)
     | (DoNothingOrProduceWarning, _, _) -> false
 

--- a/controller/tests/server/update/outcome.ml
+++ b/controller/tests/server/update/outcome.ml
@@ -25,20 +25,21 @@ let slot_spec_to_outcome ({booted_slot; primary_slot; input_versions} : Helpers.
 (* Checks if the state returned by UpdateService matches
    the expected outcome as determined by [slot_spec_to_outcome] *)
 let state_matches_expected_outcome state outcome =
-    match (outcome, state) with
-        | (InstallVsn v1,             Update.Downloading v2) ->
-                (Semver.to_string v1) = v2
-        | (InstallVsn _,              _) ->                         false
-        | (DoNothingOrProduceWarning, Update.ErrorGettingVersionInfo _) -> true
-        | (DoNothingOrProduceWarning, Update.UpToDate _) ->                true
-        | (DoNothingOrProduceWarning, Update.OutOfDateVersionSelected) ->  true
-        | (DoNothingOrProduceWarning, Update.RebootRequired) ->            true
-        | (DoNothingOrProduceWarning, Update.ReinstallRequired) ->         true
-        (* should not _directly_ return to GettingVersionInfo state *)
-        | (DoNothingOrProduceWarning, Update.GettingVersionInfo) ->        false
-        (* all the other states are part of the installation process
-           and are treated as errors *)
-        | (DoNothingOrProduceWarning, _) ->                         false
+    let open Update in
+    match (outcome, state.system_status, state.process_state) with
+    | (InstallVsn v1, NeedsUpdate, Downloading v2) ->
+            (Semver.to_string v1) = v2 &&
+            Option.fold ~none:false ~some:(fun v -> v.latest = v1) state.version_info
+    | (InstallVsn _, _, _) -> false
+    | (DoNothingOrProduceWarning, UpdateError (ErrorGettingVersionInfo _), Sleeping _) -> true
+    | (DoNothingOrProduceWarning, UpToDate, Sleeping _) -> true
+    | (DoNothingOrProduceWarning, OutOfDateVersionSelected, Sleeping _) -> true
+    | (DoNothingOrProduceWarning, RebootRequired, Sleeping _) -> true
+    | (DoNothingOrProduceWarning, ReinstallRequired, Sleeping _) ->true
+    (* should not _directly_ return to GettingVersionInfo state *) (*TODO: redundant now *)
+    | (DoNothingOrProduceWarning, _, Update.GettingVersionInfo) -> false
+    (* all the other state combos are treated as errors *)
+    | (DoNothingOrProduceWarning, _, _) ->false
 
 (** Tests if the input UpdateService run with the given [Helpers.system_slot_spec]
     [case] scenario produces the expected outcome state (defined by
@@ -64,7 +65,7 @@ let test_slot_spec case =
         let () = Helpers.setup_mocks_from_system_slot_spec mocks case in
 
         let module UpdateServiceI = (val mocks.update_service) in
-        let%lwt out_state = UpdateServiceI.run_step GettingVersionInfo in
+        let%lwt out_state = UpdateServiceI.run_step Update.initial_state in
         if state_matches_expected_outcome out_state expected_outcome then
             Lwt.return ()
         else

--- a/controller/tests/server/update/update_prop_tests.ml
+++ b/controller/tests/server/update/update_prop_tests.ml
@@ -98,8 +98,8 @@ let test_random_failure_case =
                         (Printexc.get_backtrace ())
                         (state_seq_to_str state_seq)
 
-                | (Ok Update.GettingVersionInfo) ->
-                        Queue.push Update.GettingVersionInfo state_seq;
+                | Ok ({process_state = Update.GettingVersionInfo; _} as state) ->
+                        Queue.push state state_seq;
                         true
                 | (Ok state) ->
                         if (c < loop_lim) then
@@ -112,7 +112,7 @@ let test_random_failure_case =
                                 loop_lim
                                (state_seq_to_str state_seq)
         in
-        do_while 5 Update.GettingVersionInfo
+        do_while 5 Update.initial_state
     in
     QCheck2.Test.make
          ~count:10_000

--- a/controller/tests/server/update/update_tests.ml
+++ b/controller/tests/server/update/update_tests.ml
@@ -4,14 +4,23 @@ open Update_test_helpers
 
 (* Main test scenario: full update process *)
 let both_out_of_date ({update_client; rauc}: Helpers.test_context) =
-  let init_state = GettingVersionInfo in
   let booted_version = "10.0.0" in
   let inactive_version = "9.0.0" in
   let upstream_version = "10.0.2" in
-
+  let vsn_info = {
+      booted = Semver.of_string booted_version |> Option.get;
+      inactive = Semver.of_string inactive_version |> Option.get;
+      latest = Semver.of_string upstream_version |> Option.get;
+  } in
   let expected_bundle_name vsn =
       Mock_update_client.test_bundle_name ^ Scenario._WILDCARD_PAT ^ vsn ^ Scenario._WILDCARD_PAT
   in
+
+  let base_expected_state = {
+      version_info = Some vsn_info;
+      system_status = NeedsUpdate;
+      process_state = GettingVersionInfo
+  } in
 
   let expected_state_sequence =
     [
@@ -24,9 +33,11 @@ let both_out_of_date ({update_client; rauc}: Helpers.test_context) =
             ("BUNDLE_CONTENTS: " ^ upstream_version);
         update_client#set_latest_version upstream_version;
       );
-      Scenario.StateReached GettingVersionInfo;
-      Scenario.StateReached (Downloading upstream_version);
-      Scenario.StateReached (Installing (Scenario._WILDCARD_PAT ^ expected_bundle_name upstream_version));
+      Scenario.StateReached Update.initial_state;
+      Scenario.StateReached {base_expected_state with process_state = Downloading upstream_version};
+      Scenario.StateReached {base_expected_state with
+            process_state = (Installing (Scenario._WILDCARD_PAT ^ expected_bundle_name upstream_version));
+      };
       Scenario.ActionDone
         ( "bundle was installed into secondary slot",
           fun _ ->
@@ -37,17 +48,34 @@ let both_out_of_date ({update_client; rauc}: Helpers.test_context) =
                 upstream_version status.version
             in
             Lwt.return true );
-      Scenario.StateReached RebootRequired;
-      Scenario.StateReached GettingVersionInfo;
+      Scenario.StateReached {base_expected_state with
+        version_info = None;
+        process_state = GettingVersionInfo;
+      };
+      Scenario.StateReached {
+        version_info = Some {vsn_info with inactive = vsn_info.latest };
+        system_status = RebootRequired;
+        process_state = Sleeping Helpers.default_test_config.check_for_updates_interval;
+      };
     ]
   in
-  (expected_state_sequence, init_state)
+  (expected_state_sequence, Update.initial_state)
 
 let delete_downloaded_bundle_on_err ({update_client; rauc}: Helpers.test_context) =
   let inactive_version = "9.0.0" in
+  let booted_version = inactive_version in
   let upstream_version = "10.0.0" in
 
-  let init_state = Downloading upstream_version in
+  let vsn_info = {
+      booted = Semver.of_string booted_version |> Option.get;
+      inactive = Semver.of_string inactive_version |> Option.get;
+      latest = Semver.of_string upstream_version |> Option.get;
+  } in
+  let init_state = {
+      system_status = NeedsUpdate;
+      version_info = Some vsn_info;
+      process_state = Downloading upstream_version;
+  } in
   let expected_bundle_name vsn =
       Mock_update_client.test_bundle_name ^ Scenario._WILDCARD_PAT ^ vsn ^ Scenario._WILDCARD_PAT
   in
@@ -61,11 +89,13 @@ let delete_downloaded_bundle_on_err ({update_client; rauc}: Helpers.test_context
            as invalid by mock RAUC *)
         update_client#add_bundle upstream_version "CORRUPT_BUNDLE_CONTENTS"
       );
-      Scenario.StateReached (Downloading upstream_version);
-      Scenario.StateReached (Installing (Scenario._WILDCARD_PAT ^ expected_bundle_name upstream_version));
+      Scenario.StateReached init_state;
+      Scenario.StateReached {init_state with process_state =
+          (Installing (Scenario._WILDCARD_PAT ^ expected_bundle_name upstream_version));
+      };
       Scenario.ActionDone
         ( "bundle was deleted from path due to installation error",
-          fun (Installing path) ->
+          fun ({process_state = Installing path; _}) ->
             let status = rauc#get_slot_status SystemB in
             Alcotest.(check string)
                 "Inactive slot remains in the same version"
@@ -74,54 +104,60 @@ let delete_downloaded_bundle_on_err ({update_client; rauc}: Helpers.test_context
                 "Downloaded corrupt bundle was deleted"
                 false (Sys.file_exists path);
             Lwt.return true );
-      Scenario.StateReached (ErrorInstalling Scenario._WILDCARD_PAT);
-      Scenario.StateReached GettingVersionInfo;
+      Scenario.StateReached {init_state with
+        process_state = Sleeping Helpers.default_test_config.error_backoff_duration;
+        system_status = UpdateError (ErrorInstalling Scenario._WILDCARD_PAT);
+      };
+      Scenario.StateReached {init_state with
+        process_state = GettingVersionInfo;
+        system_status = UpdateError (ErrorInstalling Scenario._WILDCARD_PAT);
+      };
     ]
   in
   (expected_state_sequence, init_state)
 
-let sleep_after_error_or_check_test () =
-  (* long-ish timeouts, but these will run in parallel, so no biggie *)
-  let test_config = {
-    error_backoff_duration = 1.0;
-    check_for_updates_interval = 2.0;
-  } in
 
-  let ({update_service; _}: Helpers.test_context) = Helpers.init_test_deps ~test_config () in
+let sleep_on_get_version_err _ () =
+  let always_fail_gen () = Lwt.return true in
+  let { update_service ; _}: Helpers.test_context = Helpers.init_test_deps
+    ~failure_gen_upd:always_fail_gen ()
+  in
   let module UpdateServiceI = (val update_service) in
+  let init_state = Update.initial_state in
+  let expected_state = {
+      version_info = None;
+      system_status = UpdateError (ErrorGettingVersionInfo Scenario._WILDCARD_PAT);
+      process_state = Sleeping Helpers.default_test_config.error_backoff_duration;
+  } in
+  let%lwt out_state = UpdateServiceI.run_step init_state in
+  Lwt.return @@ Alcotest.check Scenario.testable_state
+    "Output state matches"
+    expected_state
+    out_state
 
-  let error_states = [
-      ErrorGettingVersionInfo "err";
-      ErrorInstalling "err";
-      ErrorDownloading "err";
-  ] in
-  let post_check_states = [
-      UpToDate (Helpers.vsn_triple_to_version_info (Helpers.v1, Helpers.v1, Helpers.v1));
-      RebootRequired;
-      OutOfDateVersionSelected;
-      ReinstallRequired;
-  ] in
 
-  let test_state expected_timeout inp_state =
-      let start_time = Unix.gettimeofday () in
-      (* NOTE: running the same step TWICE to ensure
-         that we execute the code in the same thread multiple times *)
-      let%lwt _ = UpdateServiceI.run_step inp_state in
-      let%lwt _ = UpdateServiceI.run_step inp_state in
-      let end_time = Unix.gettimeofday () in
-      let elasped_seconds = end_time -. start_time in
-      if elasped_seconds > (expected_timeout *. 2.0) then
-          Lwt.return ()
-      else
-          Lwt.return @@ Alcotest.fail @@
-            Format.sprintf "Slept shorter than expected (expected %f; slept %f) after state %s"
-                (expected_timeout *. 2.0) elasped_seconds (Helpers.statefmt inp_state)
-   in
-   Lwt.join @@
-    (List.map (test_state test_config.error_backoff_duration) error_states)
-    @
-    (List.map (test_state test_config.check_for_updates_interval) post_check_states)
-
+let sleep_on_download_err _ () =
+  let always_fail_gen () = Lwt.return true in
+  let { update_service ; _}: Helpers.test_context = Helpers.init_test_deps
+    ~failure_gen_upd:always_fail_gen ()
+  in
+  let module UpdateServiceI = (val update_service) in
+  let init_state: Update.state = {
+      version_info = Some
+        { latest = Helpers.v2; booted = Helpers.v1; inactive = Helpers.v1; };
+      system_status = NeedsUpdate;
+      process_state = Downloading (Semver.to_string Helpers.v2);
+  } in
+  let expected_state = {
+      version_info = None;
+      system_status = UpdateError (ErrorDownloading Scenario._WILDCARD_PAT);
+      process_state = Sleeping Helpers.default_test_config.error_backoff_duration;
+  } in
+  let%lwt out_state = UpdateServiceI.run_step init_state in
+  Lwt.return @@ Alcotest.check Scenario.testable_state
+    "Output state matches"
+    expected_state
+    out_state
 
 let both_newer_than_upstream =
   let input_versions = {
@@ -129,9 +165,7 @@ let both_newer_than_upstream =
         inactive = Helpers.v2;
         latest = Helpers.v1;
   } in
-  let expected_state =
-      UpToDate input_versions
-  in
+  let expected_state = UpToDate in
   Scenario.scenario_from_system_spec ~input_versions expected_state
 
 let booted_newer_secondary_older =
@@ -140,9 +174,7 @@ let booted_newer_secondary_older =
         booted = Helpers.v3;
         inactive = Helpers.v1;
   } in
-  let expected_state =
-      UpToDate input_versions
-  in
+  let expected_state = UpToDate in
   Scenario.scenario_from_system_spec ~input_versions expected_state
 
 let booted_older_secondary_newer =
@@ -151,9 +183,7 @@ let booted_older_secondary_newer =
         booted = Helpers.v1;
         inactive = Helpers.v3;
   } in
-  let expected_state =
-      OutOfDateVersionSelected
-  in
+  let expected_state = OutOfDateVersionSelected in
   Scenario.scenario_from_system_spec ~input_versions expected_state
 
 let booted_current_secondary_current =
@@ -162,9 +192,7 @@ let booted_current_secondary_current =
         booted = Helpers.v2;
         inactive = Helpers.v2;
   } in
-  let expected_state =
-      UpToDate input_versions
-  in
+  let expected_state = UpToDate in
   Scenario.scenario_from_system_spec ~input_versions expected_state
 
 let booted_current_secondary_older =
@@ -173,9 +201,7 @@ let booted_current_secondary_older =
         booted = Helpers.v2;
         inactive = Helpers.v1;
   } in
-  let expected_state =
-      UpToDate input_versions
-  in
+  let expected_state = UpToDate in
   Scenario.scenario_from_system_spec ~input_versions expected_state
 
 let booted_older_secondary_current =
@@ -184,8 +210,7 @@ let booted_older_secondary_current =
         booted = Helpers.v1;
         inactive = Helpers.v2;
   } in
-  let expected_state = OutOfDateVersionSelected
-  in
+  let expected_state = OutOfDateVersionSelected in
   Scenario.scenario_from_system_spec ~input_versions expected_state
 
 let () =
@@ -219,9 +244,10 @@ let () =
            [
              Alcotest_lwt.test_case "Delete downloaded bundle on install error"
              `Quick (fun _ () -> Scenario.run delete_downloaded_bundle_on_err);
-
-             Alcotest_lwt.test_case "Sleep for a duration after error or check"
-             `Quick (fun _ () -> sleep_after_error_or_check_test ());
+             Alcotest_lwt.test_case "Update enters sleep after get version error"
+             `Quick sleep_on_get_version_err;
+             Alcotest_lwt.test_case "Update enters sleep after get download error"
+             `Quick sleep_on_get_version_err;
            ] );
          ( "All version/slot combinations",
            List.map Outcome.test_slot_spec Helpers.all_possible_slot_spec_combos );


### PR DESCRIPTION
This refactors Update state into 3 parts:
- `process_state`, which indicates what action the Update process is currently performing (checking, downloading, installing or sleeping)
- `system_status`, which reflects what the Update process thinks is the current system state (up-to-date, needs-update, etc)
- `version_info`, which reflects the current slot and latest upstream versions.

The reason for doing this is to decompose the process transitions from the (determined) system state, as consumed by other components via the `React.Signal`. For example, this allows to observe the last `system_status` in the GUI while the Update process is performing other tasks.

Note that only the `process_state` is an input state (meaning that the behaviour of Update process depends on it), whereas the `system_status` and `version_info` are "output" states.

In theory, the basic FSM step could be refactored into something like:

        val run_step: process_state
            -> (process_state * (system_status option) * (version_info option)) Lwt.t

where the recursive loop would now `run_rec` maintain the `state` and update it's fields if the output `option`s are set. However, this splits the logic over two functions rather than one and makes it more complicated to interpret state machine.

See inline comments for explanations on some of the changes.

## Checklist

-   [ ] Changelog updated
-   [X] Code documented
-   [ ] User manual updated
