### PR TITLE
Add step to remove unused libraries to gain space

### DIFF
--- a/.github/actions/prep-build-env/action.yml
+++ b/.github/actions/prep-build-env/action.yml
@@ -5,6 +5,16 @@ runs:
   - name: Ensure KVM is usable by nix-build
     run: sudo chmod a+rwx /dev/kvm
     shell: bash
+  - name: Remove unused libraries for more available disk space
+    run: |
+        df -h
+        sudo rm -rf /usr/share/dotnet         # .NET SDKs
+        sudo rm -rf /usr/local/lib/android    # Android SDK
+        sudo rm -rf /opt/hostedtoolcache      # Hosted tool cache (CodeQL, etc.)
+        sudo rm -rf /usr/lib/jvm              # Java/JDK installations
+        sudo docker system prune --all --force
+        df -h
+    shell: bash
   - uses: cachix/install-nix-action@v18
     with:
       nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION
We started seeing failures in the release-validation build on GitHub Actions due to full disk, but in PRs that should not materially impact size of artifacts at all. (https://github.com/dividat/playos/issues/271)

As a sanity check, started unmodified https://github.com/dividat/playos/actions/runs/19498481785 which I expect to also fail in the same way (confirming there is no change in the outputs we produce, but a change in Ubuntu runners).

This PR tries to free up space on the runner before starting the actual build.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
