### PR TITLE
Set custom os-release meta data

### DIFF
--- a/base/default.nix
+++ b/base/default.nix
@@ -51,6 +51,19 @@ with lib;
 
     playos = { inherit version kioskUrl; };
 
+    # Make a PlayOS-specific os-release file
+    # https://www.freedesktop.org/software/systemd/man/latest/os-release.html
+    environment.etc."os-release".text = lib.mkForce ''
+      ID=${safeProductName}
+      ID_LIKE="nixos"
+      NAME="${fullProductName}"
+      PRETTY_NAME="${fullProductName} ${version} (NixOS ${config.system.nixos.release} ${config.system.nixos.codeName})"
+      VERSION="${version}"
+      VERSION_ID="${version}"
+      HOME_URL="https://github.com/dividat/playos"
+      BUG_REPORT_URL="https://github.com/dividat/playos/issues"
+    '';
+
     # 'Welcome Screen'
     services.getty = {
       greetingLine = greeting "${fullProductName} (${version})";


### PR DESCRIPTION
Sets PlayOS specific meta data in /etc/os-release, which systemd variously relies on.

Considered but not added for now:

- VENDOR_NAME, VENDOR_URL
- SUPPORT_URL, DOCUMENTATION_URL
- ANSI_COLOR -- no color, no bikeshedding :-)

We don't rely on these in our UI, and to my understanding nothing is displayed in terminal outputs if these are not set.

Setting custom meta data in this file also disables the EOS warning during boot we previously inherited from the underlying NixOS version.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
