### PR TITLE
Add user-agent in controller's curl wrapper

### DIFF
--- a/controller/bindings/curl/curl.ml
+++ b/controller/bindings/curl/curl.ml
@@ -60,7 +60,7 @@ let parse_status_code_and_body str =
   >>= fun (body, code_str) ->
   safe_int_of_string code_str >>= fun code -> return (code, body)
 
-let user_agent = "PlayOS/" ^ Config.System.version
+let user_agent = "playos-controller/" ^ Config.System.version
 
 let request ?proxy ?(headers = []) ?data ?(options = []) url =
   let cmd =


### PR DESCRIPTION
It may be handy to be able to identify requests from specific versions of PlayOS for analysis or version-dependent dispatch.

I briefly considered to also include something like `curl/8.14.1` in the user agent string, but I can not tell curl to automatically add its own user-agent string to the one I set, and doing so manually would require another curl invocation just to read the version. It seems unnecessary, since one version of PlayOS will come with only one exact version of curl.

This is added opportunistically, no particular relevance to upcoming releases.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
