### PR TITLE
Extend interval until next installation attempt after failure

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -1,3 +1,7 @@
+## Changed
+
+- controller: Extend wait after failed update installation attempt from 30 s to 5 min
+
 # [2025.3.2] - 2025-12-04
 
 # [2025.3.2-VALIDATION] - 2025-11-21

--- a/controller/server/update.ml
+++ b/controller/server/update.ml
@@ -56,7 +56,8 @@ type state =
 [@@deriving sexp_of]
 
 type config =
-  { error_backoff_duration : sleep_duration
+  { http_error_backoff_duration : sleep_duration
+  ; install_error_backoff_duration : sleep_duration
   ; check_for_updates_interval : sleep_duration
   }
 
@@ -183,7 +184,7 @@ module Make (Deps : ServiceDeps) : UpdateService = struct
               )
             in
             return
-              { process_state = Sleeping config.error_backoff_duration
+              { process_state = Sleeping config.http_error_backoff_duration
               ; (* unsetting version_info to indicate we are unclear about
                    current system state *)
                 version_info = None
@@ -207,7 +208,7 @@ module Make (Deps : ServiceDeps) : UpdateService = struct
             in
             return
               { state with
-                process_state = Sleeping config.error_backoff_duration
+                process_state = Sleeping config.http_error_backoff_duration
               ; system_status = UpdateError (ErrorDownloading exn_str)
               }
       )
@@ -237,7 +238,7 @@ module Make (Deps : ServiceDeps) : UpdateService = struct
             in
             return
               { state with
-                process_state = Sleeping config.error_backoff_duration
+                process_state = Sleeping config.install_error_backoff_duration
               ; system_status = UpdateError (ErrorInstalling exn_str)
               }
       )
@@ -251,7 +252,8 @@ module Make (Deps : ServiceDeps) : UpdateService = struct
 end
 
 let default_config : config =
-  { error_backoff_duration = 30.0
+  { http_error_backoff_duration = 30.0
+  ; install_error_backoff_duration = 5. *. 60.
   ; check_for_updates_interval = 1. *. 60. *. 60.
   }
 

--- a/controller/server/update.mli
+++ b/controller/server/update.mli
@@ -41,7 +41,9 @@ type state =
 
 type config =
   { (* time to sleep in seconds until retrying after a (Curl/HTTP) error *)
-    error_backoff_duration : sleep_duration
+    http_error_backoff_duration : sleep_duration
+  ; (* time to sleep in seconds until retrying after installation failed *)
+    install_error_backoff_duration : sleep_duration
   ; (* time to sleep in seconds between checking for available updates *)
     check_for_updates_interval : sleep_duration
   }

--- a/controller/tests/server/update/helpers.ml
+++ b/controller/tests/server/update/helpers.ml
@@ -27,7 +27,10 @@ let statefmt (state : Update.state) : string =
 (* === Mock init and setup === *)
 
 let default_test_config : Update.config =
-  { error_backoff_duration = 0.01; check_for_updates_interval = 0.05 }
+  { http_error_backoff_duration = 0.01
+  ; install_error_backoff_duration = 0.02
+  ; check_for_updates_interval = 0.05
+  }
 
 type test_context =
   { update_client : Mock_update_client.mock

--- a/controller/tests/server/update/update_prop_tests.ml
+++ b/controller/tests/server/update/update_prop_tests.ml
@@ -60,7 +60,8 @@ let test_random_failure_case =
     let failure_gen_upd = failure_seq_to_f seq_upd in
     let failure_gen_rauc = failure_seq_to_f seq_rauc in
     let test_config =
-      { Update.error_backoff_duration = 0.001
+      { Update.http_error_backoff_duration = 0.001
+      ; Update.install_error_backoff_duration = 0.002
       ; Update.check_for_updates_interval = 0.002
       }
     in

--- a/controller/tests/server/update/update_tests.ml
+++ b/controller/tests/server/update/update_tests.ml
@@ -122,7 +122,7 @@ let delete_downloaded_bundle_on_err
     ; Scenario.StateReached
         { init_state with
           process_state =
-            Sleeping Helpers.default_test_config.error_backoff_duration
+            Sleeping Helpers.default_test_config.install_error_backoff_duration
         ; system_status = UpdateError (ErrorInstalling Scenario._WILDCARD_PAT)
         }
     ; Scenario.StateReached
@@ -146,7 +146,7 @@ let sleep_on_get_version_err _ () =
     ; system_status =
         UpdateError (ErrorGettingVersionInfo Scenario._WILDCARD_PAT)
     ; process_state =
-        Sleeping Helpers.default_test_config.error_backoff_duration
+        Sleeping Helpers.default_test_config.http_error_backoff_duration
     }
   in
   let%lwt out_state = UpdateServiceI.run_step init_state in
@@ -171,7 +171,7 @@ let sleep_on_download_err _ () =
     { version_info = None
     ; system_status = UpdateError (ErrorDownloading Scenario._WILDCARD_PAT)
     ; process_state =
-        Sleeping Helpers.default_test_config.error_backoff_duration
+        Sleeping Helpers.default_test_config.http_error_backoff_duration
     }
   in
   let%lwt out_state = UpdateServiceI.run_step init_state in


### PR DESCRIPTION
Decouple from interval for HTTP errors, as this is a heavier action and less likely to fail transiently.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
