### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: "Test"
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/dividat/playos/security/code-scanning/8](https://github.com/dividat/playos/security/code-scanning/8)

To fix the issue, we need to add a `permissions` key to restrict the GITHUB_TOKEN's privileges. Since the workflow primarily performs actions like running tests and building artifacts, it does not need write permissions. Therefore, we can set the `permissions` key at the root level of the workflow to `contents: read`, which grants read-only access to the repository contents. This ensures all jobs in the workflow inherit the least privilege unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
