### PR TITLE
Stop kiosk when any QWebEngineView renderer stops abnormaly

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -8,6 +8,7 @@
 ## Fixed
 
 - os: Ensure the system is not marked as failed due to display selection errors
+- kiosk: Restart kiosk application when renderer process quits unexpectedly
 
 # [2025.3.2] - 2025-12-04
 

--- a/kiosk/kiosk_browser/__init__.py
+++ b/kiosk/kiosk_browser/__init__.py
@@ -55,7 +55,7 @@ def start(kiosk_url, settings_url, toggle_settings_key, fullscreen = True):
     signal.signal(signal.SIGTERM, quit_on_signal)
 
     # Start application
-    app.exec()
+    sys.exit(app.exec())
 
 def parseUrl(url):
     parsed_url = QUrl(url)


### PR DESCRIPTION
- OOM killer likes to snipe individual tabs / processes
- It is possible that a page might crash due to a variety of reasons, in which case kiosk will not currently recover (user will see a blank page)

Since we do not expect pages to crash under normal circumstances, we simply stop the whole kiosk application and let the rest of process management to kick in for recovery.

Backported to 2025.3.x release branch from https://github.com/dividat/playos/pull/274.

Example:

```
$ bin/kiosk-browser https://dev-play.dividat.com/ http://localhost
INFO:root:Set no proxy in Qt application
INFO:root:Primary screen changed to DP-2
INFO:root:Resizing widget based on new screen size: PyQt6.QtCore.QSize(1755, 987)
ERROR:root:QtWebEngine Renderer process exited abnormaly (termination_status=<RenderProcessTerminationStatus.KilledTerminationStatus: 3> exit_code=61696), stopping application
```

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
