### PR TITLE
Backport release disk to 2023.9.1

### DIFF
--- a/.github/workflows/gen-release-summary.sh
+++ b/.github/workflows/gen-release-summary.sh
@@ -32,4 +32,4 @@ echo -e "
 # print changelog since $prev_tag (exclusive)
 grep -E -B10000 "^# \[$prev_tag\]" ./Changelog.md \
     | head -n -1 \
-    | sed -E 's/#+/\0#/'
+    | sed -E 's/#+/\0##/'

--- a/.github/workflows/gen-release-summary.sh
+++ b/.github/workflows/gen-release-summary.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+RELEASE_TAG="$1"
+
+echo -e "
+# Release $RELEASE_TAG
+
+## Artifacts
+
+- Test disk: [https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-disk-$RELEASE_TAG.img.zst](https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-disk-$RELEASE_TAG.img.zst)
+
+## Changelog
+
+"
+
+earlier_rels=3 # include VALIDATION changelog in final release
+
+if [[ "$RELEASE_TAG" == *"-VALIDATION" ]]; then
+    earlier_rels=2
+fi
+
+# get changelogs up to previous $earlier_rels-1
+grep -m ${earlier_rels} -B10000 '^# ' ./Changelog.md | head -n -1 | sed -E 's/#+/\0#/'

--- a/.github/workflows/gen-release-summary.sh
+++ b/.github/workflows/gen-release-summary.sh
@@ -25,7 +25,7 @@ echo -e "
 
 ## Artifacts
 
-- Test disk: [https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-disk-$RELEASE_TAG.img.zst](https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-disk-$RELEASE_TAG.img.zst)
+- Test disk: [https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-release-disk-$RELEASE_TAG.img.zst](https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-release-disk-$RELEASE_TAG.img.zst)
 
 ## Changelog
 

--- a/.github/workflows/gen-release-summary.sh
+++ b/.github/workflows/gen-release-summary.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 
 RELEASE_TAG="$1"
 
-# find the previous "proper" release (i.e. not VALIDATION) tag
+# Find the previous "proper" release (i.e. not VALIDATION) tag.
+# Note: `--version-sort` incorrectly sorts semver pre-releases, but
+# these get filtered out later, so it does not matter.
 prev_tag="$(git tag \
-    | sort \
+    | sort --version-sort \
     | grep -B10000 "$RELEASE_TAG" \
     | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
     | head -n -1 \

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,68 @@
+name: Release Tag
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Make more space available on the runner
+        run: |
+          sudo rm -rf /usr/share/dotnet \
+                      /usr/local/lib/android \
+                      /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL
+
+      - uses: ./.github/actions/prep-build-env
+
+      - name: Make magic-nix-cache read-only by removing post-build-hook
+        run: sed -i '/post-build-hook = magic-nix-cache-build-hook/d' $HOME/.config/nix/nix.conf
+
+      - name: Validate tag
+        run: |
+          app_vsn="$(nix eval --raw -f application.nix 'version')"
+          if [ "$app_vsn" != "$GITHUB_REF_NAME" ]; then
+            echo "Git tag ($GITHUB_REF_NAME) does not match version in application.nix ($app_vsn), aborting!"
+            exit 1
+          fi
+
+      - name: Build release disk
+        run: ./build release-disk
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id:  ${{ secrets.TEST_DISKS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TEST_DISKS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+
+      - name: Publish to S3
+        run: ./.github/workflows/upload-test-disk.sh "$GITHUB_REF_NAME"
+
+      - name: Create Release summary
+        run: ./.github/workflows/gen-release-summary.sh "$GITHUB_REF_NAME" > ./release-notes.md
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          extra_args=""
+          if [[ "$GITHUB_REF_NAME" == *VALIDATION ]]; then
+            extra_args="--prerelease"
+          elif [[ "$GITHUB_REF_NAME" == *TEST ]]; then
+            extra_args="--draft"
+          fi
+
+          gh release create --verify-tag \
+            -F ./release-notes.md \
+            $extra_args \
+            "$GITHUB_REF_NAME"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Ensure KVM is usable by nix-build
         run: sudo chmod a+rwx /dev/kvm

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -15,14 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Make more space available on the runner
-        run: |
-          sudo rm -rf /usr/share/dotnet \
-                      /usr/local/lib/android \
-                      /opt/ghc \
-                      /opt/hostedtoolcache/CodeQL
-
-      - uses: ./.github/actions/prep-build-env
+      - name: Ensure KVM is usable by nix-build
+        run: sudo chmod a+rwx /dev/kvm
+        shell: bash
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            system-features = nixos-test benchmark big-parallel kvm
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Make magic-nix-cache read-only by removing post-build-hook
         run: sed -i '/post-build-hook = magic-nix-cache-build-hook/d' $HOME/.config/nix/nix.conf

--- a/.github/workflows/upload-test-disk.sh
+++ b/.github/workflows/upload-test-disk.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RELEASE_TAG="$1"
+
+set -euo pipefail
+set -x
+disk_path="$(readlink ./result/playos-disk-$RELEASE_TAG.img)"
+target_url="s3://dividat-playos-test-disks/by-tag/playos-disk-$RELEASE_TAG.img.zst"
+echo "Compressing and uploading test disk to: $target_url"
+zstd --stdout "$disk_path" | aws s3 cp - "$target_url"

--- a/.github/workflows/upload-test-disk.sh
+++ b/.github/workflows/upload-test-disk.sh
@@ -4,7 +4,7 @@ RELEASE_TAG="$1"
 
 set -euo pipefail
 set -x
-disk_path="$(readlink ./result/playos-disk-$RELEASE_TAG.img)"
-target_url="s3://dividat-playos-test-disks/by-tag/playos-disk-$RELEASE_TAG.img.zst"
-echo "Compressing and uploading test disk to: $target_url"
-zstd --stdout "$disk_path" | aws s3 cp - "$target_url"
+disk_path="$(readlink ./result/playos-release-disk-$RELEASE_TAG.img.zst)"
+target_url="s3://dividat-playos-test-disks/by-tag/playos-release-disk-$RELEASE_TAG.img.zst"
+echo "Uploading test disk to: $target_url"
+aws s3 cp "$disk_path" "$target_url"

--- a/application.nix
+++ b/application.nix
@@ -1,7 +1,7 @@
 rec {
     fullProductName = "Dividat PlayOS";
     safeProductName = "playos";
-    version = "2023.9.1";
+    version = "2023.9.1-DISK";
 
     greeting = label: ''
                                            _

--- a/build
+++ b/build
@@ -109,7 +109,8 @@ elif [ "$TARGET" == "release-disk" ]; then
       --arg buildInstaller false \
       --arg buildBundle false \
       --arg buildLive false \
-      --arg buildDisk true
+      --arg buildDisk true \
+      --arg extraModules '[ ./testing/system/passwordless-root.nix ]'
   )
 
 elif [ "$TARGET" == "default" ]; then

--- a/build
+++ b/build
@@ -102,6 +102,13 @@ elif [ "$TARGET" == "shed-key" ]; then
 # builds a disk to be used as a base image in ./testing/release-validation.nix
 elif [ "$TARGET" == "release-disk" ]; then
 
+  echo -e "
+Building release disk image for release validation tests.
+
+Note: requires around 30GiB of free space for storing the intermediate disk
+images. The final compressed disk image is much smaller (~4 GiB).
+"
+
   (set -x; nix-build \
       --arg kioskUrl "http://kiosk-server.local/" \
       --arg updateUrl "http://update-server.local/" \
@@ -109,8 +116,8 @@ elif [ "$TARGET" == "release-disk" ]; then
       --arg buildInstaller false \
       --arg buildBundle false \
       --arg buildLive false \
-      --arg buildDisk true \
-      --arg extraModules '[ ./testing/system/passwordless-root.nix ]'
+      --arg buildDisk false \
+      --arg buildReleaseDisk true
   )
 
 elif [ "$TARGET" == "default" ]; then

--- a/build
+++ b/build
@@ -99,6 +99,19 @@ elif [ "$TARGET" == "shed-key" ]; then
     --arg buildBundle false \
     --arg buildDisk false)
 
+# builds a disk to be used as a base image in ./testing/release-validation.nix
+elif [ "$TARGET" == "release-disk" ]; then
+
+  (set -x; nix-build \
+      --arg kioskUrl "http://kiosk-server.local/" \
+      --arg updateUrl "http://update-server.local/" \
+      --arg buildVm false \
+      --arg buildInstaller false \
+      --arg buildBundle false \
+      --arg buildLive false \
+      --arg buildDisk true
+  )
+
 elif [ "$TARGET" == "default" ]; then
 
   (set -x; nix-build)

--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,9 @@ in
 
 , applicationPath ? ./application.nix
 
+# extra modules to include in the systemImage, used in ./build release-disk
+, extraModules ? [ ]
+
   ##### Allow disabling the build of unused artifacts when developing/testing #####
 , buildInstaller ? true
 , buildBundle ? true
@@ -55,7 +58,10 @@ let
     updateCert = copyPathToStore updateCert;
 
     # System image as used in full installation
-    systemImage = callPackage ./system-image { application = application; };
+    systemImage = callPackage ./system-image {
+        application = application;
+        extraModules = extraModules;
+    };
 
     # USB live system
     live = callPackage ./live { application = application; };

--- a/default.nix
+++ b/default.nix
@@ -115,6 +115,9 @@ with pkgs; stdenv.mkDerivation {
   + lib.optionalString buildLive ''
     ln -s ${components.live}/iso/${components.safeProductName}-live-${components.version}.iso $out/${components.safeProductName}-live-${components.version}.iso
   ''
+  + lib.optionalString buildDisk ''
+    ln -s ${components.disk} $out/${components.safeProductName}-disk-${components.version}.img
+  ''
   # Installer ISO image
   + lib.optionalString buildInstaller ''
     ln -s ${components.installer}/iso/${components.safeProductName}-installer-${components.version}.iso $out/${components.safeProductName}-installer-${components.version}.iso

--- a/installer/install-playos/install-playos.py
+++ b/installer/install-playos/install-playos.py
@@ -12,8 +12,8 @@ import configparser
 import re
 from datetime import datetime
 
-PARTITION_SIZE_GB_SYSTEM = 10
-PARTITION_SIZE_GB_DATA = 5
+PARTITION_SIZE_GB_SYSTEM = 9
+PARTITION_SIZE_GB_DATA = 1
 
 GRUB_CFG = "@grubCfg@"
 GRUB_ENV = '/mnt/boot/grub/grubenv'

--- a/system-image/default.nix
+++ b/system-image/default.nix
@@ -1,5 +1,5 @@
 # Build an installable system image assuming a disk layout of a full A/B installation
-{pkgs, lib, updateCert, kioskUrl, playos-controller, application }:
+{pkgs, lib, updateCert, kioskUrl, playos-controller, application, extraModules ? [ ] }:
 with lib;
 let nixos = pkgs.importFromNixos ""; in
 (nixos {
@@ -13,7 +13,7 @@ let nixos = pkgs.importFromNixos ""; in
 
       # Application-specific module
       application.module
-    ];
+    ] ++ extraModules;
 
     # Storage
     fileSystems = {

--- a/testing/disk/release.nix
+++ b/testing/disk/release.nix
@@ -1,0 +1,49 @@
+# Similarly to testing/disk/default.nix, this builds a disk image containing
+# a full PlayOS installation, with these differences:
+# - It uses default system and boot partition sizes. Total disk size is ~20 GiB
+# - It produces a (sparsified) qcow2 image rather than a raw one. This reduces
+#   the image size to ~8GiB
+# - It compresses the final image using zstd to reduce disk usage.
+#   Final compressed file size is around ~4GiB.
+{ pkgs
+, lib
+, install-playos
+}:
+with pkgs;
+with lib;
+let
+  # all sizes in MiB
+  partSizes = {
+    boot = 525; # 525 MiB (matches install-playos default)
+    system = 1024 * 9;  # 9 GiB (install-playos default - 1GiB)
+    data = 400; # 400 MiB (same as testing/disk/default.nix)
+  };
+  diskSizeMiB = 8 + partSizes."boot" + partSizes."data" + (partSizes."system" * 2) + 1;
+in
+vmTools.runInLinuxVM (
+  runCommand "build-playos-release-disk"
+    {
+      buildInputs = [install-playos];
+
+      preVM = ''
+        diskImage=nixos.raw
+        truncate -s ${toString diskSizeMiB}MiB $diskImage
+      '';
+
+      postVM = ''
+        mkdir -p $out
+        ${pkgs.qemu}/bin/qemu-img convert -f raw -O qcow2 $diskImage $out/playos-disk.img
+        rm $diskImage
+        ${pkgs.zstd}/bin/zstd --rm -f $out/playos-disk.img -o $out/playos-disk.img.zst
+        diskImage=$out/playos-disk.img.zst
+      '';
+      memSize = 1024;
+    }
+    ''
+      # machine-id of development image is hardcoded.
+      install-playos \
+        --device /dev/vda \
+        --machine-id "f414cca8312548d29689ebf287fb67e0" \
+        --no-confirm
+    ''
+) + "/playos-disk.img.zst"

--- a/testing/system/passwordless-root.nix
+++ b/testing/system/passwordless-root.nix
@@ -1,0 +1,3 @@
+{
+  users.users.root.initialHashedPassword = "";
+}


### PR DESCRIPTION
Same as #219 for `2024.7.0`

PR target branch is `release/2023.9.1-DISK`.

- `./build release-disk` tested locally
- On `main`, tested that `release-validation.nix` test passes with the built release disk image as a base. Some minor adjustments needed to improve OCR, PR incoming.

Will tag and create release after PR merge.

