### PR TITLE
Include service 'Error' property in connman DBus bindings

### DIFF
--- a/controller/bindings/connman/connman.ml
+++ b/controller/bindings/connman/connman.ml
@@ -449,6 +449,7 @@ module Service = struct
     ; type' : Technology.type'
     ; security : security list
     ; state : state
+    ; error : string option
     ; strength : int option
     ; favorite : bool
     ; autoconnect : bool
@@ -525,6 +526,7 @@ module Service = struct
           name
           type'
           state
+          error
           strength
           favorite
           autoconnect
@@ -542,6 +544,7 @@ module Service = struct
           ; name
           ; type'
           ; state
+          ; error
           ; strength
           ; favorite
           ; autoconnect
@@ -567,6 +570,7 @@ module Service = struct
           >>= string_of_obus
           >>= state_of_string
           )
+      <*> (properties |> List.assoc_opt "Error" >>= string_of_obus |> pure)
       <*> (properties |> List.assoc_opt "Strength" >>= strength_of_obus |> pure)
       <*> (properties |> List.assoc_opt "Favorite" >>= bool_of_obus)
       <*> (properties |> List.assoc_opt "AutoConnect" >>= bool_of_obus)

--- a/controller/bindings/connman/connman.mli
+++ b/controller/bindings/connman/connman.mli
@@ -151,6 +151,7 @@ module Service : sig
     ; type' : Technology.type'
     ; security : security list
     ; state : state
+    ; error : string option
     ; strength : int option
     ; favorite : bool
     ; autoconnect : bool


### PR DESCRIPTION
This might be useful to be able to see in the UI in some cases.

Additional step would be to show errors prominently in the UI, r.t. deep in an sexp string.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
