### PR TITLE
Make network interface getter more robust

### DIFF
--- a/controller/server/network.mli
+++ b/controller/server/network.mli
@@ -15,9 +15,5 @@ module Interface : sig
 
   val to_json : t -> Ezjsonm.value
 
-  (** Get all available interfaces.
-
-      This uses the Linux `ip` utility.
-  *)
   val get_all : unit -> t list Lwt.t
 end


### PR DESCRIPTION
On my dev machine, the network overview page could not be opened (just displayed a `Not found`). The reason turned out to be that there is an LTE modem in my laptop (interface name `wwan0`), for which `ip -j link` did not report an `address` field, and so parsing failed with an exception.

As we are practically only interested in interface types which always have a link layer address, and other types can not even be configured through our UI, skip entries which do not parse into our expected format.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
