### PR TITLE
Bump driver to 2.6.0

### DIFF
--- a/application/overlays/dividat-driver/default.nix
+++ b/application/overlays/dividat-driver/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.5.0";
+  version = "2.6.0";
 
 in buildGoModule rec {
 
@@ -13,7 +13,7 @@ in buildGoModule rec {
     owner = "dividat";
     repo = "driver";
     rev = version;
-    sha256 = "sha256-Xf65d3lqhqOjF+II66BhyCxINngvK5rSvSxifOlMpoY=";
+    sha256 = "sha256-ssRGJ0p2Bld5BuwyKD057NNjDS5ukk+x73DR73SrOz0=";
   };
 
   vendorHash = "sha256-Jj6aI85hZXGeWhJ8wq9MgI9uTm11tJZUdVwI90Pio4s=";

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -3,6 +3,7 @@
 ## Changed
 
 - os: Downgrade connman to 1.42 to prevent known network issue
+- driver: Upgrade to 2.6.0 for Flex v5 support
 
 # [2025.3.0-VALIDATION] - 2025-03-20
 


### PR DESCRIPTION
Tested by doing `./build vm` and checking that `curl localhost:8382` responds with driver version 2.6.0.

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
-   [ ] User manual updated
