### PR TITLE
Add an S3 cache secondary substituter and post-build-hook for uploading

### DIFF
--- a/.github/actions/prep-build-env/action.yml
+++ b/.github/actions/prep-build-env/action.yml
@@ -1,12 +1,85 @@
 name: "Prepare nix build environment"
+
+inputs:
+  NIX_CACHE_ACCESS_KEY_ID:
+    description: AWS S3 bucket access key ID
+    required: false
+
+  NIX_CACHE_SECRET_ACCESS_KEY:
+    description: AWS S3 bucket secret access key
+    required: false
+
+  NIX_BINARY_CACHE_PRIVATE_KEY:
+    description: private key used for signing store paths for the nix cache
+    required: false
+
+  # these are not intended to be configurable, but there's simply no way
+  # to have constants/envs in a composite action
+  NIX_CACHE_S3_BUCKET:
+    default: dividat-ci-nix-cache
+
+  NIX_CACHE_S3_PROFILE:
+    default: nixcache
+
+  NIX_CACHE_S3_REGION:
+    default: eu-central-1
+
+  NIX_STORE_PUBLIC_KEY:
+    default: "dividat-ci-nix-cache-1:vhWwMmDRyiG7ICbeWWpC03k1XsRs2fIQB461il3EL3U="
+
+  NIX_STORE_PRIVATE_KEY_FILE:
+    default: "/etc/nix/key.private"
 runs:
   using: "composite"
   steps:
   - name: Ensure KVM is usable by nix-build
     run: sudo chmod a+rwx /dev/kvm
     shell: bash
+
+  - name: Install task-spooler
+    run: |
+      sudo apt-get update
+      sudo apt-get install -y task-spooler
+    shell: bash
+
+  - name: Write private key to file
+    shell: bash
+    if: ${{ inputs.NIX_BINARY_CACHE_PRIVATE_KEY }}
+    run: |
+      sudo mkdir -p $(dirname "${{ inputs.NIX_STORE_PRIVATE_KEY_FILE }}")
+      echo -n "${{ inputs.NIX_BINARY_CACHE_PRIVATE_KEY }}" | sudo tee "${{ inputs.NIX_STORE_PRIVATE_KEY_FILE }}"
+
+  - name: Create AWS credentials and config for profile
+    shell: bash
+    if: ${{ inputs.NIX_CACHE_ACCESS_KEY_ID && inputs.NIX_CACHE_SECRET_ACCESS_KEY }}
+    run: |
+      sudo -i aws configure set aws_access_key_id ${{ inputs.NIX_CACHE_ACCESS_KEY_ID }} --profile ${{ inputs.NIX_CACHE_S3_PROFILE}}
+      sudo -i aws configure set aws_secret_access_key ${{ inputs.NIX_CACHE_SECRET_ACCESS_KEY }} --profile ${{ inputs.NIX_CACHE_S3_PROFILE}}
+      sudo -i aws configure set region ${{ inputs.NIX_CACHE_S3_REGION }} --profile ${{ inputs.NIX_CACHE_S3_PROFILE}}
+      # Allow any user to access the AWS credentials and provide it both for
+      # current user and root, since it's tricky to ensure different nix
+      # commands (nix-build, nix copy) read from the right locations, see:
+      # https://github.com/NixOS/nix/issues/2161
+      sudo chmod -R a+rx /root/.aws
+      sudo chmod a+rx /root/
+      cp -r /root/.aws ~/.aws
+
+
+  - name: Install post-run action
+    uses: gacts/run-and-post-run@v1
+    with:
+      post: |
+        echo "Waiting for cache uploads to finish"
+        sudo -i tsp -w || true
+        sudo -i tsp -l
+
+
   - uses: cachix/install-nix-action@v18
     with:
       nix_path: nixpkgs=channel:nixos-unstable
       extra_nix_config: |
         system-features = nixos-test benchmark big-parallel kvm
+        substituters = https://cache.nixos.org/ https://${{ inputs.NIX_CACHE_S3_BUCKET }}.s3.${{ inputs.NIX_CACHE_S3_REGION }}.amazonaws.com
+        trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ inputs.NIX_STORE_PUBLIC_KEY }}
+        ${{ inputs.NIX_CACHE_SECRET_ACCESS_KEY && format('post-build-hook = {0}/.github/workflows/upload-to-s3-cache.sh', github.workspace) || '' }}
+        ${{ inputs.NIX_BINARY_CACHE_PRIVATE_KEY && format('secret-key-files = {0}', inputs.NIX_STORE_PRIVATE_KEY_FILE) || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prep-build-env
+      with:
+        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+        NIX_BINARY_CACHE_PRIVATE_KEY: ${{ secrets.NIX_BINARY_CACHE_PRIVATE_KEY }}
     - run: NIXPKGS_ALLOW_UNFREE=1 nix-build ${{ matrix.file }}
 
 
@@ -44,6 +48,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prep-build-env
+      with:
+        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+        NIX_BINARY_CACHE_PRIVATE_KEY: ${{ secrets.NIX_BINARY_CACHE_PRIVATE_KEY }}
     - run: NIXPKGS_ALLOW_UNFREE=1 nix-build -A driverInteractive ${{ matrix.file }}
 
 
@@ -52,6 +60,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prep-build-env
+      with:
+        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+        NIX_BINARY_CACHE_PRIVATE_KEY: ${{ secrets.NIX_BINARY_CACHE_PRIVATE_KEY }}
     - run: cd kiosk && nix-shell --run bin/test
 
   build-vm:
@@ -59,6 +71,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prep-build-env
+      with:
+        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+        NIX_BINARY_CACHE_PRIVATE_KEY: ${{ secrets.NIX_BINARY_CACHE_PRIVATE_KEY }}
     - run: NIXPKGS_ALLOW_UNFREE=1 ./build vm
 
   e2e-tests:
@@ -66,6 +82,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prep-build-env
+      with:
+        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+        NIX_BINARY_CACHE_PRIVATE_KEY: ${{ secrets.NIX_BINARY_CACHE_PRIVATE_KEY }}
     - name: Make more space available on the runner
       run: |
         sudo rm -rf /usr/share/dotnet \
@@ -82,6 +102,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prep-build-env
+      with:
+        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+        NIX_BINARY_CACHE_PRIVATE_KEY: ${{ secrets.NIX_BINARY_CACHE_PRIVATE_KEY }}
     - run: cd controller && nix-shell --run 'bin/test --force --no-buffer'
 
   ocaml-formatting:
@@ -89,4 +113,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/prep-build-env
+      with:
+        NIX_CACHE_ACCESS_KEY_ID: ${{ secrets.NIX_CACHE_ACCESS_KEY_ID }}
+        NIX_CACHE_SECRET_ACCESS_KEY: ${{ secrets.NIX_CACHE_SECRET_ACCESS_KEY }}
+        NIX_BINARY_CACHE_PRIVATE_KEY: ${{ secrets.NIX_BINARY_CACHE_PRIVATE_KEY }}
     - run: cd controller && nix-shell --run 'dune build @fmt'

--- a/.github/workflows/upload-to-s3-cache.sh
+++ b/.github/workflows/upload-to-s3-cache.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+set -f # disable globbing
+export IFS=' '
+
+export S3_BUCKET=${S3_BUCKET:-dividat-ci-nix-cache}
+export S3_BUCKET_PARAMS=${S3_BUCKET_PARAMS:-compression=zstd&profile=nixcache&region=eu-central-1}
+# see https://github.com/NixOS/nix/issues/4902
+export PATH=$PATH:/nix/var/nix/profiles/default/bin
+
+# how many uploads to perform in parallel
+export TS_SLOTS=10
+
+# exclude closures larger than 3GB to avoid polluting the cache
+SMALL_OUT_PATHS="$(nix path-info -S $OUT_PATHS | awk '{if ($2 < 10 ^ 9 * 3) print $1;}')"
+BIG_PATHS=$(comm -23 \
+    <(tr ' ' '\n' <<<"$OUT_PATHS" | sort) \
+    <(tr ' ' '\n' <<<"$SMALL_OUT_PATHS" | sort) \
+        | tr '\n' ' ')
+
+if ! [[ -z "$BIG_PATHS" ]]; then
+    echo "Skipping large paths:"
+    nix path-info -Sh $BIG_PATHS
+fi
+
+if ! [[ -z "$SMALL_OUT_PATHS" ]]; then
+    echo "Queuing cache upload of: $SMALL_OUT_PATHS"
+    # Running with `sudo -i` to ensure `tsp` is sharing a single queue owned by root
+    sudo -i tsp nix copy --to "s3://${S3_BUCKET}?${S3_BUCKET_PARAMS}" $SMALL_OUT_PATHS
+else
+    echo "Nothing to upload after filtering!"
+fi


### PR DESCRIPTION
This was painful and took much longer due to the slow and obscure feedback loop of Github Actions. See comments/referenced issues for details.

Anyway, everything seems to work:
- builds are signed and uploaded: https://github.com/dividat/playos/actions/runs/16420048350/job/46395839724#step:7:6 (you can verify locally with e.g. `nix store verify --store https://dividat-ci-nix-cache.s3.eu-central-1.amazonaws.com/ /nix/store/pvnw37av6397kv3xwykda7my9n3k58cp-string-hosts` if you add the public key to `trusted-public-keys`)
- cache is accessible on forks for reads: https://github.com/yfyf/playos/actions
- large closures are being skipped: https://github.com/dividat/playos/actions/runs/16420048350/job/46395839729#step:4:4698

Regarding the last point - it would be preferable to skip not whole closures, but individual derivations/packages, but `nix copy` operates on closures, so I don't think that's possible.