### PR TITLE
Remove magic-nix-cache since it no longer works with new GH Actions Cache

### DIFF
--- a/.github/actions/prep-build-env/action.yml
+++ b/.github/actions/prep-build-env/action.yml
@@ -10,4 +10,3 @@ runs:
       nix_path: nixpkgs=channel:nixos-unstable
       extra_nix_config: |
         system-features = nixos-test benchmark big-parallel kvm
-  - uses: DeterminateSystems/magic-nix-cache-action@v8

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -27,9 +27,6 @@ jobs:
 
       - uses: ./.github/actions/prep-build-env
 
-      - name: Make magic-nix-cache read-only by removing post-build-hook
-        run: sed -i '/post-build-hook = magic-nix-cache-build-hook/d' $HOME/.config/nix/nix.conf
-
       - name: Validate tag
         run: |
           app_vsn="$(nix eval --raw -f application.nix 'version')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prep-build-env
-    - name: Make magic-nix-cache read-only by removing post-build-hook
-      run: sed -i '/post-build-hook = magic-nix-cache-build-hook/d' $HOME/.config/nix/nix.conf
     - run: NIXPKGS_ALLOW_UNFREE=1 nix-build -A driverInteractive ${{ matrix.file }}
 
 
@@ -74,8 +72,6 @@ jobs:
                     /usr/local/lib/android \
                     /opt/ghc \
                     /opt/hostedtoolcache/CodeQL
-    - name: Make magic-nix-cache read-only by removing post-build-hook
-      run: sed -i '/post-build-hook = magic-nix-cache-build-hook/d' $HOME/.config/nix/nix.conf
     - run: ./build test-e2e
     - name: Add summary
       run: cat test-output/test-report.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This seems to currently cause massive delays to CI builds due to upload errors, see e.g. https://github.com/dividat/playos/actions/runs/15464521505/job/43533422961

See https://github.com/DeterminateSystems/magic-nix-cache/issues/123 and https://determinate.systems/posts/magic-nix-cache-free-tier-eol/

We can revert this if it gets supported again, some efforts in: https://github.com/DeterminateSystems/magic-nix-cache/pull/139

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
