### PR TITLE
Fix controller-wifi test flakiness

### DIFF
--- a/testing/integration/controller-wifi.nix
+++ b/testing/integration/controller-wifi.nix
@@ -41,6 +41,8 @@ pkgs.testers.runNixOSTest {
         networking.wireless.enable = mkOverride 0 true;
         services.connman.enable = mkOverride 0 true;
 
+        virtualisation.vlans = mkOverride 0 [ ];
+
         # wlan1 is the client interface, wlan0* are the simulated APs
         networking.wireless.interfaces = [ "wlan1" ];
 

--- a/testing/integration/controller-wifi.nix
+++ b/testing/integration/controller-wifi.nix
@@ -217,10 +217,10 @@ def service_req(service, endpoint, data=None, timeout=30):
 def remove_req(service):
     return service_req(service, "remove")
 
-def connect_req(service, passphrase=None):
+def connect_req(service, passphrase=None, timeout=30):
     data = {'passphrase': passphrase} if passphrase else None
     try:
-        return service_req(service, "connect", data=data)
+        return service_req(service, "connect", data=data, timeout=timeout)
     except Exception as e:
         print(f"Failed to connect to AP: {service['name']}")
         raise e
@@ -279,7 +279,7 @@ EAP_SERVICE = find_service_by_name("bad-ap-eap", BAD_SERVICES)
 with TestCase("controller can connect to all good APs") as t:
     for service in GOOD_SERVICES:
         passphrase = None if service['name'] == "test-ap-open" else 'reproducibility'
-        r = connect_req(service, passphrase=passphrase)
+        r = connect_req(service, passphrase=passphrase, timeout=60)
         r.raise_for_status()
         output = r.json()
         out_services = output['services']


### PR DESCRIPTION
I made a [separate branch which just runs this test 20x](https://github.com/dividat/playos/compare/main...yfyf:playos:reduce-controller-wifi-flakiness) and it seems the [timeout bump is sufficient to make it unflaky](https://github.com/yfyf/playos/actions/runs/16168742673).

The flaky tests were failing because the controller connect request was timing out when trying to connect to `test-ap-sae`. I tried also shuffling the AP order, but it was still always `test-ap-sae`. Not sure why it takes longer to connect to this specific AP, but it's probably not worth digging deeper either.