### PR TITLE
Simulate a working self-update setup in ./build vm

### DIFF
--- a/testing/system/default.nix
+++ b/testing/system/default.nix
@@ -15,8 +15,7 @@ let nixos = pkgs.importFromNixos ""; in
     application.module
 
     # Testing machinery
-    (import ./testing.nix { inherit lib pkgs kioskUrl; })
-    ./testing-wifi.nix # comment out to disable simulated wifi APs
+    ./testing.nix
   ];
   };
   system = "x86_64-linux";

--- a/testing/system/fake-rauc-boot.nix
+++ b/testing/system/fake-rauc-boot.nix
@@ -1,44 +1,58 @@
-{ pkgs, config, ...}: {
-    config = {
-        # These are sufficient to fool RAUC into thinking things are somewhat
-        # properly set up.
-        virtualisation.fileSystems."/boot" = {
+# This module sets up a boot partition and GRUB in a way that is sufficient
+# to fool RAUC into thinking things are somewhat properly set up.
+# Allows doing various tests without mocking out RAUC.
+{ pkgs, config, options, ... }:
+with pkgs;
+with lib;
+let
+    bootFsConfig = {
+        "/boot" = {
           device = "tmpfs";
           fsType = "tmpfs";
           options = [ "mode=0755" ];
+
           neededForBoot = true; # only to consolidate it with qemu-vm.nix
-                                # creating an ad-hoc /boot directory during stage-1
-        };
-        boot.kernelParams = [
-            "rauc.slot=a"
-        ];
-        boot.postBootCommands = ''
-            mkdir -p /boot/grub
-            ${pkgs.grub2_efi}/bin/grub-editenv - create
-            ${pkgs.grub2_efi}/bin/grub-editenv - set 'ORDER="a b"'
-            ${pkgs.grub2_efi}/bin/grub-editenv - set a_TRY=0
-            ${pkgs.grub2_efi}/bin/grub-editenv - set a_OK=1
-            ${pkgs.grub2_efi}/bin/grub-editenv - set b_TRY=0
-            ${pkgs.grub2_efi}/bin/grub-editenv - set b_OK=1
-            cat <<EOF > /boot/status.ini
-                [slot.system.a]
-                bundle.version=${config.playos.version}
-                installed.timestamp=2024-10-16T05:36:25.460927
-                installed.count=0
-                activated.timestamp=2024-10-16T07:55:41Z
-                activated.count=1
-
-                [slot.system.b]
-                bundle.version=${config.playos.version}
-                installed.timestamp=2024-10-16T05:37:35.663552
-                installed.count=0
-            EOF
-            '';
-
-        playos.selfUpdate = {
-          enable = true;
-          updateCert = pkgs.writeText "dummy.pem"  "";
+                                # creating an ad-hoc /boot directory during
+                                # stage-1
         };
     };
-}
+in
+{
+    fileSystems = bootFsConfig;
 
+    # this is needed for integration tests
+    virtualisation = lib.optionalAttrs (options?virtualisation.fileSystems)
+        { fileSystems = bootFsConfig; };
+
+    boot.kernelParams = [
+        "rauc.slot=a"
+    ];
+    boot.postBootCommands = ''
+        mkdir -p /boot/grub
+        ${pkgs.grub2_efi}/bin/grub-editenv - create
+        ${pkgs.grub2_efi}/bin/grub-editenv - set 'ORDER="a b"'
+        ${pkgs.grub2_efi}/bin/grub-editenv - set a_TRY=0
+        ${pkgs.grub2_efi}/bin/grub-editenv - set a_OK=1
+        ${pkgs.grub2_efi}/bin/grub-editenv - set b_TRY=0
+        ${pkgs.grub2_efi}/bin/grub-editenv - set b_OK=1
+        cat <<EOF > /boot/status.ini
+            [slot.system.a]
+            bundle.version=${config.playos.version}
+            installed.timestamp=2024-10-16T05:36:25.460927
+            installed.count=0
+            activated.timestamp=2024-10-16T07:55:41Z
+            activated.count=1
+
+            [slot.system.b]
+            bundle.version=${config.playos.version}
+            installed.timestamp=2024-10-16T05:37:35.663552
+            installed.count=0
+        EOF
+        '';
+
+    playos.selfUpdate = {
+      enable = true;
+      updateCert = pkgs.writeText "dummy.pem"  "";
+    };
+
+}

--- a/testing/system/stub-update-server.nix
+++ b/testing/system/stub-update-server.nix
@@ -1,0 +1,41 @@
+# The module also provides a stub update server service running on localhost
+{ pkgs, config, options, modulesPath, ... }:
+let
+    cfg = config.playos.testing;
+in
+with pkgs;
+with lib;
+{
+    options = {
+      playos.testing.stubUpdateServer = {
+        returnedVersion = mkOption {
+            description = "What version will the stub server returns as the latest";
+            default = "1.0.0";
+            type = types.str;
+        };
+
+        port = mkOption {
+            description = "HTTP port that the server will listen on";
+            default = 9000;
+            type = types.ints.positive;
+        };
+      };
+    };
+
+
+    config = {
+        systemd.services.stub-update-server = {
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network.target" ];
+          serviceConfig = {
+            ExecStart =
+              let
+                respond =
+                    ''echo -e "HTTP/1.1 200 OK\r\n" && echo "${cfg.stubUpdateServer.returnedVersion}"'';
+              in
+              "${pkgs.nmap}/bin/ncat -lk -p ${toString cfg.stubUpdateServer.port} -c '${respond}'";
+            Restart = "always";
+          };
+        };
+    };
+}

--- a/testing/system/testing.nix
+++ b/testing/system/testing.nix
@@ -1,10 +1,13 @@
 # Test machinery
-{lib, pkgs, kioskUrl, ...}:
+{lib, pkgs, config, modulesPath, ...}:
 
 {
   imports = [
-    (pkgs.importFromNixos "modules/profiles/qemu-guest.nix")
-    (pkgs.importFromNixos "modules/testing/test-instrumentation.nix")
+    "${modulesPath}/profiles/qemu-guest.nix"
+    "${modulesPath}/testing/test-instrumentation.nix"
+    ./testing-wifi.nix # comment out to disable simulated wifi APs
+    ./fake-rauc-boot.nix # comment out to disable RAUC/self-update
+    ./stub-update-server.nix # comment out to disable stub-update-server
   ];
 
   config = {
@@ -33,7 +36,7 @@
     # run a little bit faster for easier testing
     playos.networking.watchdog = {
         enable = true;
-        checkURLs = [ kioskUrl ];
+        checkURLs = [ config.playos.kioskUrl ];
         maxNumFailures = 3;
         checkInterval = 10;
         settingChangeDelay = 15;


### PR DESCRIPTION
This is achieved by slightly generalizing and re-using fake-rauc-boot and providing the stub server.

This was prompted by getting tired of mocking RAUC/controller to just see how the status page UI looks in the VM.