### PR TITLE
Make disk size logic the same for buildDisk and buildReleaseDisk

### DIFF
--- a/testing/disk/default.nix
+++ b/testing/disk/default.nix
@@ -25,7 +25,7 @@ let
 
   bootPartSizeMiB = computeImageSizeMiB rescueSystem;
   systemPartSizeMiB = computeImageSizeMiB systemImage;
-  diskSizeMiB = 10 + bootPartSizeMiB + dataPartSizeMiB + systemPartSizeMiB*2;
+  diskSizeMiB = 8 + bootPartSizeMiB + dataPartSizeMiB + systemPartSizeMiB*2 + 1;
 in vmTools.runInLinuxVM (
   runCommand "build-playos-disk"
     {


### PR DESCRIPTION
Follow-up from #218 

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
