### PR TITLE
Add the ability to label connected network services with discovered services

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -214,6 +214,8 @@ rec {
 
       # Enable avahi for Senso discovery
       services.avahi.enable = true;
+      # Mark network services with discoverable Sensos
+      playos.controller.annotateDiscoveredServices = [ "_sensoControl._tcp" "_sensoUpdate._udp" ];
 
       # Enable pcscd for smart card identification
       services.pcscd.enable = true;

--- a/base/controller-service.nix
+++ b/base/controller-service.nix
@@ -1,6 +1,31 @@
 { config, pkgs, lib, playos-controller }:
+let
+  cfg = config.playos.controller;
+  hasAnnotatedServices = cfg.annotateDiscoveredServices != [];
+in
+with lib;
 {
+  options = {
+    playos.controller = {
+      annotateDiscoveredServices = mkOption {
+        default = [];
+        example = [ "_ftp._tcp" ];
+        description = "DNS-SD service types to browse for and annotate networks with in controller UI"; 
+        type = types.listOf types.str;
+      };
+    };
+  };
+
   config = {
+    assertions = [
+      {
+        assertion = !(hasAnnotatedServices && config.services.avahi.enable == false);
+        message   = "playos.controller.annotateDiscoveredServices requires avahi to be enabled.";
+      }
+    ];
+
+    services.avahi.enable = mkIf hasAnnotatedServices true;
+
     systemd.services.playos-controller = {
       description = "PlayOS Controller";
       serviceConfig = {
@@ -12,6 +37,12 @@
       wantedBy = [ "multi-user.target" ];
       requires = [ "connman.service" ];
       after = [ "rauc.service" "connman.service" ];
+      # DNS-SD annotations
+      path = mkIf hasAnnotatedServices [ pkgs.avahi ];
+      environment = {
+        PLAYOS_ANNOTATE_DISCOVERED_SERVICES =
+          mkIf hasAnnotatedServices (concatStringsSep ";" cfg.annotateDiscoveredServices);
+      };
     };
   };
 

--- a/base/controller-service.nix
+++ b/base/controller-service.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, lib, playos-controller }:
+{
+  config = {
+    systemd.services.playos-controller = {
+      description = "PlayOS Controller";
+      serviceConfig = {
+        ExecStart = "${playos-controller}/bin/playos-controller";
+        User = "root";
+        RestartSec = "10s";
+        Restart = "always";
+      };
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "connman.service" ];
+      after = [ "rauc.service" "connman.service" ];
+    };
+  };
+
+}

--- a/base/controller-service.nix
+++ b/base/controller-service.nix
@@ -19,8 +19,8 @@ with lib;
   config = {
     assertions = [
       {
-        assertion = !(hasAnnotatedServices && config.services.avahi.enable == false);
-        message   = "playos.controller.annotateDiscoveredServices requires avahi to be enabled.";
+        assertion = !hasAnnotatedServices || config.services.avahi.enable;
+        message = "playos.controller.annotateDiscoveredServices requires avahi to be enabled.";
       }
     ];
 

--- a/base/controller-service.nix
+++ b/base/controller-service.nix
@@ -26,24 +26,49 @@ with lib;
 
     services.avahi.enable = mkIf hasAnnotatedServices true;
 
-    systemd.services.playos-controller = {
-      description = "PlayOS Controller";
-      serviceConfig = {
-        ExecStart = "${playos-controller}/bin/playos-controller";
-        User = "root";
-        RestartSec = "10s";
-        Restart = "always";
+    systemd.services =
+    let
+      systemdServices = {
+        playos-controller = {
+          description = "PlayOS Controller";
+          serviceConfig = {
+            ExecStart = "${playos-controller}/bin/playos-controller";
+            User = "root";
+            RestartSec = "10s";
+            Restart = "always";
+          };
+          wantedBy = [ "multi-user.target" ];
+          requires = [ "connman.service" ];
+          after = [ "rauc.service" "connman.service" ];
+          # DNS-SD annotations
+          path = mkIf hasAnnotatedServices [ pkgs.avahi ];
+          environment = {
+            PLAYOS_ANNOTATE_DISCOVERED_SERVICES =
+              mkIf hasAnnotatedServices (concatStringsSep ";" cfg.annotateDiscoveredServices);
+          };
+        };
       };
-      wantedBy = [ "multi-user.target" ];
-      requires = [ "connman.service" ];
-      after = [ "rauc.service" "connman.service" ];
-      # DNS-SD annotations
-      path = mkIf hasAnnotatedServices [ pkgs.avahi ];
-      environment = {
-        PLAYOS_ANNOTATE_DISCOVERED_SERVICES =
-          mkIf hasAnnotatedServices (concatStringsSep ";" cfg.annotateDiscoveredServices);
-      };
-    };
+    in
+    # Create a proactive service browser for each annotated service type
+    # This ensures that we don't rely on the application's actions for letting
+    # avahi build a service table.
+    lib.foldl' (acc: serviceType:
+      acc // {
+        "avahi-browse-${lib.escapeShellArg serviceType}" = {
+          description = "Proactively browse DNS-SD for ${serviceType}";
+          after = [ "avahi-daemon.service" ];
+          requires = [ "avahi-daemon.service" ];
+
+          serviceConfig = {
+            ExecStart = "${pkgs.avahi}/bin/avahi-browse -r ${serviceType}";
+            Restart = "always";
+            RestartSec = "5s";
+          };
+
+          wantedBy = [ "multi-user.target" ];
+        };
+      }
+    ) systemdServices cfg.annotateDiscoveredServices;
   };
 
 }

--- a/base/controller-service.nix
+++ b/base/controller-service.nix
@@ -60,7 +60,7 @@ with lib;
           requires = [ "avahi-daemon.service" ];
 
           serviceConfig = {
-            ExecStart = "${pkgs.avahi}/bin/avahi-browse -r ${serviceType}";
+            ExecStart = "${pkgs.avahi}/bin/avahi-browse ${serviceType}";
             Restart = "always";
             RestartSec = "5s";
           };

--- a/base/default.nix
+++ b/base/default.nix
@@ -9,6 +9,7 @@ with lib;
 {
   imports = [
     (import ./networking/default.nix { hostName = safeProductName; inherit lib pkgs config; })
+    (import ./controller-service.nix { inherit config lib pkgs playos-controller; })
     ./networking/watchdog
     ./hardening.nix
     ./localization.nix
@@ -53,20 +54,6 @@ with lib;
     # 'Welcome Screen'
     services.getty = {
       greetingLine = greeting "${fullProductName} (${version})";
-    };
-
-    # Start controller
-    systemd.services.playos-controller = {
-      description = "PlayOS Controller";
-      serviceConfig = {
-        ExecStart = "${playos-controller}/bin/playos-controller";
-        User = "root";
-        RestartSec = "10s";
-        Restart = "always";
-      };
-      wantedBy = [ "multi-user.target" ];
-      requires = [ "connman.service" ];
-      after = [ "rauc.service" "connman.service" ];
     };
 
   };

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -5,7 +5,7 @@
 - os: Add network watchdog
 - kiosk: Add virtual keyboard
 - kiosk: Auto-disable virtual keyboard when real keyboard detected
-- controller: Show a label for networks that contain a Senso
+- controller: Show a label for networks in which a Senso is found
 
 # [2025.3.1] - 2025-07-04
 

--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -5,6 +5,7 @@
 - os: Add network watchdog
 - kiosk: Add virtual keyboard
 - kiosk: Auto-disable virtual keyboard when real keyboard detected
+- controller: Show a label for networks that contain a Senso
 
 # [2025.3.1] - 2025-07-04
 

--- a/controller/Readme.md
+++ b/controller/Readme.md
@@ -46,6 +46,10 @@ Run `nix-shell` to create a suitable development environment.
 
 Then, start the the controller with `bin/dev-server`.
 
+## Configuration in testing
+
+- To define which DNS-SD service types are used to label networks, set `PLAYOS_ANNOTATE_DISCOVERED_SERVICES` to a semicolon-separated list of service types.
+
 ## Code style
 
 - Author CSS according to the [BEM methodology](http://getbem.com/) in the format `d-Block__Element--Modifier`.

--- a/controller/bindings/avahi/avahi.ml
+++ b/controller/bindings/avahi/avahi.ml
@@ -83,7 +83,7 @@ module Service = struct
    *)
   let get_all ?(timeout_seconds = 0.2) () =
     let cmd =
-      [| "/run/current-system/sw/bin/avahi-browse"
+      [| "avahi-browse"
        ; "--all"
        ; "--parsable"
        ; "--cache" (* print cache and exit immediately *)

--- a/controller/bindings/avahi/avahi.ml
+++ b/controller/bindings/avahi/avahi.ml
@@ -73,7 +73,7 @@ module Service = struct
     | _ ->
         None
 
-  (* Gets all announced services of any type known to avahi at time of call.
+  (* Gets all services of the given type known to avahi at time of call.
 
      We race with a timeout because avahi is rumored to block even when
      only the cached table is requested: https://github.com/avahi/avahi/issues/264
@@ -81,12 +81,12 @@ module Service = struct
      In case of timeout we return an empty list of services.
 
    *)
-  let get_all ?(timeout_seconds = 0.2) () =
+  let get_service_type ?(timeout_seconds = 0.2) service_type =
     let cmd =
       [| "avahi-browse"
-       ; "--all"
        ; "--parsable"
        ; "--cache" (* print cache and exit immediately *)
+       ; service_type
       |]
     in
     let query =

--- a/controller/bindings/avahi/avahi.ml
+++ b/controller/bindings/avahi/avahi.ml
@@ -1,0 +1,100 @@
+open Lwt
+
+module Service = struct
+  type t =
+    { service_name : string
+    ; service_type : string
+    ; interface : string
+    }
+
+  (** Decodes an escaped service instance name.
+
+      avahi produces UTF-8 output, but encodes any but a few "known-good" ASCII
+      bytes when printing the instance name in the parsable form:
+
+        - [-_a-zA-Z0-9] are printed directly
+        - \ and . are escaped with a backslash
+        - any other byte value is output as three digit decimal \ddd
+
+      https://github.com/avahi/avahi/blob/2bb03084505fb9e2041ee8083a0ca08f1665f0f5/avahi-common/domain.c#L116
+
+      This decoding function is more lax than it could be and copies
+      non-escaped characters directly instead of verifying they are from
+      avahi's "direct" range.
+
+  *)
+  let unescape_label s =
+    let len = String.length s in
+    let buf = Buffer.create len in
+    let is_digit c = c >= '0' && c <= '9' in
+    let rec loop i =
+      if i >= len then
+        (* Whole string has been processed *)
+        Some (Buffer.contents buf)
+      else if s.[i] <> '\\' then (
+        (* Not an escape sequence, copy the character *)
+        Buffer.add_char buf s.[i] ;
+        loop (i + 1)
+      )
+      else if i + 1 < len && (s.[i + 1] = '\\' || s.[i + 1] = '.') then (
+        (* Escaped backslash or dot *)
+        Buffer.add_char buf s.[i + 1] ;
+        loop (i + 2)
+      )
+      else if
+        i + 3 < len
+        && is_digit s.[i + 1]
+        && is_digit s.[i + 2]
+        && is_digit s.[i + 3]
+      then
+        (* Three-digit escape string '\ddd' *)
+        match int_of_string_opt (String.sub s (i + 1) 3) with
+        | Some code when code <= 255 ->
+            Buffer.add_char buf (Char.chr code) ;
+            loop (i + 4)
+        | _ ->
+            (* Out of range code *)
+            None
+      else
+        (* Malformed escape sequence *)
+        None
+    in
+    loop 0
+
+  let parse_service line =
+    match String.split_on_char ';' line with
+    (* e.g. +;eth1;IPv4;MyPrinter;_myprinter._tcp;local *)
+    | [ _; iface; _; name; stype; _ ] ->
+        Some
+          { service_name = unescape_label name |> Option.value ~default:name
+          ; service_type = stype
+          ; interface = iface
+          }
+    | _ ->
+        None
+
+  (* Gets all announced services of any type known to avahi at time of call.
+
+     We race with a timeout because avahi is rumored to block even when
+     only the cached table is requested: https://github.com/avahi/avahi/issues/264
+
+     In case of timeout we return an empty list of services.
+
+   *)
+  let get_all ?(timeout_seconds = 0.2) () =
+    let cmd =
+      [| "/run/current-system/sw/bin/avahi-browse"
+       ; "--all"
+       ; "--parsable"
+       ; "--cache" (* print cache and exit immediately *)
+      |]
+    in
+    let query =
+      ("", cmd)
+      |> Lwt_process.pread_lines
+      |> Lwt_stream.to_list
+      >|= List.filter_map parse_service
+    in
+    let timeout = Lwt_unix.sleep timeout_seconds >|= fun () -> [] in
+    Lwt.pick [ query; timeout ]
+end

--- a/controller/bindings/avahi/avahi.mli
+++ b/controller/bindings/avahi/avahi.mli
@@ -5,7 +5,7 @@ module Service : sig
     ; interface : string
     }
 
-  val get_all : ?timeout_seconds:float -> unit -> t list Lwt.t
+  val get_service_type : ?timeout_seconds:float -> string -> t list Lwt.t
 
   (* Exposed for unit tests *)
   val unescape_label : string -> string option

--- a/controller/bindings/avahi/avahi.mli
+++ b/controller/bindings/avahi/avahi.mli
@@ -1,0 +1,11 @@
+module Service : sig
+  type t =
+    { service_name : string
+    ; service_type : string
+    ; interface : string
+    }
+
+  val unescape_label : string -> string option
+
+  val get_all : ?timeout_seconds:float -> unit -> t list Lwt.t
+end

--- a/controller/bindings/avahi/avahi.mli
+++ b/controller/bindings/avahi/avahi.mli
@@ -5,7 +5,8 @@ module Service : sig
     ; interface : string
     }
 
-  val unescape_label : string -> string option
-
   val get_all : ?timeout_seconds:float -> unit -> t list Lwt.t
+
+  (* Exposed for unit tests *)
+  val unescape_label : string -> string option
 end

--- a/controller/bindings/avahi/avahi_test.ml
+++ b/controller/bindings/avahi/avahi_test.ml
@@ -1,0 +1,28 @@
+open Alcotest
+
+let decode input expected () =
+  check (option string) "same string" (Some expected)
+    (Avahi.Service.unescape_label input)
+
+let fail input () =
+  check (option string) "no output" None (Avahi.Service.unescape_label input)
+
+let suite =
+  [ ("empty string", `Quick, decode "" "")
+  ; ("no escape strings", `Quick, decode "printer_foo" "printer_foo")
+  ; ("leading space", `Quick, decode "\\032start" " start")
+  ; ("space", `Quick, decode "ho\\032ho" "ho ho")
+  ; ("closing space", `Quick, decode "\\032start" " start")
+  ; ("exclaim", `Quick, decode "warn\\033" "warn!")
+  ; ("slash", `Quick, decode "path\\047to" "path/to")
+  ; ("emoji", `Quick, decode "Hi\\032\\240\\159\\152\\132" "Hi 😄")
+  ; ("dot is de-escaped", `Quick, decode "foo\\.bar" "foo.bar")
+  ; ("backslash is de-escaped", `Quick, decode "\\\\" "\\")
+  ; ("escaped alnum are accepted", `Quick, decode "\\065\\066\\049" "AB1")
+  ; ("escaped dot is accepted", `Quick, decode "foo\\046bar" "foo.bar")
+  ; ("unescaped space is accepted", `Quick, decode " " " ")
+  ; ("illegal code fails", `Quick, fail "\\333")
+  ; ("single backslash fails", `Quick, fail "\\")
+  ]
+
+let () = Alcotest.run "Avahi" [ ("decode_instance_name", suite) ]

--- a/controller/bindings/avahi/dune
+++ b/controller/bindings/avahi/dune
@@ -1,0 +1,11 @@
+(library
+ (name avahi)
+ (modules avahi)
+ (libraries base config lwt lwt.unix)
+ (preprocess
+  (pps lwt_ppx)))
+
+(test
+ (name avahi_test)
+ (modules avahi_test)
+ (libraries avahi alcotest base config lwt lwt.unix))

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -220,6 +220,20 @@ html {
     background: #E0CB52;
 }
 
+.d-NetworkList__Labels {
+  margin-left: var(--spacing-cat);
+  display: inline-flex;
+  gap: var(--spacing-mouse);
+}
+
+.d-NetworkList__Label {
+  color: var(--color-hint);
+  border: 2px solid var(--color-hint);
+  border-radius: var(--box-radius);
+  padding: var(--spacing-cat);
+  font-size: small;
+}
+
 .d-NetworkList__Address {
   color: var(--color-hint);
   font-size: small;

--- a/controller/gui/style.css
+++ b/controller/gui/style.css
@@ -28,6 +28,9 @@
     --font-size-rhino: 3.375rem;
     --font-size-elephant: 4.25rem;
     --font-size-mammoth: 5.25rem;
+
+    /* Common styles */
+    --box-radius: 0.4rem;
 }
 
 /* Layout */
@@ -427,11 +430,10 @@ html {
 }
 
 .d-Markdown code {
-    background-color: gray;
     padding: .2rem .5rem;
     background: #f1f1f1;
     border: 1px solid #e1e1e1;
-    border-radius: 4px;
+    border-radius: var(--box-radius);
 }
 
 /* Loading */
@@ -472,7 +474,7 @@ html {
     background-color: #F1F1F1;
     color: #606060;
     border: 0.1rem solid #E1E1E1;
-    border-radius: 0.4rem;
+    border-radius: var(--box-radius);
     padding: 0.2rem 0.5rem;
 }
 

--- a/controller/server/dune
+++ b/controller/server/dune
@@ -33,6 +33,7 @@
   tyxml
   rauc
   zerotier
+  avahi
   connman
   locale
   network

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -223,10 +223,9 @@ module NetworkGui = struct
       get_env_list "PLAYOS_ANNOTATE_DISCOVERED_SERVICES"
     in
     let%lwt annotated_services =
-      Avahi.Service.get_all ()
-      >|= List.filter (fun (s : Avahi.Service.t) ->
-              List.mem s.service_type annotated_service_types
-          )
+      annotated_service_types
+      |> Lwt_list.map_p Avahi.Service.get_service_type
+      >|= List.concat
     in
     interfaces
     |> List.map (fun (interface : Network.Interface.t) ->

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -219,20 +219,20 @@ module NetworkGui = struct
      by network interface.
   *)
   let interface_annotations interfaces =
-    let open Avahi.Service in
-    let open Network.Interface in
     let annotated_service_types =
       get_env_list "PLAYOS_ANNOTATE_DISCOVERED_SERVICES"
     in
     let%lwt annotated_services =
       Avahi.Service.get_all ()
-      >|= List.filter (fun s -> List.mem s.service_type annotated_service_types)
+      >|= List.filter (fun (s : Avahi.Service.t) ->
+              List.mem s.service_type annotated_service_types
+          )
     in
     interfaces
-    |> List.map (fun interface ->
+    |> List.map (fun (interface : Network.Interface.t) ->
            ( interface.name
            , List.filter_map
-               (fun s ->
+               (fun (s : Avahi.Service.t) ->
                  if s.interface = interface.name then Some s.service_name
                  else None
                )

--- a/controller/server/view/network_list_page.ml
+++ b/controller/server/view/network_list_page.ml
@@ -3,7 +3,7 @@ open Tyxml.Html
 open Sexplib.Std
 open Protocol_conv_jsonm
 
-let service_item ({ id; name; strength; ipv4 } as service) =
+let service_item get_labels ({ id; name; strength; ipv4 } as service) =
   let icon =
     match strength with
     | Some s ->
@@ -18,10 +18,17 @@ let service_item ({ id; name; strength; ipv4 } as service) =
       [ "d-NetworkList__Network--Connected" ]
     else []
   in
+  let labels =
+    get_labels service
+    |> List.map (fun label_text ->
+           span ~a:[ a_class [ "d-NetworkList__Label" ] ] [ txt label_text ]
+       )
+  in
   li
     [ a
         ~a:[ a_class classes; a_href ("/network/" ^ id) ]
-        [ div [ txt name ]
+        [ div
+            [ txt name; span ~a:[ a_class [ "d-NetworkList__Labels" ] ] labels ]
         ; ( match ipv4 with
           | Some ipv4_addr ->
               div
@@ -39,10 +46,11 @@ type params =
   { proxy : string option
   ; services : Connman.Service.t list
   ; interfaces : Network.Interface.t list
+  ; interface_annotations : (string * string list) list
   }
 [@@deriving protocol ~driver:(module Jsonm)]
 
-let html { proxy; services; interfaces } =
+let html { proxy; services; interfaces; interface_annotations } =
   let connected_services, available_services =
     List.partition Connman.Service.is_connected services
   in
@@ -50,6 +58,10 @@ let html { proxy; services; interfaces } =
     interfaces
     |> [%sexp_of: Network.Interface.t list]
     |> Sexplib.Sexp.to_string_hum
+  in
+  let get_labels service =
+    List.assoc_opt service.ethernet.interface interface_annotations
+    |> Option.value ~default:[]
   in
   Page.html ~current_page:Page.Network
     ~header:
@@ -64,7 +76,7 @@ let html { proxy; services; interfaces } =
              section
                [ ul
                    ~a:[ a_class [ "d-NetworkList" ]; a_role [ "list" ] ]
-                   (List.map service_item connected_services)
+                   (List.map (service_item get_labels) connected_services)
                ]
          )
        ; Definition.list
@@ -96,7 +108,7 @@ let html { proxy; services; interfaces } =
                else
                  ul
                    ~a:[ a_class [ "d-NetworkList" ]; a_role [ "list" ] ]
-                   (List.map service_item available_services)
+                   (List.map (service_item (fun _ -> [])) available_services)
              )
            ]
        ; section

--- a/controller/server/view/network_list_page.mli
+++ b/controller/server/view/network_list_page.mli
@@ -4,6 +4,7 @@ type params =
   { proxy : string option
   ; services : Connman.Service.t list
   ; interfaces : Network.Interface.t list
+  ; interface_annotations : (string * string list) list
   }
 [@@deriving protocol ~driver:(module Jsonm)]
 

--- a/testing/integration/controller-interface-labeling.nix
+++ b/testing/integration/controller-interface-labeling.nix
@@ -1,0 +1,116 @@
+let
+  pkgs = import ../../pkgs { };
+
+  # Boilerplate params for PlayOS controller
+  version = "1.1.1-TEST";
+  greeting = s: "hello: ${s}";
+  updateUrl = "http://update-server.local/";
+  kioskUrl = "http://127.0.0.1:3355";
+
+  playos-controller = import ../../controller {
+    inherit pkgs version updateUrl kioskUrl;
+    bundleName = "playos-bundle";
+  };
+in
+pkgs.testers.runNixOSTest {
+  name = "Controller labeling network services";
+
+  nodes = {
+    senso = { config, pkgs, ... }: {
+      services.avahi = {
+        enable = true;
+        nssmdns4 = true;
+
+        publish = {
+          enable = true;
+          addresses = true;
+          domain = true;
+          userServices = true;
+          workstation = true;
+        };
+      };
+
+      environment.systemPackages = [ pkgs.avahi ];
+    };
+
+    playos_with_avahi = { config, ... }: {
+      imports = [
+        (import ../../base {
+          inherit pkgs kioskUrl playos-controller greeting version;
+          fullProductName = "playos_with_avahi";
+          safeProductName = "playos_with_avahi";
+        })
+      ];
+
+      config = {
+        services.connman.enable = pkgs.lib.mkOverride 0 true; # disabled in runNixOSTest by default
+
+        playos.controller.annotateDiscoveredServices = [ "_soundso._tcp" ];
+
+        playos.storage = {
+          persistentDataPartition = {
+            device = "tmpfs";
+            fsType = "tmpfs";
+            options = [ "mode=0755" ];
+          };
+        };
+      };
+    };
+
+    playos_no_avahi = { config, ... }: {
+      imports = [
+        (import ../../base {
+          inherit pkgs kioskUrl playos-controller greeting version;
+          fullProductName = "playos_no_avahi";
+          safeProductName = "playos_no_avahi";
+        })
+      ];
+
+      config = {
+        services.connman.enable = pkgs.lib.mkOverride 0 true; # disabled in runNixOSTest by default
+
+        playos.storage = {
+          persistentDataPartition = {
+            device = "tmpfs";
+            fsType = "tmpfs";
+            options = [ "mode=0755" ];
+          };
+        };
+      };
+    };
+  };
+
+  extraPythonPackages = ps: [
+    ps.colorama
+    ps.types-colorama
+  ];
+
+  testScript =
+''
+${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+start_all()
+
+playos_with_avahi.wait_for_unit("playos-controller.service")
+playos_with_avahi.wait_until_succeeds("curl --fail http://localhost:3333/")
+
+with TestPrecondition("avahi browse finds Senso service"):
+    # Publish our service of interest
+    senso.succeed("avahi-publish -s 'Davidat Soundso' _soundso._tcp 8080 >&2 &")
+    # Also publish a service with 'malicious' instance name
+    senso.succeed("avahi-publish -s '<script>Inject</script>' _soundso._tcp 8080 >&2 &")
+
+    # Ensure it is picked up
+    playos_with_avahi.wait_until_succeeds("test `avahi-browse -r -t _soundso._tcp | wc -l` -gt 0")
+    print(playos_with_avahi.succeed("avahi-browse -pfc _soundso._tcp"))
+
+with TestCase("System without avahi can list networks"):
+    playos_no_avahi.succeed("curl --fail http://localhost:3333/network | grep Wired")
+
+with TestCase("Label is applied"):
+    playos_with_avahi.wait_until_succeeds("curl http://localhost:3333/network | grep 'Davidat Soundso'")
+
+with TestCase("Injectable label contents are escaped"):
+    playos_with_avahi.wait_until_succeeds("curl http://localhost:3333/network | grep '&lt;script&gt;Inject&lt;/script&gt;'")
+'';
+
+}

--- a/testing/integration/controller-interface-labeling.nix
+++ b/testing/integration/controller-interface-labeling.nix
@@ -99,10 +99,6 @@ with TestPrecondition("avahi browse finds Senso service"):
     # Also publish a service with 'malicious' instance name
     senso.succeed("avahi-publish -s '<script>Inject</script>' _soundso._tcp 8080 >&2 &")
 
-    # Ensure it is picked up
-    playos_with_avahi.wait_until_succeeds("test `avahi-browse -r -t _soundso._tcp | wc -l` -gt 0")
-    print(playos_with_avahi.succeed("avahi-browse -pfc _soundso._tcp"))
-
 with TestCase("System without avahi can list networks"):
     playos_no_avahi.succeed("curl --fail http://localhost:3333/network | grep Wired")
 

--- a/testing/integration/controller-interface-labeling.nix
+++ b/testing/integration/controller-interface-labeling.nix
@@ -45,7 +45,8 @@ pkgs.testers.runNixOSTest {
       config = {
         services.connman.enable = pkgs.lib.mkOverride 0 true; # disabled in runNixOSTest by default
 
-        playos.controller.annotateDiscoveredServices = [ "_soundso._tcp" "_yesyes._udp" ];
+        # Includes non-existent "bigfoot" in services of interest, to confirm it does not break anything
+        playos.controller.annotateDiscoveredServices = [ "_soundso._tcp" "_yesyes._udp" "_bigfoot._tcp" ];
 
         playos.storage = {
           persistentDataPartition = {


### PR DESCRIPTION
This allows us to label connected networks which (potentially) establish a connection to a local Senso device, to more easily distinguish them from networks used for Internet access.

In this example, the Senso is connected to the same router used by the machine for Internet access, which would be labeled as well:

<img width="1486" height="343" alt="image" src="https://github.com/user-attachments/assets/00cb3a57-406d-4f4a-ac6b-f6fc6995732f" />

The option to label is added as a generic ability of the PlayOS controller, and inactive if no service types to annotate are configured. 

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [ ] Check reason for late labeling by eavesdropping on mDNS
-   [ ] User manual updated
