### PR TITLE
Downgrade connman to 1.42

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,5 +1,9 @@
 # [UNRELEASED]
 
+## Changed
+
+- os: Downgrade connman to 1.42 to prevent known network issue
+
 # [2025.3.0-VALIDATION] - 2025-03-20
 
 ## Added

--- a/pkgs/connman/create-libppp-compat.h.patch
+++ b/pkgs/connman/create-libppp-compat.h.patch
@@ -1,0 +1,132 @@
+new file mode 100644
+index 000000000..eee1d09d6
+--- /dev/null
++++ b/scripts/libppp-compat.h
+@@ -0,0 +1,127 @@
++/* Copyright (C) Eivind Naess, eivnaes@yahoo.com */
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++
++#ifndef __LIBPPP_COMPAT_H__
++#define __LIBPPP_COMPAT_H__
++
++/* Define USE_EAPTLS compile with EAP TLS support against older pppd headers,
++ * pppd >= 2.5.0 use PPP_WITH_EAPTLS and is defined in pppdconf.h */
++#define USE_EAPTLS 1
++
++/* Define INET6 to compile with IPv6 support against older pppd headers,
++ * pppd >= 2.5.0 use PPP_WITH_IPV6CP and is defined in pppdconf.h */
++#define INET6 1
++
++/* PPP < 2.5.0 defines and exports VERSION which overlaps with current package VERSION define.
++ * this silly macro magic is to work around that. */
++#undef VERSION
++#include <pppd/pppd.h>
++
++#ifndef PPPD_VERSION
++#define PPPD_VERSION VERSION
++#endif
++
++#include <pppd/fsm.h>
++#include <pppd/ccp.h>
++#include <pppd/eui64.h>
++#include <pppd/ipcp.h>
++#include <pppd/ipv6cp.h>
++#include <pppd/eap.h>
++#include <pppd/upap.h>
++
++#ifdef HAVE_PPPD_CHAP_H
++#include <pppd/chap.h>
++#endif
++
++#ifdef HAVE_PPPD_CHAP_NEW_H
++#include <pppd/chap-new.h>
++#endif
++
++#ifdef HAVE_PPPD_CHAP_MS_H
++#include <pppd/chap_ms.h>
++#endif
++
++#ifndef PPP_PROTO_CHAP
++#define PPP_PROTO_CHAP 0xc223
++#endif 
++
++#ifndef PPP_PROTO_EAP
++#define PPP_PROTO_EAP  0xc227
++#endif
++
++
++#if WITH_PPP_VERSION < PPP_VERSION(2,5,0)
++
++static inline bool
++debug_on (void)
++{
++	return debug;
++}
++
++static inline const char
++*ppp_ipparam (void)
++{
++	return ipparam;
++}
++
++static inline int
++ppp_ifunit (void)
++{
++	return ifunit;
++}
++
++static inline const char *
++ppp_ifname (void)
++{
++	return ifname;
++}
++
++static inline int
++ppp_get_mtu (int idx)
++{
++	return netif_get_mtu(idx);
++}
++
++typedef enum ppp_notify
++{
++    NF_PID_CHANGE,
++    NF_PHASE_CHANGE,
++    NF_EXIT,
++    NF_SIGNALED,
++    NF_IP_UP,
++    NF_IP_DOWN,
++    NF_IPV6_UP,
++    NF_IPV6_DOWN,
++    NF_AUTH_UP,
++    NF_LINK_DOWN,
++    NF_FORK,
++    NF_MAX_NOTIFY
++} ppp_notify_t;
++
++typedef void (ppp_notify_fn) (void *ctx, int arg);
++
++static inline void
++ppp_add_notify (ppp_notify_t type, ppp_notify_fn *func, void *ctx)
++{
++	struct notifier **list[NF_MAX_NOTIFY] = {
++		[NF_PID_CHANGE  ] = &pidchange,
++		[NF_PHASE_CHANGE] = &phasechange,
++		[NF_EXIT        ] = &exitnotify,
++		[NF_SIGNALED    ] = &sigreceived,
++		[NF_IP_UP       ] = &ip_up_notifier,
++		[NF_IP_DOWN     ] = &ip_down_notifier,
++		[NF_IPV6_UP     ] = &ipv6_up_notifier,
++		[NF_IPV6_DOWN   ] = &ipv6_down_notifier,
++		[NF_AUTH_UP     ] = &auth_up_notifier,
++		[NF_LINK_DOWN   ] = &link_down_notifier,
++		[NF_FORK        ] = &fork_notifier,
++	};
++
++	struct notifier **notify = list[type];
++	if (notify) {
++		add_notifier(notify, func, ctx);
++	}
++}
++
++#endif /* #if WITH_PPP_VERSION < PPP_VERSION(2,5,0) */
++#endif /* #if__LIBPPP_COMPAT_H__ */

--- a/pkgs/connman/default.nix
+++ b/pkgs/connman/default.nix
@@ -1,0 +1,14 @@
+super:
+let
+    version = "1.42";
+in
+super.connman.overrideAttrs (old: {
+    inherit version;
+    src = super.fetchurl {
+      url = "mirror://kernel/linux/network/connman/connman-${version}.tar.xz";
+      hash = "sha256-o+a65G/Age8una48qk92Sd6JLD3mIsICg6wMqBQjwqo=";
+    };
+    patches = [
+      ./create-libppp-compat.h.patch
+    ];
+})

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -25,6 +25,7 @@ let
             ./ocaml-modules/ppx_protocol_conv_jsonm {};
       });
 
+      connman = (import ./connman) super;
     };
 
 in


### PR DESCRIPTION
This is basically squashed commits from [the DCONNMAN branch](https://github.com/dividat/playos/compare/main...yfyf:playos:build/2025.3.1-DCONNMAN).

Did a quick check with `./build vm` that `connmand --version` returns 1.42

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
