### PR TITLE
Stop kiosk when any QWebEngineView renderer stops abnormaly

### DIFF
--- a/kiosk/kiosk_browser/__init__.py
+++ b/kiosk/kiosk_browser/__init__.py
@@ -54,7 +54,7 @@ def start(kiosk_url, settings_url, toggle_settings_key, fullscreen = True):
     signal.signal(signal.SIGTERM, quit_on_signal)
 
     # Start application
-    app.exec()
+    sys.exit(app.exec())
 
 def parseUrl(url):
     parsed_url = QUrl(url)


### PR DESCRIPTION
- OOM killer likes to snipe individual tabs / processes
- It is possible that a page might crash due to a variety of reasons, in which case kiosk will not currently recover (user will see a blank page)

Since we do not expect pages to crash under normal circumstances, we simply stop the whole kiosk application and let the rest of process management to kick in for recovery.

I am thinking to create an automated test later on that checks #273 and this PR in a combination, since they both deal with failure modes and recovery.

## Checklist

-   [ ] Changelog updated
-   [X] Code documented
-   [ ] ~~User manual updated~~
