### PR TITLE
Enable mouse cursor hiding when idle

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -141,6 +141,13 @@ rec {
 
         defaultSession = sessionName;
       };
+      # Hide mouse cursor when not in use
+      services.unclutter-xfixes = {
+        enable = true;
+        timeout = 10;
+        threshold = 1;
+        extraOptions = [ "start-hidden" ];
+      };
 
       # Firewall configuration
       networking.firewall = {

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -7,6 +7,7 @@
 - kiosk: Add hotplugging support for HDMI screens
 - os: Improve installation device selection
 - os: Add end-to-end system tests
+- os: Hide mouse cursor when idle
 - controller: Enable spatial navigation using the arrow keys
 - controller: Add factory reset button to System Status page
 - controller: Add system switch calls to System Status page


### PR DESCRIPTION
This lets the mouse cursor be initially hidden, appear when moved, and hidden again after 10 seconds of being idle.

The timing is chosen so that the cursor is normally hidden, but stays visible for relatively long period should someone attach and use a mouse.

We have been hiding idle cursors in the Play web app, but have found that the mouse needs to be moved once upon boot for the web app's logic to work, which leaves the cursor permanently visible in mouse free use. This seems to be a system/engine level issue, that we can not control from the web app. By moving mouse hiding to the OS we can also remove the complexity and event handling overhead from the web runtime.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
