### PR TITLE
Add alternative F20 long-press shortcut for hard-refresh

### DIFF
--- a/kiosk/kiosk_browser/main_widget.py
+++ b/kiosk/kiosk_browser/main_widget.py
@@ -127,6 +127,12 @@ class MainWidget(QtWidgets.QWidget):
                 name = "hard-refresh",
                 keys = { Qt.Key.Key_Escape, Qt.Key.Key_Down },
                 action = self._browser_widget.hard_refresh
+            ),
+            # The DT-007c remote control has Escape+Down mapped to F20 in the firmware
+            ShortcutDef(
+                name = "hard-refresh-alt",
+                keys = { Qt.Key.Key_F20 },
+                action = self._browser_widget.hard_refresh
             )
         ]
 


### PR DESCRIPTION
In preparation for the updated DT-007c firmware.

Tested by doing `xmodmap -e "keysym F10 = F10 F20"` and using Shift+F10 to simulate an F20 long-press.