### PR TITLE
Improve password reveal

### DIFF
--- a/controller/gui/client.js
+++ b/controller/gui/client.js
@@ -29,20 +29,7 @@ customElements.define(
         }
       }
 
-      input.oninput = function (e) {
-        if (e.target.value.length > 0) {
-          button.style.visibility = 'visible'
-        } else {
-          button.style.visibility = 'hidden'
-          updatePasswordVisibility(false)
-        }
-      }
-
-      // If the input has a right margin, position the button accordingly
-      const rightMargin = parseFloat(window.getComputedStyle(input).getPropertyValue('margin-right'))
-
       button.style = `
-        visibility: hidden;
         border: none;
         background-color: transparent;
         color: #555555;


### PR DESCRIPTION
Small quality of life improvements for the password reveal web component:

- Fix a bug I introduced in https://github.com/dividat/playos/pull/254 that repurposed pressing Enter on the input field
- Always show the toggle button, even when input is empty

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
