### PR TITLE
Hygiene: avoid using Qt signal handlers not bound to objects

### DIFF
--- a/kiosk/kiosk_browser/browser_widget.py
+++ b/kiosk/kiosk_browser/browser_widget.py
@@ -44,11 +44,10 @@ class BrowserWidget(QtWidgets.QWidget):
         self._layout.addWidget(self._loading_page)
         self._layout.addWidget(self._network_error_page)
         self._layout.addWidget(self._webview)
+        self._get_current_proxy = get_current_proxy
 
         # Register proxy authentication handler
-        self._webview.page().proxyAuthenticationRequired.connect(
-            lambda url, auth, proxyHost: self._proxy_auth(
-                get_current_proxy, url, auth, proxyHost))
+        self._webview.page().proxyAuthenticationRequired.connect(self._proxy_auth)
 
         # Override user agent
         self._webview.page().profile().setHttpUserAgent(user_agent_with_system(
@@ -137,8 +136,8 @@ class BrowserWidget(QtWidgets.QWidget):
         self._view(Status.LOADING)
         self._reload_timer.start(250)
 
-    def _proxy_auth(self, get_current_proxy, url, auth, proxyHost):
-        proxy = get_current_proxy()
+    def _proxy_auth(self, url, auth, proxyHost):
+        proxy = self._get_current_proxy()
         if proxy is not None and proxy.credentials is not None:
             logging.info("Authenticating proxy")
             auth.setUser(proxy.credentials.username)

--- a/kiosk/kiosk_browser/keyboard_detector.py
+++ b/kiosk/kiosk_browser/keyboard_detector.py
@@ -70,12 +70,10 @@ class KeyboardDetector(QObject):
     # different thread. So instead we introduce a Qt signal.
     keyboard_available_changed = pyqtSignal(bool)
 
-    def __init__(self, keyboard_available_changed_callback):
-        super().__init__()
+    def __init__(self, parent):
+        super().__init__(parent)
 
         self.keyboard_available = None
-        # connect early to not miss the initial signal emit
-        self.keyboard_available_changed.connect(keyboard_available_changed_callback)
 
         context = pyudev.Context()
         self._monitor = pyudev.Monitor.from_netlink(context)

--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -53,7 +53,9 @@ class MainWidget(QtWidgets.QWidget):
 
         # Virtual keyboard
         self._keyboardWidget = None
-        self._keyboard_detector = KeyboardDetector(self._toggle_virtual_keyboard)
+        self._keyboard_detector = KeyboardDetector(self)
+        self._keyboard_detector.keyboard_available_changed.connect(self._toggle_virtual_keyboard)
+        self._toggle_virtual_keyboard(self._keyboard_detector.keyboard_available)
 
         # Browser widget
         self._kiosk_url = kiosk_url


### PR DESCRIPTION
Signal handlers (i.e. Slots in Qt's terms) not bound to an object instance do not get automatically disconnected and GC'ed, which can lead to crashes where the handler outlives the object it should belong to.

The cases here should not lead to crashes within the current usage, but it's good to avoid these patterns in case the code is refactored.

Discovered in #246 