### PR TITLE
Support for multiple 'Power Button's

### DIFF
--- a/application/power-management/default.nix
+++ b/application/power-management/default.nix
@@ -60,7 +60,7 @@ in {
 
   systemd.services.power-button-shutdown = {
     enable = true;
-    description = "Detect Power Button key presses, by Power Button device only and not remote controls, then shutdown computer";
+    description = "Handle Power Button device key presses.";
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
       ExecStart = "${power-button-shutdown}/bin/power-button-shutdown";

--- a/application/power-management/power-button-shutdown.py
+++ b/application/power-management/power-button-shutdown.py
@@ -28,9 +28,10 @@ def get_power_button_devices():
     power_button_devices = []
     for device in devices:
         try:
-            capabilities = device.capabilities()
-            if device.name == 'Power Button' and evdev.ecodes.EV_KEY in capabilities and evdev.ecodes.KEY_POWER in capabilities[evdev.ecodes.EV_KEY]:
-                power_button_devices.append(device)
+            if device.name == 'Power Button':
+                ev_capabilities = device.capabilities().get(evdev.ecodes.EV_KEY, [])
+                if evdev.ecodes.KEY_POWER in ev_capabilities:
+                    power_button_devices.append(device)
         except Exception as e:
             logging.warning(f'Failed to inspect {device.path}: {e}')
 

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -17,6 +17,7 @@
 - controller: Suppress password prompt for open WiFi networks
 - controller: Explicitly mark WiFi networks with unsupported authentication methods
 - controller: Improve error messages when connecting to WiFi networks fails
+- os: Extend Power Button handling to multiple devices
 
 ## Removed
 

--- a/testing/integration/power-button-shutdown.nix
+++ b/testing/integration/power-button-shutdown.nix
@@ -1,0 +1,28 @@
+let
+  pkgs = import ../../pkgs { };
+in
+pkgs.testers.runNixOSTest {
+  name = "ACPI power button handling";
+
+  nodes = {
+    machine = { config, pkgs, ... }: {
+      imports = [ ../../application/power-management ];
+    };
+  };
+
+  testScript = {nodes}:
+''
+machine.start()
+machine.wait_for_unit("multi-user.target")
+machine.wait_for_console_text("Power Button")
+
+print(machine.succeed("cat /proc/bus/input/devices"))
+
+# Trigger ACPI shutdown command and expect shutdown
+machine.send_monitor_command("system_powerdown")
+machine.wait_for_console_text("Stopped target Multi-User System")
+
+# Test script does not finish on its own after shutdown
+exit(0)
+'';
+}

--- a/testing/integration/power-button-shutdown.nix
+++ b/testing/integration/power-button-shutdown.nix
@@ -10,17 +10,33 @@ pkgs.testers.runNixOSTest {
     };
   };
 
+  extraPythonPackages = ps: [
+    ps.colorama
+    ps.types-colorama
+  ];
+
   testScript = {nodes}:
 ''
-machine.start()
-machine.wait_for_unit("multi-user.target")
-machine.wait_for_console_text("Power Button")
+${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+import time
 
-print(machine.succeed("cat /proc/bus/input/devices"))
+with TestPrecondition("Power Button has been recognized"):
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_console_text("Power Button")
 
-# Trigger ACPI shutdown command and expect shutdown
-machine.send_monitor_command("system_powerdown")
-machine.wait_for_console_text("Stopped target Multi-User System")
+    print(machine.succeed("cat /proc/bus/input/devices"))
+
+with TestCase("Short press on power and sleep from regular keyboard are ignored"):
+    # https://github.com/qemu/qemu/blob/master/pc-bios/keymaps/en-us
+    machine.send_monitor_command("sendkey 0xde") # XF86PowerOff
+    machine.send_monitor_command("sendkey 0xdf") # XF86Sleep
+    time.sleep(5)
+    machine.succeed("echo still alive", timeout=1)
+
+with TestCase("ACPI shutdown command invokes shutdown"):
+    machine.send_monitor_command("system_powerdown")
+    machine.wait_for_console_text("Stopped target Multi-User System")
 
 # Test script does not finish on its own after shutdown
 exit(0)


### PR DESCRIPTION
The original special casing of 'Power Button' devices stops working (on the ASUS device) after upgrading to nixpkgs 24.11 (#184), because the system has more than one input devices with this name.

I added a basic integration test for the basic feature: Ignoring key presses from keyboards, but acting on presses from "Power Button" device.

I tried to extend the test for the multiple device scenario as well, unfortunately I ran into a seeming limitations of QEMU: It doesn't seem to be possible to rename either `usb-kbd` or `virtio-keyboard` in QEMU, so the test does not capture that multiple devices named "Power Button" are handled properly.

I also couldn't figure out how to inject long key presses.

It might be possible to use something like xdotool or evemu for complete testing.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
