### PR TITLE
Release test disk build+upload workflow

### DIFF
--- a/.github/workflows/gen-release-summary.sh
+++ b/.github/workflows/gen-release-summary.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+RELEASE_TAG="$1"
+
+echo -e "
+# Release $RELEASE_TAG
+
+## Artifacts
+
+- Test disk: [https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-disk-$RELEASE_TAG.img.zst](https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-disk-$RELEASE_TAG.img.zst)
+
+## Changelog
+
+"
+
+earlier_rels=3 # include VALIDATION changelog in final release
+
+if [[ "$RELEASE_TAG" == *"-VALIDATION" ]]; then
+    earlier_rels=2
+fi
+
+# get changelogs up to previous $earlier_rels-1
+grep -m ${earlier_rels} -B10000 '^# ' ./Changelog.md | head -n -1 | sed -E 's/#+/\0#/'

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,68 @@
+name: Release Tag
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Make more space available on the runner
+        run: |
+          sudo rm -rf /usr/share/dotnet \
+                      /usr/local/lib/android \
+                      /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL
+
+      - uses: ./.github/actions/prep-build-env
+
+      - name: Make magic-nix-cache read-only by removing post-build-hook
+        run: sed -i '/post-build-hook = magic-nix-cache-build-hook/d' $HOME/.config/nix/nix.conf
+
+      - name: Validate tag
+        run: |
+          app_vsn="$(nix eval --raw -f application.nix 'version')"
+          if [ "$app_vsn" != "$GITHUB_REF_NAME" ]; then
+            echo "Git tag ($GITHUB_REF_NAME) does not match version in application.nix ($app_vsn), aborting!"
+            exit 1
+          fi
+
+      - name: Build release disk
+        run: ./build release-disk
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id:  ${{ secrets.TEST_DISKS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TEST_DISKS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+
+      - name: Publish to S3
+        run: ./.github/workflows/upload-test-disk.sh "$GITHUB_REF_NAME"
+
+      - name: Create Release summary
+        run: ./.github/workflows/gen-release-summary.sh "$GITHUB_REF_NAME" > ./release-notes.md
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          extra_args=""
+          if [[ "$GITHUB_REF_NAME" == *VALIDATION ]]; then
+            extra_args="--prerelease"
+          elif [[ "$GITHUB_REF_NAME" == *TEST ]]; then
+            extra_args="--draft"
+          fi
+
+          gh release create --verify-tag \
+            -F ./release-notes.md \
+            $extra_args \
+            "$GITHUB_REF_NAME"

--- a/.github/workflows/upload-test-disk.sh
+++ b/.github/workflows/upload-test-disk.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RELEASE_TAG="$1"
+
+set -euo pipefail
+set -x
+disk_path="$(readlink ./result/playos-disk-$RELEASE_TAG.img)"
+target_url="s3://dividat-playos-test-disks/by-tag/playos-disk-$RELEASE_TAG.img.zst"
+echo "Compressing and uploading test disk to: $target_url"
+zstd --stdout "$disk_path" | aws s3 cp - "$target_url"

--- a/build
+++ b/build
@@ -142,7 +142,8 @@ elif [ "$TARGET" == "release-disk" ]; then
       --arg buildInstaller false \
       --arg buildBundle false \
       --arg buildLive false \
-      --arg buildDisk true
+      --arg buildDisk true \
+      --arg extraModules '[ ./testing/system/passwordless-root.nix ]'
   )
 
 elif [ "$TARGET" == "all" ]; then

--- a/build
+++ b/build
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 {vm|develop|validation|master|stuck|lab-key|shed-key|test-e2e|all}"
+  echo "Usage: $0 {vm|develop|validation|master|stuck|lab-key|shed-key|test-e2e|release-disk|all}"
   exit 1
 }
 
@@ -131,6 +131,19 @@ elif [ "$TARGET" == "test-e2e" ]; then
   echo "Running e2e tests..."
   (set -x; nix-build $test_flags -A tests -o test-output)
   exit $(cat test-output/status)
+
+# builds a disk to be used as a base image in ./testing/release-validation.nix
+elif [ "$TARGET" == "release-disk" ]; then
+
+  (set -x; nix-build \
+      --arg kioskUrl "http://kiosk-server.local/" \
+      --arg updateUrl "http://update-server.local/" \
+      --arg buildVm false \
+      --arg buildInstaller false \
+      --arg buildBundle false \
+      --arg buildLive false \
+      --arg buildDisk true
+  )
 
 elif [ "$TARGET" == "all" ]; then
 

--- a/default.nix
+++ b/default.nix
@@ -144,6 +144,9 @@ with pkgs; stdenv.mkDerivation {
   + lib.optionalString buildLive ''
     ln -s ${components.live}/iso/${components.safeProductName}-live-${components.version}.iso $out/${components.safeProductName}-live-${components.version}.iso
   ''
+  + lib.optionalString buildDisk ''
+    ln -s ${components.disk} $out/${components.safeProductName}-disk-${components.version}.img
+  ''
   # Installer ISO image
   + lib.optionalString buildInstaller ''
     ln -s ${components.installer}/iso/${components.safeProductName}-installer-${components.version}.iso $out/${components.safeProductName}-installer-${components.version}.iso

--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,9 @@ in
 
 , applicationPath ? ./application.nix
 
+# extra modules to include in the systemImage, used in ./build release-disk
+, extraModules ? [ ]
+
   ##### Allow disabling the build of unused artifacts when developing/testing #####
 , buildVm ? true
 , buildInstaller ? true
@@ -59,6 +62,7 @@ let
     # System image as used in full installation
     systemImage = callPackage ./system-image {
         application = application;
+        extraModules = extraModules;
     };
 
     # USB live system

--- a/system-image/default.nix
+++ b/system-image/default.nix
@@ -1,5 +1,5 @@
 # Build an installable system image assuming a disk layout of a full A/B installation
-{pkgs, lib, updateCert, kioskUrl, playos-controller, application }:
+{pkgs, lib, updateCert, kioskUrl, playos-controller, application, extraModules ? [ ] }:
 with lib;
 let nixos = pkgs.importFromNixos ""; in
 (nixos {
@@ -13,7 +13,7 @@ let nixos = pkgs.importFromNixos ""; in
 
       # Application-specific module
       application.module
-    ];
+    ] ++ extraModules;
 
     # Storage
     fileSystems = {

--- a/testing/system/passwordless-root.nix
+++ b/testing/system/passwordless-root.nix
@@ -1,0 +1,3 @@
+{
+  users.users.root.initialHashedPassword = "";
+}


### PR DESCRIPTION
This is a companion to #200, but I made it into a separate PR for easier reviewing.

The PR introduces a `./build release-disk` command and a Github workflow for building+publishing the disk image for every tag pushed. One draft/preview release is available [here](https://github.com/dividat/playos/releases/tag/untagged-ad34d84bf821e12cdd8e).

I am conflicted about the `extraModules` and passwordless-root inclusion. My original idea was that the test disk image has to be identical to the real system, therefore cannot use any extra modules/configuration. However, I realized that for debugging you need root access, otherwise if tests fail it is impossible to investigate what went wrong (check logs, etc.).

An alternative would be to not include it and use SSH access for debugging, but this has several issues:
- debugging becomes impossible without access to SSH keys (e.g. for me)
- if the SSH keys get changed/rotated, they have to be "backported" and disk images have to be rebuilt for earlier releases

P.S. I will backport this workflow to 1 or 2 earlier releases (so 2024.7.0 and maybe also 2023.9.1), so that we get release disk images for them for use in tests.

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
