### PR TITLE
Apply two upstream patches for connman

### DIFF
--- a/pkgs/connman/default.nix
+++ b/pkgs/connman/default.nix
@@ -10,5 +10,16 @@ super.connman.overrideAttrs (old: {
     };
     patches = [
       ./create-libppp-compat.h.patch
+      # Patches for CVEs, fixed in upstream ConnMan >=1.45
+      (super.fetchpatch {
+        name = "CVE-2025-32366.patch";
+        url = "https://git.kernel.org/pub/scm/network/connman/connman.git/patch/?id=8d3be0285f1d4667bfe85dba555c663eb3d704b4";
+        hash = "sha256-kPb4pZVWvnvTUcpc4wRc8x/pMUTXGIywj3w8IYKRTBs=";
+      })
+      (super.fetchpatch {
+        name = "CVE-2025-32743.patch";
+        url = "https://git.kernel.org/pub/scm/network/connman/connman.git/patch/?id=d90b911f6760959bdf1393c39fe8d1118315490f";
+        hash = "sha256-odkjYC/iM6dTIJx2WM/KKotXdTtgv8NMFNJMzx5+YU4=";
+      })
     ];
 })


### PR DESCRIPTION
Fix two CVEs with patches from ConnMan project:

https://euvd.enisa.europa.eu/vulnerability/CVE-2025-32743
https://euvd.enisa.europa.eu/vulnerability/CVE-2025-32366

From upstream nixpkgs:
https://github.com/NixOS/nixpkgs/commit/e50edd162befd42b359bc3eae2dad1e63719c7ba

These are unrelated to wifi stability, but important patches to ship.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
