### PR TITLE
Upgrade to Nixpkgs 25.11

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -358,7 +358,9 @@ rec {
       '';
 
       # Set a low default timeout when stopping services, to prevent the Windows 95 shutdown experience
-      systemd.extraConfig = "DefaultTimeoutStopSec=15s";
+      systemd.settings.Manager = {
+        DefaultTimeoutStopSec = "15s";
+      };
 
       playos.hardening.enable = true;
 

--- a/application.nix
+++ b/application.nix
@@ -169,6 +169,7 @@ rec {
 
               # Enable Qt WebEngine Developer Tools (https://doc.qt.io/qt-6/qtwebengine-debugging.html)
               export QTWEBENGINE_REMOTE_DEBUGGING="127.0.0.1:3355"
+              export VK_DRIVER_FILES=/nonexistent
 
               ${pkgs.playos-kiosk-browser}/bin/kiosk-browser \
                 --max-cache-size ${toString max-browser-cache-size} \

--- a/application.nix
+++ b/application.nix
@@ -128,8 +128,8 @@ rec {
       };
 
       # Limit virtual terminals that can be switched to
-      # Virtual terminal 7 is the kiosk, 8 is the status screen
-      playos.xserver.activeVirtualTerminals = [ 7 8 ];
+      # Virtual terminal 1 is the kiosk, 8 is the status screen
+      playos.xserver.activeVirtualTerminals = [ 1 8 ];
 
       # System-wide packages
       environment.systemPackages = with pkgs; [ breeze-contrast-cursor-theme playos-diagnostics ];

--- a/application.nix
+++ b/application.nix
@@ -15,6 +15,8 @@ rec {
    <`-       (__< <           :
     (__        (_<_<          ;     ${label}
 -----`------------------------------------------------------ ----------- ------
+
+Press Ctrl+Alt+F1 to return to the graphical session.
     '';
 
     overlays = [

--- a/application.nix
+++ b/application.nix
@@ -309,7 +309,7 @@ rec {
       # Audio
       services.pipewire.enable = false;
 
-      hardware.pulseaudio = {
+      services.pulseaudio = {
         enable = true;
         extraConfig = ''
           # Use HDMI output

--- a/application/power-management/default.nix
+++ b/application/power-management/default.nix
@@ -21,16 +21,16 @@ in {
   # Ignore system control keys that do not make sense for kiosk applications.
   # Ignore power key as well, but set up a systemd service shutting down the
   # computer on Power Button key press.
-  services.logind.extraConfig = ''
-    HandlePowerKey=ignore
-    HandleRebootKey=ignore
-    HandleSuspendKey=ignore
-    HandleHibernateKey=ignore
-    HandlePowerKeyLongPress=poweroff
-    HandleRebootKeyLongPress=poweroff
-    HandleSuspendKeyLongPress=poweroff
-    HandleHibernateKeyLongPress=poweroff
-  '';
+  services.logind.settings.Login = {
+    HandlePowerKey = "ignore";
+    HandleRebootKey = "ignore";
+    HandleSuspendKey = "ignore";
+    HandleHibernateKey = "ignore";
+    HandlePowerKeyLongPress = "poweroff";
+    HandleRebootKeyLongPress = "poweroff";
+    HandleSuspendKeyLongPress = "poweroff";
+    HandleHibernateKeyLongPress = "poweroff";
+  };
 
   users = {
     users.${user} = {

--- a/base/networking/default.nix
+++ b/base/networking/default.nix
@@ -76,6 +76,15 @@ in
   };
   # Issue 1: Make sure connman starts after wpa_supplicant
   systemd.services."connman".after = wpaSupplicantServices;
+
+  # connman provides /etc/resolv.conf (via its built-in DNS proxy).
+  # Use the standard nss-lookup.target synchronization point so services
+  # that depend on name resolution can order themselves with After=.
+  systemd.services."connman".wants = [ "nss-lookup.target" ];
+  systemd.services."connman".before = [ "nss-lookup.target" ];
+
+  # avahi-daemon needs /etc/resolv.conf to be available before it starts
+  systemd.services."avahi-daemon".after = [ "nss-lookup.target" ];
   # Issue 2: Restart wpa_supplicant (and thereby connman) after rfkill unblock of wlan
   #          This addresses the problem of wpa_supplicant with connman not seeing any
   #          networks if wlan was initially soft blocked. (https://web.archive.org/web/20191211094135/https://01.org/jira/browse/CM-670)

--- a/base/networking/default.nix
+++ b/base/networking/default.nix
@@ -48,6 +48,9 @@ in
     '';
   };
 
+  # connman runs a local caching DNS proxy and manages /etc/resolv.conf
+  networking.resolvconf.enable = false;
+
   networking = {
     hostName = hostName;
 

--- a/base/networking/default.nix
+++ b/base/networking/default.nix
@@ -21,6 +21,8 @@ in
     traceroute # for connectivity
   ];
 
+  systemd.targets.network.wantedBy = [ "multi-user.target" ];
+
   # Set up networking with ConnMan
   # We need to work around various issues in the interplay of connman and
   # wpa_supplicant for this to work.

--- a/base/networking/watchdog/default.nix
+++ b/base/networking/watchdog/default.nix
@@ -4,41 +4,44 @@ with pkgs;
 let
   cfg = config.playos.networking.watchdog;
   watchdog = python3Packages.buildPythonApplication rec {
-      pname = "playos_network_watchdog";
-      version = "0.1.0";
+    pname = "playos_network_watchdog";
+    version = "0.1.0";
 
-      src = ./.;
+    src = ./.;
 
-      nativeBuildInputs = [
-          wrapGAppsHook
-      ];
+    pyproject = true;
+    build-system = with python3Packages; [ setuptools ];
+
+    nativeBuildInputs = [
+      wrapGAppsHook3
+    ];
 
     nativeCheckInputs = with python3Packages; [
-        types-requests
-        ruff
-        mypy
+      types-requests
+      ruff
+      mypy
     ];
 
     checkPhase = ''
-        runHook preCheck
+      runHook preCheck
 
-        ruff check
+      ruff check
 
-        mypy \
-            --no-color-output \
-            --pretty \
-            --exclude 'build/.*' \
-            --exclude setup.py \
-            .
+      mypy \
+          --no-color-output \
+          --pretty \
+          --exclude 'build/.*' \
+          --exclude setup.py \
+          .
 
-        runHook postCheck
+      runHook postCheck
      '';
 
       propagatedBuildInputs = with python3Packages; [
-          dbus-python
-          pygobject3
-          requests
-          playos-proxy-utils
+        dbus-python
+        pygobject3
+        requests
+        playos-proxy-utils
       ];
   };
 in

--- a/build
+++ b/build
@@ -72,8 +72,9 @@ PlayOS shortcuts:
 - Toggle controller: ctrl-shift-f12
 
 You can switch virtual consoles in the guest via QEMU monitor (ctrl-alt-2), sending a key combination via 'sendkey <key-comb>, and returning to QEMU display (ctrl-alt-1).
+- Graphical system: ctrl-alt-f1
+- TTY: ctrl-alt-f3
 - Status console: ctrl-alt-f8
-- Graphical system: ctrl-alt-f7
 "
 
 elif [ "$TARGET" == "develop" ]; then

--- a/controller/.ocamlformat
+++ b/controller/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.27.0
+version = 0.28.1
 
 profile = ocamlformat
 

--- a/controller/default.nix
+++ b/controller/default.nix
@@ -67,7 +67,7 @@ ocamlPackages.buildDunePackage rec {
 
   buildInputs = with ocamlPackages; [
     opium
-    ocaml_lwt
+    lwt
     logs
     fpath
     tyxml

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -87,9 +87,9 @@ module InfoGui = struct
   let build app =
     app
     |> get "/info" (fun _ ->
-           let%lwt server_info = Info.get () in
-           Lwt.return (page (Info_page.html server_info))
-       )
+        let%lwt server_info = Info.get () in
+        Lwt.return (page (Info_page.html server_info))
+    )
 end
 
 (** Localization GUI *)
@@ -229,16 +229,15 @@ module NetworkGui = struct
     in
     interfaces
     |> List.map (fun (interface : Network.Interface.t) ->
-           ( interface.name
-           , List.filter_map
-               (fun (s : Avahi.Service.t) ->
-                 if s.interface = interface.name then Some s.service_name
-                 else None
-               )
-               annotated_services
-             |> List.sort_uniq String.compare
-           )
-       )
+        ( interface.name
+        , List.filter_map
+            (fun (s : Avahi.Service.t) ->
+              if s.interface = interface.name then Some s.service_name else None
+            )
+            annotated_services
+          |> List.sort_uniq String.compare
+        )
+    )
     |> return
 
   let overview ~(connman : Manager.t) req =
@@ -525,38 +524,38 @@ module StatusGui = struct
           )
          )
     |> post "/watchdog/enable" (fun _req ->
-           let%lwt () = Network_watchdog.enable systemd in
-           redirect' (Uri.of_string "/status")
-       )
+        let%lwt () = Network_watchdog.enable systemd in
+        redirect' (Uri.of_string "/status")
+    )
     |> post "/watchdog/disable" (fun _req ->
-           let%lwt () = Network_watchdog.disable systemd in
-           redirect' (Uri.of_string "/status")
-       )
+        let%lwt () = Network_watchdog.disable systemd in
+        redirect' (Uri.of_string "/status")
+    )
     |> get "/status" (fun _req ->
-           let%lwt status = get_status ~systemd ~update_s ~health_s ~rauc in
-           Lwt.return (page (Status_page.html status))
-       )
+        let%lwt status = get_status ~systemd ~update_s ~health_s ~rauc in
+        Lwt.return (page (Status_page.html status))
+    )
 end
 
 module ChangelogGui = struct
   let build app =
     app
     |> get "/changelog" (fun _ ->
-           let%lwt changelog =
-             Util.read_from_file log_src
-               (Util.resource_path (Fpath.v "Changelog.html"))
-           in
-           Lwt.return (page (Changelog_page.html changelog))
-       )
+        let%lwt changelog =
+          Util.read_from_file log_src
+            (Util.resource_path (Fpath.v "Changelog.html"))
+        in
+        Lwt.return (page (Changelog_page.html changelog))
+    )
 end
 
 module LicensingGui = struct
   let build app =
     app
     |> get "/licensing" (fun _ ->
-           let%lwt p = Licensing_page.html in
-           Lwt.return (page p)
-       )
+        let%lwt p = Licensing_page.html in
+        Lwt.return (page p)
+    )
 end
 
 module RemoteMaintenanceGui = struct
@@ -571,26 +570,22 @@ module RemoteMaintenanceGui = struct
   let build ~systemd app =
     app
     |> post "/remote-maintenance/enable" (fun _ ->
-           let%lwt () =
-             Systemd.Manager.start_unit systemd "zerotierone.service"
-           in
-           with_timeout
-             { duration = 2.0
-             ; on_timeout =
-                 (fun () ->
-                   let msg = "Timeout starting remote maintenance service." in
-                   let%lwt () = Logs_lwt.err (fun m -> m "%s" msg) in
-                   fail_with msg
-                 )
-             }
-             wait_until_zerotier_is_on
-       )
+        let%lwt () = Systemd.Manager.start_unit systemd "zerotierone.service" in
+        with_timeout
+          { duration = 2.0
+          ; on_timeout =
+              (fun () ->
+                let msg = "Timeout starting remote maintenance service." in
+                let%lwt () = Logs_lwt.err (fun m -> m "%s" msg) in
+                fail_with msg
+              )
+          }
+          wait_until_zerotier_is_on
+    )
     |> post "/remote-maintenance/disable" (fun _ ->
-           let%lwt () =
-             Systemd.Manager.stop_unit systemd "zerotierone.service"
-           in
-           redirect' (Uri.of_string "/info")
-       )
+        let%lwt () = Systemd.Manager.stop_unit systemd "zerotierone.service" in
+        redirect' (Uri.of_string "/info")
+    )
 end
 
 let routes ~systemd ~health_s ~update_s ~rauc ~connman app =

--- a/controller/server/health.ml
+++ b/controller/server/health.ml
@@ -40,17 +40,17 @@ let rec run ~systemd ~rauc ~set_state =
           |> set
     )
   | MarkingAsGood -> (
-      (* Mark currently booted slot as "good" *)
-      match%lwt
-        Lwt_result.catch (fun () ->
-            Rauc.get_booted_slot rauc >>= Rauc.mark_good rauc
-        )
-      with
-      | Ok () ->
-          set Good
-      | Error exn ->
-          set (Bad ("Failed to mark system good: " ^ Printexc.to_string exn))
-    )
+    (* Mark currently booted slot as "good" *)
+    match%lwt
+      Lwt_result.catch (fun () ->
+          Rauc.get_booted_slot rauc >>= Rauc.mark_good rauc
+      )
+    with
+    | Ok () ->
+        set Good
+    | Error exn ->
+        set (Bad ("Failed to mark system good: " ^ Printexc.to_string exn))
+  )
   | Good ->
       (* this thread should not terminate, thus create a never ending task.
 

--- a/controller/server/network.ml
+++ b/controller/server/network.ml
@@ -13,8 +13,8 @@ let enable_and_scan_wifi_devices ~connman =
        let%lwt () =
          technologies
          |> List.filter (fun (t : Technology.t) ->
-                t.type' = Technology.Wifi && not t.powered
-            )
+             t.type' = Technology.Wifi && not t.powered
+         )
          |> List.map Technology.enable
          |> Lwt.join
        in

--- a/controller/server/server.ml
+++ b/controller/server/server.ml
@@ -52,13 +52,13 @@ let main debug port =
   let%lwt () =
     (* Initialize Network, parallel to starting server *)
     ( match%lwt Network.init ~connman with
-    | Ok () ->
-        return_unit
-    | Error exn ->
-        Logs_lwt.warn (fun m ->
-            m "network initialization failed: %s" (Printexc.to_string exn)
-        )
-    )
+      | Ok () ->
+          return_unit
+      | Error exn ->
+          Logs_lwt.warn (fun m ->
+              m "network initialization failed: %s" (Printexc.to_string exn)
+          )
+      )
     <&> Lwt.pick
           [ (* Make sure all threads run forever. *)
             gui_p (* GUI *)

--- a/controller/server/update.ml
+++ b/controller/server/update.ml
@@ -195,23 +195,25 @@ module Make (Deps : ServiceDeps) : UpdateService = struct
         let%lwt () = Lwt_unix.sleep duration in
         return { state with process_state = GettingVersionInfo }
     | Downloading version -> (
-        (* download latest version *)
-        match%lwt Lwt_result.catch (fun () -> ClientI.download version) with
-        | Ok bundle_path ->
-            return { state with process_state = Installing bundle_path }
-        | Error exn ->
-            let exn_str = Printexc.to_string exn in
-            let%lwt () =
-              Logs_lwt.err ~src:log_src (fun m ->
-                  m "failed to download RAUC bundle: %s" exn_str
-              )
-            in
-            return
-              { state with
-                process_state = Sleeping config.http_error_backoff_duration
-              ; system_status = UpdateError (ErrorDownloading exn_str)
-              }
-      )
+      (* download latest version *)
+      match%lwt
+        Lwt_result.catch (fun () -> ClientI.download version)
+      with
+      | Ok bundle_path ->
+          return { state with process_state = Installing bundle_path }
+      | Error exn ->
+          let exn_str = Printexc.to_string exn in
+          let%lwt () =
+            Logs_lwt.err ~src:log_src (fun m ->
+                m "failed to download RAUC bundle: %s" exn_str
+            )
+          in
+          return
+            { state with
+              process_state = Sleeping config.http_error_backoff_duration
+            ; system_status = UpdateError (ErrorDownloading exn_str)
+            }
+    )
     | Installing bundle_path ->
         Lwt.finalize
           (fun () ->

--- a/controller/server/view/common/page.ml
+++ b/controller/server/view/common/page.ml
@@ -106,8 +106,8 @@ let html ?current_page ?header content =
                ; Licensing
                ]
               |> List.concat_map (fun page ->
-                     [ menu_item current_page page; txt " " ]
-                 )
+                  [ menu_item current_page page; txt " " ]
+              )
               )
           ; form
               ~a:

--- a/controller/server/view/localization_page.ml
+++ b/controller/server/view/localization_page.ml
@@ -24,8 +24,8 @@ let select_form params options =
           ]
         ((params.placeholder
          |> Option.map (fun p ->
-                option ~a:[ a_disabled (); a_selected () ] (txt p)
-            )
+             option ~a:[ a_disabled (); a_selected () ] (txt p)
+         )
          |> Base.Option.to_list
          )
         @ options
@@ -85,12 +85,10 @@ let keyboard_form keymaps current_keymap =
 let scaling_form current_scaling =
   [ Screen_settings.Default; Screen_settings.FullHD; Screen_settings.Native ]
   |> List.map (fun s ->
-         select_option
-           (Some (Screen_settings.string_of_scaling current_scaling))
-           ( Screen_settings.string_of_scaling s
-           , Screen_settings.label_of_scaling s
-           )
-     )
+      select_option
+        (Some (Screen_settings.string_of_scaling current_scaling))
+        (Screen_settings.string_of_scaling s, Screen_settings.label_of_scaling s)
+  )
   |> select_form
        { action_url = "/localization/scaling"
        ; legend = "Display resolution"

--- a/controller/server/view/network_list_page.ml
+++ b/controller/server/view/network_list_page.ml
@@ -29,10 +29,10 @@ let service_item interface_annotations ({ id; name; strength; ipv4 } as service)
                 (List.assoc_opt service.ethernet.interface interface_annotations
                 |> Option.value ~default:[]
                 |> List.map (fun label_text ->
-                       span
-                         ~a:[ a_class [ "d-NetworkList__Label" ] ]
-                         [ txt label_text ]
-                   )
+                    span
+                      ~a:[ a_class [ "d-NetworkList__Label" ] ]
+                      [ txt label_text ]
+                )
                 )
             ]
         ; ( match ipv4 with
@@ -86,13 +86,13 @@ let html { proxy; services; interfaces; interface_annotations } =
          )
        ; Definition.list
            (( match proxy with
-            | Some p ->
-                [ Definition.term [ txt "Proxy" ]
-                ; Definition.description [ txt p ]
-                ]
-            | None ->
-                []
-            )
+              | Some p ->
+                  [ Definition.term [ txt "Proxy" ]
+                  ; Definition.description [ txt p ]
+                  ]
+              | None ->
+                  []
+              )
            @ [ Definition.term [ txt "Internet" ]
              ; Definition.description
                  [ div

--- a/default.nix
+++ b/default.nix
@@ -153,10 +153,18 @@ with pkgs; stdenv.mkDerivation {
   buildCommand = ''
     mkdir -p $out
 
-    ln -s ${components.docs} $out/docs
+    ln_checked() {
+      if [[ ! -e "$1" ]]; then
+        echo "Build error: target file does not exist: $1" >&2
+        exit 1
+      fi
+      ln -s "$1" "$2"
+    }
+
+    ln_checked ${components.docs} $out/docs
 
     # Certificate used to verify update bundles
-    ln -s ${updateCert} $out/cert.pem
+    ln_checked ${updateCert} $out/cert.pem
   ''
   + lib.optionalString buildVm ''
     mkdir -p $out/bin
@@ -164,29 +172,29 @@ with pkgs; stdenv.mkDerivation {
     chmod +x $out/bin/run-in-vm
   ''
   + lib.optionalString buildLive ''
-    ln -s ${components.live}/iso/${components.live.isoName} $out/${components.safeProductName}-live-${components.version}.iso
+    ln_checked ${components.live}/iso/${components.live.isoName} $out/${components.safeProductName}-live-${components.version}.iso
   ''
   + lib.optionalString buildDisk ''
-    ln -s ${components.disk} $out/${components.safeProductName}-disk-${components.version}.img
+    ln_checked ${components.disk} $out/${components.safeProductName}-disk-${components.version}.img
   ''
   + lib.optionalString buildReleaseDisk ''
-    ln -s ${releaseDisk} $out/${components.safeProductName}-release-disk-${components.version}.img.zst
+    ln_checked ${releaseDisk} $out/${components.safeProductName}-release-disk-${components.version}.img.zst
   ''
   # Installer ISO image
   + lib.optionalString buildInstaller ''
-    ln -s ${components.installer.isoImage}/iso/${components.installer.isoImage.isoName} $out/${components.safeProductName}-installer-${components.version}.iso
+    ln_checked ${components.installer.isoImage}/iso/${components.installer.isoImage.isoName} $out/${components.safeProductName}-installer-${components.version}.iso
   ''
   # RAUC bundle
   + lib.optionalString buildBundle ''
-    ln -s ${components.unsignedRaucBundle} $out/${components.safeProductName}-${components.version}-UNSIGNED.raucb
+    ln_checked ${components.unsignedRaucBundle} $out/${components.safeProductName}-${components.version}-UNSIGNED.raucb
     cp ${components.deploy-update} $out/bin/deploy-update
     chmod +x $out/bin/deploy-update
   ''
   # Tests
   + lib.optionalString buildTest ''
     mkdir -p $out/tests
-    ln -s ${testComponents.tests.interactive} $out/tests/interactive
-    ln -s ${testComponents.tests.tests} $out/tests/tests
+    ln_checked ${testComponents.tests.interactive} $out/tests/interactive
+    ln_checked ${testComponents.tests.tests} $out/tests/tests
   '';
 
   passthru.tests = testComponents.tests.run;

--- a/default.nix
+++ b/default.nix
@@ -164,7 +164,7 @@ with pkgs; stdenv.mkDerivation {
     chmod +x $out/bin/run-in-vm
   ''
   + lib.optionalString buildLive ''
-    ln -s ${components.live}/iso/${components.safeProductName}-live-${components.version}.iso $out/${components.safeProductName}-live-${components.version}.iso
+    ln -s ${components.live}/iso/${components.live.isoName} $out/${components.safeProductName}-live-${components.version}.iso
   ''
   + lib.optionalString buildDisk ''
     ln -s ${components.disk} $out/${components.safeProductName}-disk-${components.version}.img

--- a/deployment/deploy-update/default.nix
+++ b/deployment/deploy-update/default.nix
@@ -1,11 +1,10 @@
-{ substituteAll
+{ replaceVars
 , application, updateCert, unsignedRaucBundle, docs, installer, live
 , deployUrl, updateUrl, kioskUrl
 , rauc, awscli, python3
 }:
-substituteAll {
-  src = ./deploy-update.py;
-  dummyBuildCert = ../../pki/dummy/cert.pem;
+replaceVars ./deploy-update.py {
+  dummyBuildCert = "${../../pki/dummy/cert.pem}";
   inherit updateCert unsignedRaucBundle docs installer live deployUrl updateUrl kioskUrl;
   inherit rauc awscli python3;
   inherit (application) fullProductName safeProductName version;

--- a/docs/user-manual/Readme.org
+++ b/docs/user-manual/Readme.org
@@ -210,7 +210,7 @@ View what has been added, changed and fixed with each version.
 
 ** Status screen
 
-A status screen providing a brief status report about various components of the system is available on ~tty8~. It can be accessed using the key combination ~Ctrl-Alt-F8~. To get back from the status screen to the graphical interface, use ~Ctrl-Alt-F7~.
+A status screen providing a brief status report about various components of the system is available on ~tty8~. It can be accessed using the key combination ~Ctrl-Alt-F8~. To get back from the status screen to the graphical interface, use ~Ctrl-Alt-F1~.
 
 ** Clearing kiosk browser cache
 

--- a/flavors/portable.nix
+++ b/flavors/portable.nix
@@ -22,7 +22,7 @@ in
       playos.monitoring.enable = lib.mkForce false;
 
       # Do not hard-code HDMI as default
-      hardware.pulseaudio = {
+      services.pulseaudio = {
         extraConfig = lib.mkForce ''
           # Respond to changes in connected outputs
           load-module module-switch-on-port-available

--- a/kiosk/default.nix
+++ b/kiosk/default.nix
@@ -18,6 +18,9 @@ python3Packages.buildPythonApplication rec {
       --replace "@focus_shift_path@" "${pkgs.focus-shift.main}" \
   '';
 
+  pyproject = true;
+  build-system = with python3Packages; [ setuptools ];
+
   buildInputs = [
     bashInteractive
     makeWrapper

--- a/kiosk/default.nix
+++ b/kiosk/default.nix
@@ -33,7 +33,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     qt6.wrapQtAppsHook
-    wrapGAppsHook
+    wrapGAppsHook3
   ];
 
   checkPhase = ''

--- a/kiosk/default.nix
+++ b/kiosk/default.nix
@@ -68,6 +68,9 @@ python3Packages.buildPythonApplication rec {
 
       ;
 
+  dontWrapQtApps = true;
+  makeWrapperArgs = [ "\${qtWrapperArgs[@]}" ];
+
   postInstall = ''
     cp -r images/ $out/images
   '';

--- a/kiosk/kiosk_browser/browser_widget.py
+++ b/kiosk/kiosk_browser/browser_widget.py
@@ -289,6 +289,10 @@ class BrowserWidget(QtWidgets.QWidget):
     # Note: this assumes script injection rules are not changing, i.e.
     # we remain in the same dialog (cf. `BrowserWidget.load(..)`)
     def full_reload(self, url=""):
+        if self._is_full_reload:
+            logging.debug("Full reload already in progress, ignoring.")
+            return
+
         # Temporarily navigate to an empty page
         self._webview.setUrl(QUrl("about:none"))
 

--- a/kiosk/kiosk_browser/keyboard_detector/linux.py
+++ b/kiosk/kiosk_browser/keyboard_detector/linux.py
@@ -86,11 +86,12 @@ def device_is_a_keyboard(device: evdev.InputDevice) -> bool:
     return len(relevant_ev_keys) > 60
 
 
-def find_keyboard_devices() -> evdev.InputDevice:
+def find_keyboard_devices() -> list[evdev.InputDevice]:
     devices = list(map(evdev.InputDevice, evdev.list_devices()))
     # even if nothing is plugged in, there should be at least a power button here!
     if len(devices) == 0:
         logging.error("No input devices found, is the current user in the `input` group?")
+        return []
 
     return [d for d in devices if device_is_a_keyboard(d) and not device_is_blacklisted(d)]
 

--- a/live/default.nix
+++ b/live/default.nix
@@ -18,10 +18,10 @@ let nixos = pkgs.importFromNixos ""; in
 
     config = {
       # ISO image customization
+      image.baseName = lib.mkForce "${application.safeProductName}-live-${application.version}";
       isoImage = {
         makeEfiBootable = true;
         makeUsbBootable = true;
-        isoName = "${application.safeProductName}-live-${application.version}.iso";
         appendToMenuLabel = " Live System";
       } // lib.optionalAttrs (squashfsCompressionOpts != null) { squashfsCompression = squashfsCompressionOpts; };
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,9 +3,9 @@
 let
 
   nixpkgs = builtins.fetchTarball {
-    # release-24.11 2025-02-10
-    url = "https://github.com/NixOS/nixpkgs/archive/edd84e9bffdf1c0ceba05c0d868356f28a1eb7de.tar.gz";
-    sha256 = "1gb61gahkq74hqiw8kbr9j0qwf2wlwnsvhb7z68zhm8wa27grqr0";
+    # release-25.11 2026-04-30
+    url = "https://github.com/NixOS/nixpkgs/archive/5a9c58fc6ac2ec48bf9cf4c07de27f912b1ed1cc.tar.gz";
+    sha256 = "0s0r78hddzrb5hnc95l0qlg6lfk7lwp3sl49adj3fc96yjfr63va";
   };
 
   overlay =

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -30,6 +30,7 @@ let
 
       python3Packages = super.python3Packages.overrideScope (self: super: {
         playos-proxy-utils = self.callPackage ../proxy-utils {};
+        playos-test-helpers = self.callPackage ../testing/helpers {};
       });
 
       qt6 = super.qt6.overrideScope (qtself: qtsuper: {

--- a/pkgs/ocaml-modules/obus/default.nix
+++ b/pkgs/ocaml-modules/obus/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchFromGitHub, buildDunePackage
-, ppxlib, ppx_tools_versioned, ocaml_lwt
+, ppxlib, ppx_tools_versioned, lwt
 , lwt_react, lwt_ppx, lwt_log, react, xmlm, menhir }:
 
 buildDunePackage rec {
@@ -23,7 +23,7 @@ buildDunePackage rec {
     lwt_log
     lwt_ppx
     lwt_react
-    ocaml_lwt
+    lwt
     ppxlib
     react
     xmlm

--- a/pkgs/ocaml-modules/ppx_protocol_conv/default.nix
+++ b/pkgs/ocaml-modules/ppx_protocol_conv/default.nix
@@ -11,15 +11,15 @@
 
 buildDunePackage rec {
   pname = "ppx_protocol_conv";
-  version = "5.2.1";
+  version = "5.2.3";
 
   minimumOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "andersfugmann";
     repo = "ppx_protocol_conv";
-    rev = "0a4fd698932f20345cb3ba12bab82a9eda4d9147";
-    sha256 = "sha256-gFYg0251NOPPkc01BiSU3NEj3JWGKg1fu6UgQ67BBZM=";
+    rev = "425a7a1a26c26fcb740e5574e252043fd03eff46";
+    sha256 = "sha256-G6zMgHioPUCh2i50cjQ6talN8CYO6UhEaWgi0xe3CWA=";
   };
 
   useDune2 = true;

--- a/proxy-utils/default.nix
+++ b/proxy-utils/default.nix
@@ -7,6 +7,9 @@ python3Packages.buildPythonPackage rec {
 
     src = ./.;
 
+    pyproject = true;
+    build-system = with python3Packages; [ setuptools ];
+
     nativeBuildInputs = [
         wrapGAppsHook3
     ];

--- a/proxy-utils/default.nix
+++ b/proxy-utils/default.nix
@@ -8,7 +8,7 @@ python3Packages.buildPythonPackage rec {
     src = ./.;
 
     nativeBuildInputs = [
-        wrapGAppsHook
+        wrapGAppsHook3
     ];
 
     nativeCheckInputs = with python3Packages; [

--- a/rauc-bundle/default.nix
+++ b/rauc-bundle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, perl, pixz, pathsFromGraph
+{ stdenv, perl, pixz
 , importFromNixos
 , rauc
 , version

--- a/rauc-bundle/default.nix
+++ b/rauc-bundle/default.nix
@@ -167,4 +167,7 @@ stdenv.mkDerivation {
       $out
   '';
 
+   # reduce build time by telling nix to not scan for dependencies
+   __structuredAttrs = true;
+   unsafeDiscardReferences.out = true;
 }

--- a/skeleton/installer/install-playos/default.nix
+++ b/skeleton/installer/install-playos/default.nix
@@ -14,9 +14,9 @@ in
 stdenv.mkDerivation {
   name = "install-playos-${systemMetadata.version}";
 
-  src = substituteAll {
-    src = ./install-playos.py;
-    inherit grubCfg systemImage rescueSystem systemClosureInfo;
+  src = replaceVars ./install-playos.py {
+    grubCfg = "${grubCfg}";
+    inherit systemImage rescueSystem systemClosureInfo;
     inherit (systemMetadata) version kioskUrl updateUrl;
     inherit python;
   };

--- a/skeleton/installer/install-playos/default.nix
+++ b/skeleton/installer/install-playos/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     patchShebangs $out/bin/install-playos
     # Add required tools to path
     wrapProgram $out/bin/install-playos \
-      --prefix PATH ":" ${utillinux}/bin \
+      --prefix PATH ":" ${util-linux}/bin \
       --prefix PATH ":" ${e2fsprogs}/bin \
       --prefix PATH ":" ${dosfstools}/bin \
       --prefix PATH ":" ${grub2_efi}/bin \

--- a/skeleton/pkgs/rauc/default.nix
+++ b/skeleton/pkgs/rauc/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, autoreconfHook, dbus, glib, curl, json-glib, pkg-config, makeWrapper, grub2, utillinux, squashfsTools, e2fsprogs, gnutar, xz, ...}:
+{stdenv, fetchurl, autoreconfHook, dbus, glib, curl, json-glib, pkg-config, makeWrapper, grub2, util-linux, squashfsTools, e2fsprogs, gnutar, xz, ...}:
 stdenv.mkDerivation rec {
   name = "rauc-${version}";
   version = "1.2";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     # Add required tools to path
     wrapProgram $out/bin/rauc \
-      --prefix PATH ":" ${utillinux}/bin \
+      --prefix PATH ":" ${util-linux}/bin \
       --prefix PATH ":" ${squashfsTools}/bin \
       --prefix PATH ":" ${e2fsprogs}/bin \
       --prefix PATH ":" ${grub2}/bin \

--- a/testing/disk/default.nix
+++ b/testing/disk/default.nix
@@ -46,6 +46,10 @@ in vmTools.runInLinuxVM (
         diskImage=$out/playos-disk.img
       '';
       memSize = 2048;
+
+      # reduce build time by telling nix to not scan for dependencies
+      __structuredAttrs = true;
+      unsafeDiscardReferences.out = true;
     }
     ''
       # machine-id of development image is hardcoded

--- a/testing/disk/release.nix
+++ b/testing/disk/release.nix
@@ -38,6 +38,10 @@ vmTools.runInLinuxVM (
         diskImage=$out/playos-disk.img.zst
       '';
       memSize = 1024;
+
+      # reduce build time by telling nix to not scan for dependencies
+      __structuredAttrs = true;
+      unsafeDiscardReferences.out = true;
     }
     ''
       # machine-id of development image is hardcoded.

--- a/testing/end-to-end/profile.nix
+++ b/testing/end-to-end/profile.nix
@@ -6,9 +6,6 @@
     ];
 
     config = {
-        # disable hardware-accelerated graphics, reduces image size vastly
-        hardware.graphics.enable = false;
-
         # test-instrumentation.nix sets this in the boot as kernel param,
         # but since we are booting with a custom GRUB config it has no effect,
         # so instead we set this directly in journald

--- a/testing/end-to-end/tests/application/kiosk-persistence.nix
+++ b/testing/end-to-end/tests/application/kiosk-persistence.nix
@@ -40,6 +40,7 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
     ps.pyppeteer
@@ -48,9 +49,10 @@ pkgs.testers.runNixOSTest {
   ];
 
   testScript = ''
-${builtins.readFile ../../../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import create_overlay, TestPrecondition, TestCheck, wait_for_logs, HTTPStubServer
 ${builtins.readFile ./kiosk-persistence-helpers.py}
 import json
+import time
 from enum import StrEnum, auto
 
 # ===== Test settings
@@ -153,11 +155,11 @@ with TestPrecondition("PlayOS is booted, controller is running"):
 with TestPrecondition("VM can reach HTTP stub server"):
     playos.succeed("curl --fail '${kioskUrl}'", timeout=3)
 
-with TestCase("xserver and kiosk are running"):
+with TestCheck("xserver and kiosk are running"):
     playos.wait_for_x()
     playos.succeed("pgrep --full kiosk-browser > /dev/null")
 
-with TestCase("Kiosk's debug port open, web storage is persisted") as t:
+with TestCheck("Kiosk's debug port open, web storage is persisted") as t:
     page = aio.run(connect_and_get_kiosk_page())
 
     aio.run(populate_web_storages(page))
@@ -193,7 +195,7 @@ with TestPrecondition("Booted into slot b") as t:
     playos.wait_for_unit("rauc.service")
     t.assertEqual(get_booted_slot(), "b")
 
-with TestCase("kiosk's web storage is restored") as t:
+with TestCheck("kiosk's web storage is restored") as t:
     playos.wait_for_x()
 
     page = aio.run(connect_and_get_kiosk_page())

--- a/testing/end-to-end/tests/base/factory-reset.nix
+++ b/testing/end-to-end/tests/base/factory-reset.nix
@@ -12,12 +12,13 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = ''
-${builtins.readFile ../../../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import create_overlay, TestPrecondition, TestCheck
 create_overlay("${disk}", "${overlayPath}")
 
 # scenario is re-used in integration tests as well

--- a/testing/end-to-end/tests/base/proxy-and-update-helpers.py
+++ b/testing/end-to-end/tests/base/proxy-and-update-helpers.py
@@ -5,7 +5,7 @@ class UpdateServer:
         self.http_root = http_root
 
     def wait_for_unit(self):
-        self.vm.wait_for_unit('static-web-server.service')
+        self.vm.wait_for_unit('darkhttpd.service')
 
     def set_latest_version(self, version):
         self.vm.succeed(f"echo -n '{version}' > {self.http_root}/latest")

--- a/testing/end-to-end/tests/base/proxy-and-update.nix
+++ b/testing/end-to-end/tests/base/proxy-and-update.nix
@@ -90,9 +90,12 @@ pkgs.testers.runNixOSTest {
         virtualisation.vlans = [ 1 ];
         networking.firewall.enable = false;
 
-        services.static-web-server.enable = true;
-        services.static-web-server.listen = "[::]:80";
-        services.static-web-server.root = "/tmp/bundle-store";
+        services.darkhttpd.enable = true;
+        services.darkhttpd.address = "::";
+        services.darkhttpd.port = 80;
+        services.darkhttpd.rootDir = "/run/darkhttpd";
+        systemd.services.darkhttpd.serviceConfig.RuntimeDirectory = "darkhttpd";
+        systemd.services.darkhttpd.serviceConfig.RuntimeDirectoryMode = "0777";
 
         # the proxy achieves two things:
         # - is used to test that proxy settings are honoured
@@ -108,10 +111,6 @@ pkgs.testers.runNixOSTest {
           Upstream = ''http 127.0.0.1:80 "${update_host_port}"'';
           LogLevel = "Critical"; # comment out to debug proxied reqs
         };
-
-        systemd.tmpfiles.rules = [
-            "d ${config.services.static-web-server.root} 0777 root root -"
-        ];
 
         virtualisation.qemu.options = [
             "-enable-kvm"
@@ -138,7 +137,7 @@ pkgs.testers.runNixOSTest {
     product_name = "${safeProductName}"
     current_version = "1.1.1-TESTMAGIC"
 
-    http_root = "${nodes.sidekick.services.static-web-server.root}"
+    http_root = "${nodes.sidekick.services.darkhttpd.rootDir}"
     http_local_url = "http://127.0.0.1"
 
     proxy_url = "http://${nodes.sidekick.networking.primaryIPAddress}:8888"

--- a/testing/end-to-end/tests/base/proxy-and-update.nix
+++ b/testing/end-to-end/tests/base/proxy-and-update.nix
@@ -121,6 +121,7 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
@@ -128,10 +129,11 @@ pkgs.testers.runNixOSTest {
 
   testScript = {nodes}:
   ''
-    ${builtins.readFile ../../../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import create_overlay, TestPrecondition, TestCheck, wait_for_logs, configure_proxy
     ${builtins.readFile ./proxy-and-update-helpers.py}
     import json
     import os
+    import time
 
     product_name = "${safeProductName}"
     current_version = "1.1.1-TESTMAGIC"
@@ -151,7 +153,7 @@ pkgs.testers.runNixOSTest {
     playos.start(allow_reboot=True)
     sidekick.start()
 
-    with TestCase("Installer produced a disk without incompatible FS features") as t:
+    with TestCheck("Installer produced a disk without incompatible FS features") as t:
         playos.wait_for_unit("local-fs.target")
         features = playos.succeed('tune2fs -l "/dev/disk/by-label/system.a" | grep "Filesystem features"')
         for bad_opt in ["metadata_csum_seed", "orphan_file"]:
@@ -203,12 +205,12 @@ pkgs.testers.runNixOSTest {
 
     ### === Test scenario
 
-    with TestCase("Kiosk picks up the proxy"):
+    with TestCheck("Kiosk picks up the proxy"):
         proxy_host_port = proxy_url.replace("http://", "")
         expected_kiosk_logs = f"Set proxy to {proxy_host_port} in Qt application"
         wait_for_logs(playos, expected_kiosk_logs)
 
-    with TestCase("Controller is able to query the version"):
+    with TestCheck("Controller is able to query the version"):
         expected_states = [
             "GettingVersionInfo",
             "UpToDate",
@@ -218,7 +220,7 @@ pkgs.testers.runNixOSTest {
         for state in expected_states:
             wait_for_state(state, timeout=61)
 
-    with TestCase("Controller installs the new upstream version") as t:
+    with TestCheck("Controller installs the new upstream version") as t:
         next_version = "${nextVersion}"
 
         update_server.add_bundle(next_version, filepath="${nextVersionBundle}")
@@ -249,7 +251,7 @@ pkgs.testers.runNixOSTest {
         wait_for_state("RebootRequired", timeout=30)
 
 
-    with TestCase("RAUC status confirms the installation") as t:
+    with TestCheck("RAUC status confirms the installation") as t:
         rauc_status = json.loads(playos.succeed(
             "rauc status --detailed --output-format=json"
         ))
@@ -267,12 +269,12 @@ pkgs.testers.runNixOSTest {
             "Installed bundle does not have correct version"
         )
 
-    with TestCase("No raucb files left post-install") as t:
+    with TestCheck("No raucb files left post-install") as t:
         playos.fail("ls /tmp/*.raucb")
 
     target_disk = "/dev/disk/by-label/system.b"
 
-    with TestCase("RAUC post-install hook ran and performed compatibility fixes") as t:
+    with TestCheck("RAUC post-install hook ran and performed compatibility fixes") as t:
         wait_for_logs(playos, "Checking if host system version requires compatibility fixes", unit="rauc.service")
         wait_for_logs(playos, "Detected host system version as ${version}", unit="rauc.service")
 
@@ -283,14 +285,14 @@ pkgs.testers.runNixOSTest {
             wait_for_logs(playos, "Host system does not require compatibility fixes", unit="rauc.service")
 
 
-    with TestCase("RAUC install produced a compatible filesystem") as t:
+    with TestCheck("RAUC install produced a compatible filesystem") as t:
         features = playos.succeed(
             f'tune2fs -l "{target_disk}" | grep "Filesystem features"')
         t.assertNotIn(bad_ext4_option, features,
                       f"ext4 was formatted with {bad_ext4_option}")
 
 
-    with TestCase("System boots into the new bundle") as t:
+    with TestCheck("System boots into the new bundle") as t:
         playos.shutdown()
         playos.start()
         playos.wait_for_unit('multi-user.target')

--- a/testing/helpers/default.nix
+++ b/testing/helpers/default.nix
@@ -1,0 +1,37 @@
+{ pkgs ? (import ../../pkgs {}) }:
+with pkgs;
+with lib;
+python3Packages.buildPythonPackage {
+    pname = "playos_test_helpers";
+    version = "0.1.0";
+
+    src = ./.;
+
+    pyproject = true;
+    build-system = with python3Packages; [ setuptools ];
+
+    nativeCheckInputs = with python3Packages; [
+        ruff
+        mypy
+        types-colorama
+    ];
+
+    checkPhase = ''
+        runHook preCheck
+
+        ruff check
+
+        mypy \
+            --no-color-output \
+            --pretty \
+            --exclude 'build/.*' \
+            --exclude setup.py \
+            .
+
+        runHook postCheck
+     '';
+
+    propagatedBuildInputs = with python3Packages; [
+        colorama
+    ];
+}

--- a/testing/helpers/playos_test_helpers/__init__.py
+++ b/testing/helpers/playos_test_helpers/__init__.py
@@ -9,6 +9,18 @@ import tempfile
 import atexit
 import time
 
+__all__ = [
+    "create_overlay",
+    "eprint",
+    "TestPrecondition",
+    "TestCheck",
+    "wait_for_logs",
+    "get_first_connman_service_name",
+    "configure_proxy",
+    "HTTPStubServer",
+    "wait_until_passes",
+]
+
 
 # HACK: create writable cow disk overlay (same as in ./run-in-vm --disk)
 def create_overlay(disk, overlay_path):
@@ -55,9 +67,9 @@ class TestPrecondition(AbstractTestCheck):
     def __init__(self, test_descr):
         super().__init__("TestPrecondition", test_descr)
 
-class TestCase(AbstractTestCheck):
+class TestCheck(AbstractTestCheck):
     def __init__(self, test_descr):
-        super().__init__("TestCase", test_descr)
+        super().__init__("TestCheck", test_descr)
 
 # Wait until journactl contains a log entry with a message matching the `regex`
 # or time out. Can be optionally filtered by `since` and `unit, with the same

--- a/testing/helpers/playos_test_helpers/__init__.py
+++ b/testing/helpers/playos_test_helpers/__init__.py
@@ -154,10 +154,13 @@ class HTTPStubServer:
             f.write("Hello world\n")
 
         class Handler(http.server.SimpleHTTPRequestHandler):
+            # drop "dead" clients (e.g. when NAT is broken)
+            timeout = 2
+
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, directory=d.name, **kwargs)
 
-        self._server = http.server.HTTPServer(
+        self._server = http.server.ThreadingHTTPServer(
             ("", port),
             Handler
         )

--- a/testing/helpers/setup.py
+++ b/testing/helpers/setup.py
@@ -1,0 +1,8 @@
+import setuptools
+
+setuptools.setup(
+    name="playos_test_helpers",
+    version="0.1.0",
+    description="PlayOS NixOS test script helpers",
+    packages=setuptools.find_packages(),
+)

--- a/testing/integration/base-compatibility.nix
+++ b/testing/integration/base-compatibility.nix
@@ -26,12 +26,13 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = ''
-    ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import TestCheck
     BAD_EXT4_FEATURES = ["metadata_csum_seed", "orphan_file"]
 
     def check_for_bad_features(part_file, t):
@@ -46,12 +47,12 @@ pkgs.testers.runNixOSTest {
 
     machine.wait_for_unit("local-fs.target")
 
-    with TestCase("compatibility options are honoured when running from a shell") as t:
+    with TestCheck("compatibility options are honoured when running from a shell") as t:
         machine.succeed("truncate -s 100M /tmp/partition-shell.img")
         machine.succeed("mkfs.ext4 /tmp/partition-shell.img")
         check_for_bad_features("/tmp/partition-shell.img", t)
 
-    with TestCase("compatibility options are honoured when running in a service") as t:
+    with TestCheck("compatibility options are honoured when running in a service") as t:
         machine.wait_for_unit("test-service.service")
         check_for_bad_features("/tmp/partition-service.img", t)
   '';

--- a/testing/integration/connman-link-local-demotion.nix
+++ b/testing/integration/connman-link-local-demotion.nix
@@ -52,6 +52,7 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
@@ -61,7 +62,8 @@ let
     watchdogCfg = nodes.playos.playos.networking.watchdog;
 in
 ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestPrecondition, TestCheck, get_first_connman_service_name, wait_until_passes
+import time
 
 # ETH1 == connection to node1 via vlan1
 # ETH2 == connection to node2 via vlan2
@@ -144,7 +146,7 @@ with TestPrecondition("Wait until the secondary service receives a non-link-loca
 
 time.sleep(1)
 
-with TestCase("Confirm secondary service is now the default") as t:
+with TestCheck("Confirm secondary service is now the default") as t:
     new_default_service = get_first_connman_service_name(playos)
     t.assertEqual(
         new_default_service,
@@ -152,7 +154,7 @@ with TestCase("Confirm secondary service is now the default") as t:
         "Secondary service did not become the default!"
     )
 
-with TestCase("Confirm secondary device has the default route") as t:
+with TestCheck("Confirm secondary device has the default route") as t:
     default_route = playos.succeed("ip route | grep 'default via'").strip()
     t.assertEqual(
         default_route,

--- a/testing/integration/connman-link-local-demotion.nix
+++ b/testing/integration/connman-link-local-demotion.nix
@@ -81,7 +81,6 @@ playos.start()
 
 with TestPrecondition("Booted and running"):
     playos.wait_for_unit('connman.service')
-    playos.wait_for_unit("network-online.target")
 
 # Restart connman to clear nixosTest vlan and DHCP IPs
 playos.systemctl('restart connman.service')

--- a/testing/integration/connman-wifi-retries.nix
+++ b/testing/integration/connman-wifi-retries.nix
@@ -145,13 +145,14 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = {nodes}:
   ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestPrecondition, TestCheck, wait_for_logs
 playos.start()
 
 with TestPrecondition("Test APs are setup and visible to connman"):
@@ -163,7 +164,7 @@ with TestPrecondition("Test APs are setup and visible to connman"):
     playos.wait_until_succeeds("connmanctl services | grep test-ap-sae", timeout=60)
     print(playos.succeed("connmanctl services wifi_02deadbeef01_746573742d61702d736165_managed_psk"))
 
-with TestCase("connman applies retry mechanism after SAE auth failure") as t:
+with TestCheck("connman applies retry mechanism after SAE auth failure") as t:
     # We connect with an incorrect passphrase, which is our hack to make the
     # added retry mechanism for failed connects in ConnMan observable. We
     # expect the connection fails in this case, but want to see that ConnMan

--- a/testing/integration/controller-interface-labeling.nix
+++ b/testing/integration/controller-interface-labeling.nix
@@ -82,13 +82,14 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript =
 ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestPrecondition, TestCheck
 start_all()
 
 playos_with_avahi.wait_for_unit("playos-controller.service")
@@ -101,14 +102,14 @@ with TestPrecondition("avahi browse finds Senso service"):
     # Also publish a service with 'malicious' instance name
     senso.succeed("avahi-publish --service '<script>Inject</script>' _soundso._tcp 8080 >&2 &")
 
-with TestCase("System without avahi can list networks"):
+with TestCheck("System without avahi can list networks"):
     playos_no_avahi.succeed("curl --fail http://localhost:3333/network | grep Wired")
 
-with TestCase("Label is applied"):
+with TestCheck("Label is applied"):
     playos_with_avahi.wait_until_succeeds("curl http://localhost:3333/network | grep 'Davidat Soundso'")
     playos_with_avahi.wait_until_succeeds("curl http://localhost:3333/network | grep 'Yes Man'")
 
-with TestCase("Injectable label contents are escaped"):
+with TestCheck("Injectable label contents are escaped"):
     playos_with_avahi.wait_until_succeeds("curl http://localhost:3333/network | grep '&lt;script&gt;Inject&lt;/script&gt;'")
 '';
 

--- a/testing/integration/controller-proxy.nix
+++ b/testing/integration/controller-proxy.nix
@@ -73,6 +73,10 @@ pkgs.testers.runNixOSTest {
       ];
 
       config = {
+        # work-around to nixos broken network targets when connman is used.
+        # without this, network.target is never activated.
+        systemd.targets.network.wantedBy = [ "multi-user.target" ];
+
         networking.firewall.enable = false;
 
         services.connman = {

--- a/testing/integration/controller-proxy.nix
+++ b/testing/integration/controller-proxy.nix
@@ -96,13 +96,14 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = {nodes}:
 ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestPrecondition, TestCheck, wait_for_logs, configure_proxy
 
 latest_version = "9.9.9-TEST"
 
@@ -143,10 +144,10 @@ configure_proxy(playos, proxy_url)
 
 ### === Test scenario
 
-with TestCase("Controller uses proxy for captive portal"):
+with TestCheck("Controller uses proxy for captive portal"):
    playos.succeed("curl -f http://localhost:3333/internet/status | grep TEST_CAPTIVE_RESPONSE") 
 
-with TestCase("Controller is able to query the version and initiate download"):
+with TestCheck("Controller is able to query the version and initiate download"):
     wait_for_logs(playos,
         f"Downloading.*{latest_version}",
         unit="playos-controller.service",

--- a/testing/integration/controller-proxy.nix
+++ b/testing/integration/controller-proxy.nix
@@ -73,10 +73,6 @@ pkgs.testers.runNixOSTest {
       ];
 
       config = {
-        # work-around to nixos broken network targets when connman is used.
-        # without this, network.target is never activated.
-        systemd.targets.network.wantedBy = [ "multi-user.target" ];
-
         networking.firewall.enable = false;
 
         services.connman = {

--- a/testing/integration/controller-system-buttons.nix
+++ b/testing/integration/controller-system-buttons.nix
@@ -59,7 +59,7 @@ pkgs.testers.runNixOSTest {
     def manual_restart():
         playos.reboot()
         # needed to avoid using wait_for_unit during reboot
-        playos.wait_for_console_text("NixOS Stage 2")
+        playos.wait_for_console_text("Shutting down")
         wait_for_http()
         # produces the reboot/shutdown log messages used in `wait_for_console_text`
         playos.wait_for_unit("systemd-logind.service")

--- a/testing/integration/controller-watchdog-controls.nix
+++ b/testing/integration/controller-watchdog-controls.nix
@@ -68,7 +68,7 @@ pkgs.testers.runNixOSTest {
         playos.wait_for_console_text("playos-network-watchdog.service: Deactivated successfully.")
         playos.fail("systemctl is-active playos-network-watchdog.service")
         playos.execute("systemctl restart playos-network-watchdog.service")
-        playos.wait_for_console_text("watchdog was skipped because of an unmet condition")
+        playos.wait_for_console_text("watchdog.*skipped.*unmet condition")
         playos.fail("systemctl is-active playos-network-watchdog.service")
 
     with subtest("Network watchdog enable works"):

--- a/testing/integration/controller-wifi.nix
+++ b/testing/integration/controller-wifi.nix
@@ -249,10 +249,17 @@ with TestPrecondition("Test APs are setup and visible to connman"):
     # Wait until connman sees all the APs
     # Note: due to the wpa_supplicant restarts (from the rfkill.hook), the
     # timing is kinda unpredictable.
-    # In particular the `bad-ap-blocked` seems to take an extra 10 seconds to
-    # appear.
+
+    # Wait until rfkill is unblocked and connman can actually perform the scan
+    playos.wait_until_succeeds(
+        # connmanctl exits 0 even when scan fails ("Error ...: No carrier"),
+        "! connmanctl scan wifi 2>&1 | grep -q Error",
+        timeout=30,
+    )
+
+    # Check that each AP is visible
     for ap in all_simulated_aps:
-        playos.wait_until_succeeds(f"connmanctl services | grep {ap}", timeout=60)
+        playos.wait_until_succeeds(f"connmanctl services | grep {ap}", timeout=90)
 
 # === sanity check
 

--- a/testing/integration/controller-wifi.nix
+++ b/testing/integration/controller-wifi.nix
@@ -178,6 +178,7 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.requests
     ps.types-requests
     ps.colorama
@@ -190,7 +191,7 @@ pkgs.testers.runNixOSTest {
     badSimulatedAPs = filter (strings.hasPrefix "bad-ap-") allSSIDs;
     goodSimulatedAPs = lists.subtractLists badSimulatedAPs allSSIDs;
   in ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestPrecondition, TestCheck
 import requests
 
 bad_simulated_aps = set("${toString badSimulatedAPs}".split())
@@ -257,7 +258,7 @@ with TestPrecondition("Test APs are setup and visible to connman"):
 
 wait_for_http()
 
-with TestCase("controller sees the wifi iface and APs") as t:
+with TestCheck("controller sees the wifi iface and APs") as t:
     headers = {'Accept': 'application/json'}
     r = requests.get("http://localhost:13333/network", headers=headers)
     r.raise_for_status()
@@ -276,7 +277,7 @@ PASSPHRASE_SERVICES = [s for s in GOOD_SERVICES if s['name'] != "test-ap-open"]
 
 EAP_SERVICE = find_service_by_name("bad-ap-eap", BAD_SERVICES)
 
-with TestCase("controller can connect to all good APs") as t:
+with TestCheck("controller can connect to all good APs") as t:
     for service in GOOD_SERVICES:
         passphrase = None if service['name'] == "test-ap-open" else 'reproducibility'
         r = connect_req(service, passphrase=passphrase, timeout=60)
@@ -287,7 +288,7 @@ with TestCase("controller can connect to all good APs") as t:
         t.assertIsNotNone(found)
         t.assertEqual("Ready", found['state'])
 
-with TestCase("controller can forget all APs") as t:
+with TestCheck("controller can forget all APs") as t:
     for service in GOOD_SERVICES:
         r = remove_req(service)
         r.raise_for_status()
@@ -297,21 +298,21 @@ with TestCase("controller can forget all APs") as t:
         t.assertIsNotNone(found)
         t.assertEqual("Idle", found['state'])
 
-with TestCase("controller produces clear errors when passphrase is incorrect") as t:
+with TestCheck("controller produces clear errors when passphrase is incorrect") as t:
     for service in PASSPHRASE_SERVICES:
         r = connect_req(service, passphrase='incorrectpass')
         t.assertRaises(requests.exceptions.HTTPError, r.raise_for_status)
         output = r.json()
         t.assertIn("Password is not valid", output['message'])
 
-with TestCase("controller produces clear errors when passphrase is missing") as t:
+with TestCheck("controller produces clear errors when passphrase is missing") as t:
     for service in PASSPHRASE_SERVICES:
         r = connect_req(service, passphrase=None)
         t.assertRaises(requests.exceptions.HTTPError, r.raise_for_status)
         output = r.json()
         t.assertIn("Password is required", output['message'])
 
-with TestCase("controller informs the user when auth protocol is unsupported") as t:
+with TestCheck("controller informs the user when auth protocol is unsupported") as t:
     r = connect_req(EAP_SERVICE, passphrase='whatever')
     t.assertRaises(requests.exceptions.HTTPError, r.raise_for_status)
     output = r.json()

--- a/testing/integration/factory-reset-scenario.py
+++ b/testing/integration/factory-reset-scenario.py
@@ -3,14 +3,14 @@ playos.start(allow_reboot=True)
 with TestPrecondition("Persistent data is mounted"):
     playos.wait_for_unit('mnt-data.mount')
 
-with TestCase("Persistent data remains after reboot"):
+with TestCheck("Persistent data remains after reboot"):
     playos.succeed("echo TEST_DATA > /mnt/data/persist-me")
     playos.shutdown()
     playos.start(allow_reboot=True)
     playos.wait_for_unit('mnt-data.mount')
     playos.succeed("grep TEST_DATA /mnt/data/persist-me")
 
-with TestCase("Persistent data is wiped if factory reset is triggered"):
+with TestCheck("Persistent data is wiped if factory reset is triggered"):
     playos.succeed("systemctl start playos-wipe-persistent-data.service")
     playos.shutdown()
     playos.start()

--- a/testing/integration/factory-reset.nix
+++ b/testing/integration/factory-reset.nix
@@ -53,12 +53,14 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestPrecondition, TestCheck
+import subprocess
 
 # ==== Setup: create disk images for /boot and /mnt/data
 

--- a/testing/integration/kiosk-audio.nix
+++ b/testing/integration/kiosk-audio.nix
@@ -92,7 +92,7 @@ pkgs.testers.runNixOSTest {
     machine.start()
 
     machine.wait_for_file("/tmp/www")
-    machine.succeed("ln -s '${opusFile}' /tmp/www/demo.opus")
+    machine.succeed("cp '${opusFile}' /tmp/www/demo.opus")
     machine.succeed("""cat << EOF > /tmp/www/index.html
     <html>
     <head>

--- a/testing/integration/kiosk-audio.nix
+++ b/testing/integration/kiosk-audio.nix
@@ -79,6 +79,7 @@ pkgs.nixosTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
     ps.pillow
@@ -86,7 +87,7 @@ pkgs.nixosTest {
   ];
 
   testScript = ''
-    ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import TestPrecondition, TestCheck, wait_for_logs
 
     machine.start()
 
@@ -115,7 +116,7 @@ pkgs.nixosTest {
     with TestPrecondition("Chromium is producing logs"):
         wait_for_logs(machine, "Ready to play", timeout=40);
 
-    with TestCase("Audio playback was succesful"):
+    with TestCheck("Audio playback was succesful"):
         wait_for_logs(machine, "Audio was played", timeout=2);
 '';
 }

--- a/testing/integration/kiosk-audio.nix
+++ b/testing/integration/kiosk-audio.nix
@@ -13,7 +13,7 @@ let
   };
   inherit (builtins) toString;
 in
-pkgs.nixosTest {
+pkgs.testers.runNixOSTest {
   name = "Kiosk can play opus files";
 
   nodes.machine = { config, ... }: {

--- a/testing/integration/kiosk-detect-keyboard.nix
+++ b/testing/integration/kiosk-detect-keyboard.nix
@@ -9,7 +9,7 @@ let
   };
   inherit (builtins) toString;
 in
-pkgs.nixosTest {
+pkgs.testers.runNixOSTest {
   name = "Virtual keyboard tests";
 
   nodes.machine = { config, ... }: {

--- a/testing/integration/kiosk-detect-keyboard.nix
+++ b/testing/integration/kiosk-detect-keyboard.nix
@@ -63,12 +63,13 @@ pkgs.nixosTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = ''
-    ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import TestCheck, wait_for_logs
 
     machine.start()
 
@@ -77,16 +78,16 @@ pkgs.nixosTest {
 
     checkpoint = None
 
-    with TestCase("kiosk detects no keyboard attached"):
+    with TestCheck("kiosk detects no keyboard attached"):
         checkpoint = wait_for_logs(machine, "enabling virtual keyboard", timeout=20)
 
-    with TestCase("new keyboard device -> disable virtual keyboard"):
+    with TestCheck("new keyboard device -> disable virtual keyboard"):
         machine.send_monitor_command("device_add usb-kbd,id=testkbd")
         wait_for_logs(machine, "New USB device found", since=checkpoint, timeout=5)
         checkpoint = wait_for_logs(machine, "Product: QEMU USB Keyboard", since=checkpoint, timeout=5)
         checkpoint = wait_for_logs(machine, "disabling virtual keyboard", since=checkpoint, timeout=5)
 
-    with TestCase("keyboard device unplugged -> enable virtual keyboard"):
+    with TestCheck("keyboard device unplugged -> enable virtual keyboard"):
         machine.send_monitor_command("device_del testkbd")
         checkpoint = wait_for_logs(machine, "enabling virtual keyboard", since=checkpoint, timeout=5)
 '';

--- a/testing/integration/kiosk-proxy.nix
+++ b/testing/integration/kiosk-proxy.nix
@@ -10,7 +10,7 @@ let
   };
   toString = builtins.toString;
 in
-pkgs.nixosTest {
+pkgs.testers.runNixOSTest {
   name = "proxy-test";
 
   nodes = {

--- a/testing/integration/kiosk-proxy.nix
+++ b/testing/integration/kiosk-proxy.nix
@@ -83,13 +83,14 @@ pkgs.nixosTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
 
   testScript = ''
-    ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import TestPrecondition, TestCheck, wait_for_logs, get_first_connman_service_name
 
     def reset():
       theproxy.succeed('rm -f /var/log/request-counter')
@@ -126,7 +127,7 @@ pkgs.nixosTest {
     client.wait_for_x()
     client.wait_for_unit("connman.service")
 
-    with TestCase('kiosk-browser uses configured proxy') as t:
+    with TestCheck('kiosk-browser uses configured proxy') as t:
       service_name = get_first_connman_service_name(client)
       client.succeed(f"connmanctl config {service_name} proxy manual http://user:p4ssw0rd@theproxy:${toString proxyPort}")
 

--- a/testing/integration/kiosk-recovery.nix
+++ b/testing/integration/kiosk-recovery.nix
@@ -19,7 +19,7 @@ let
   };
   inherit (builtins) toString;
 in
-pkgs.nixosTest {
+pkgs.testers.runNixOSTest {
   name = "Kiosk's nuke-cache clears optional data";
 
   enableOCR = true;

--- a/testing/integration/kiosk-recovery.nix
+++ b/testing/integration/kiosk-recovery.nix
@@ -82,12 +82,13 @@ pkgs.nixosTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = ''
-    ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import TestPrecondition, TestCheck, wait_for_logs
     machine.start()
     machine.wait_for_unit("graphical.target")
     machine.wait_for_unit("display-manager.service")
@@ -108,17 +109,17 @@ pkgs.nixosTest {
     out = machine.succeed("su - alice -c nuke-cache")
     print(out)
 
-    with TestCase("nuke-cache removed the expected cache / SW paths"):
+    with TestCheck("nuke-cache removed the expected cache / SW paths"):
       for path in PATHS_TO_NUKE:
         machine.fail(f"ls -l '{path}'")
 
-    with TestCase("kiosk is able to start after the removal"):
+    with TestCheck("kiosk is able to start after the removal"):
       machine.systemctl("start display-manager.service")
       machine.wait_for_unit("display-manager.service")
       machine.systemctl("is-active display-manager.service")
       machine.systemctl("is-active user-1000.session")
 
-    with TestCase("loading the page produced no unexpected errors from JS") as t:
+    with TestCheck("loading the page produced no unexpected errors from JS") as t:
       try:
         # these are produced in kiosk-recovery/index.html for unexpected paths,
         # so should not be present
@@ -128,7 +129,7 @@ pkgs.nixosTest {
         pass
 
     if EXPECTED_TEXT:
-      with TestCase(f"Page displays '{EXPECTED_TEXT}'"):
+      with TestCheck(f"Page displays '{EXPECTED_TEXT}'"):
         machine.wait_for_text(EXPECTED_TEXT, timeout=5)
 '';
 }

--- a/testing/integration/kiosk-recovery.nix
+++ b/testing/integration/kiosk-recovery.nix
@@ -33,11 +33,10 @@ pkgs.testers.runNixOSTest {
         "-enable-kvm"
       ];
 
-      environment.etc."www/index.html".text = builtins.readFile ./kiosk-recovery/index.html;
-      environment.etc."www/sw.js".text = builtins.readFile ./kiosk-recovery/sw.js;
       services.static-web-server.enable = true;
       services.static-web-server.listen = "[::]:8080";
-      services.static-web-server.root = "/etc/www";
+      # serves index.html and sw.js
+      services.static-web-server.root = "${./kiosk-recovery}";
 
       services.xserver = let sessionName = "kiosk-browser";
       in {

--- a/testing/integration/kiosk-reload.nix
+++ b/testing/integration/kiosk-reload.nix
@@ -9,7 +9,7 @@ let
   };
   inherit (builtins) toString;
 in
-pkgs.nixosTest {
+pkgs.testers.runNixOSTest {
   name = "Kiosk responds to Play reload events";
 
   enableOCR = true;

--- a/testing/integration/kiosk-reload.nix
+++ b/testing/integration/kiosk-reload.nix
@@ -113,23 +113,24 @@ app.run(host="0.0.0.0", port=${toString serverPort})
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = ''
-    ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import TestPrecondition, TestCheck, wait_for_logs
     machine.start()
     machine.wait_for_unit("graphical.target")
 
     with TestPrecondition("kiosk loads the page"):
         wait_for_logs(machine, "PAGE: Page loaded, counter: 1", timeout=10)
 
-    with TestCase("kiosk handles beforereload and loads specified url"):
+    with TestCheck("kiosk handles beforereload and loads specified url"):
         wait_for_logs(machine, "PAGE: Page loaded, counter: 2", timeout=10)
         checkpoint = wait_for_logs(machine, "PAGE: Page loaded, counter: 3", timeout=10)
 
-    with TestCase("kiosk returns to main url on manual reload"):
+    with TestCheck("kiosk returns to main url on manual reload"):
         machine.send_key("ctrl-r")
         wait_for_logs(machine, "PAGE: Page loaded, counter: 1", since=checkpoint, timeout=10)
 '';

--- a/testing/integration/kiosk-screen-resolution.nix
+++ b/testing/integration/kiosk-screen-resolution.nix
@@ -74,6 +74,7 @@ pkgs.nixosTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
     ps.pillow
@@ -81,7 +82,9 @@ pkgs.nixosTest {
   ];
 
   testScript = ''
-    ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import TestCheck
+    import tempfile
+    import time
     from collections import Counter
     from PIL import Image, ImageChops
 
@@ -142,7 +145,7 @@ pkgs.nixosTest {
 
     original_kiosk_pid = get_kiosk_pid()
 
-    with TestCase("kiosk gracefully responds to screen and mode changes") as t,\
+    with TestCheck("kiosk gracefully responds to screen and mode changes") as t,\
             tempfile.TemporaryDirectory() as d:
         xrandr("--mode 640x480")
         time.sleep(3) # give kiosk time to resize

--- a/testing/integration/kiosk-screen-resolution.nix
+++ b/testing/integration/kiosk-screen-resolution.nix
@@ -11,7 +11,7 @@ let
   };
   inherit (builtins) toString;
 in
-pkgs.nixosTest {
+pkgs.testers.runNixOSTest {
   name = "Kiosk gracefully switches between output modes";
 
   nodes.machine = { config, ... }: {

--- a/testing/integration/kiosk-virtual-keyboard.nix
+++ b/testing/integration/kiosk-virtual-keyboard.nix
@@ -11,7 +11,7 @@ let
   hintIcon = ../../kiosk/images/vkb-activation-hint.png;
   inherit (builtins) toString;
 in
-pkgs.nixosTest {
+pkgs.testers.runNixOSTest {
   name = "Virtual keyboard tests";
 
   nodes.machine = { config, ... }: {

--- a/testing/integration/kiosk-virtual-keyboard.nix
+++ b/testing/integration/kiosk-virtual-keyboard.nix
@@ -79,6 +79,7 @@ pkgs.nixosTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
     ps.pillow
@@ -86,7 +87,9 @@ pkgs.nixosTest {
   ];
 
   testScript = ''
-    ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import TestPrecondition, TestCheck, wait_for_logs
+    import tempfile
+    import time
     from collections import Counter
     from PIL import Image, ImageChops, ImageEnhance
 
@@ -220,7 +223,7 @@ pkgs.nixosTest {
             "Screen is not mostly white, is the keyboard visible?"
         )
 
-    with TestCase("keyboard hint shows up when input field is focused") as t:
+    with TestCheck("keyboard hint shows up when input field is focused") as t:
         # focus first numeric input field
         machine.send_key("tab")
         time.sleep(1)
@@ -230,7 +233,7 @@ pkgs.nixosTest {
             "Could not find activation hint icon in screenshot - did it show up?")
 
 
-    with TestCase("keyboard (numeric) shows up when activated"):
+    with TestCheck("keyboard (numeric) shows up when activated"):
         # activate keyboard
         machine.send_key("ret")
         time.sleep(1)
@@ -244,7 +247,7 @@ pkgs.nixosTest {
         )
 
 
-    with TestCase("keyboard (numeric) accepts input"):
+    with TestCheck("keyboard (numeric) accepts input"):
         # spam a few random keys on the vkb
         machine.send_key("down")
         machine.send_key("ret")
@@ -258,7 +261,7 @@ pkgs.nixosTest {
         time.sleep(1) # wait for all keys to be processed
 
 
-    with TestCase("keyboard (numeric) is hidden/shown with escape/enter") as t:
+    with TestCheck("keyboard (numeric) is hidden/shown with escape/enter") as t:
         pre_close_screen = make_screenshot()
 
         # close vkb
@@ -276,7 +279,7 @@ pkgs.nixosTest {
             extra_msg="Virtual keyboard not visible after reactivation with Return?")
 
 
-    with TestCase("keyboard is hidden when input field is unfocused") as t:
+    with TestCheck("keyboard is hidden when input field is unfocused") as t:
         # focus on button, keyboard should hide, no hint visible
         machine.send_key("tab")
         time.sleep(1)
@@ -285,7 +288,7 @@ pkgs.nixosTest {
             extra_msg="Virtual keyboard did not hide on unfocus?")
 
 
-    with TestCase("keyboard (text) is activated on text field") as t:
+    with TestCheck("keyboard (text) is activated on text field") as t:
         # focus on text field
         machine.send_key("tab")
         time.sleep(1)
@@ -311,7 +314,7 @@ pkgs.nixosTest {
             "Screenshots too similar, virtual keyboard layout did not change?"
         )
 
-    with TestCase("keyboard (text) accepts input") as t:
+    with TestCheck("keyboard (text) accepts input") as t:
         machine.send_key("down")
         machine.send_key("ret")
         machine.send_key("right")
@@ -324,7 +327,7 @@ pkgs.nixosTest {
         time.sleep(1) # wait for all keys to be processed
 
 
-    with TestCase("keyboard (text) can be closed and reactivated") as t:
+    with TestCheck("keyboard (text) can be closed and reactivated") as t:
         pre_close_screen_text = make_screenshot()
 
         # esc button - keyboard should be gone

--- a/testing/integration/monitoring-basic.nix
+++ b/testing/integration/monitoring-basic.nix
@@ -51,6 +51,7 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
@@ -62,8 +63,9 @@ pkgs.testers.runNixOSTest {
       dbName = monCfg.localDbName;
     in
     ''
-      ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+      from playos_test_helpers import TestCheck
       import csv
+      import time
 
       ## CONSTANTS
 
@@ -85,11 +87,11 @@ pkgs.testers.runNixOSTest {
 
       machine.start()
 
-      with TestCase("influxdb and telegraf are running"):
+      with TestCheck("influxdb and telegraf are running"):
         machine.wait_for_unit("influxdb.service", timeout=10)
         machine.wait_for_unit("telegraf.service", timeout=10)
 
-      with TestCase("Retention policy is setup") as t:
+      with TestCheck("Retention policy is setup") as t:
         results = list(run_query("SHOW RETENTION POLICIES"))
         t.assertEqual(len(results), 1,
           f"More than one retention policy found: {results}")
@@ -106,7 +108,7 @@ pkgs.testers.runNixOSTest {
       print("Restarting telegraf to force flush")
       machine.systemctl("restart telegraf.service")
 
-      with TestCase("Metrics are received") as t:
+      with TestCheck("Metrics are received") as t:
         results = list(run_query("SELECT * FROM mem LIMIT 2"))
         t.assertGreater(len(results), 1, "Expected at least 2 rows")
         first_result = results[0]
@@ -114,11 +116,11 @@ pkgs.testers.runNixOSTest {
         t.assertIn("free", first_result)
         t.assertIn("used", first_result)
 
-      with TestCase("Metrics are tagged with machine-id") as t:
+      with TestCheck("Metrics are tagged with machine-id") as t:
         machineId = machine.succeed("cat /etc/machine-id").strip()
         t.assertEqual(first_result['host'], f"playos-{machineId}")
 
-      with TestCase("Unnecessary tags are dropped") as t:
+      with TestCheck("Unnecessary tags are dropped") as t:
         cpu_row = list(run_query("SELECT * FROM cpu LIMIT 1"))[0]
         t.assertNotIn("time_guest_nice", cpu_row)
         t.assertNotIn("usage_guest_nice", cpu_row)

--- a/testing/integration/monitoring-stress.nix
+++ b/testing/integration/monitoring-stress.nix
@@ -127,6 +127,7 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
@@ -134,9 +135,10 @@ pkgs.testers.runNixOSTest {
   testScript =
     { nodes }:
     ''
-      ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+      from playos_test_helpers import TestPrecondition, TestCheck
       import math
       import json
+      import time
 
       ## CONSTANTS
 
@@ -254,14 +256,14 @@ pkgs.testers.runNixOSTest {
       print(f"Collecting Telegraf stats for {sleep_duration} seconds...")
       time.sleep(sleep_duration)
 
-      with TestCase("Memory usage of Telegraf is reasonable") as t:
+      with TestCheck("Memory usage of Telegraf is reasonable") as t:
           telegraf_stats = get_and_print_memory_stats("telegraf.service")
           t.assertLess(telegraf_stats['memory_peak'], MAX_TELEGRAF_PEAK_MEMORY_MB)
 
       print("Stopping Telegraf to force data flush.")
       machine.systemctl("stop telegraf.service")
 
-      with TestCase("Memory usage of InfluxDB is reasonable") as t:
+      with TestCheck("Memory usage of InfluxDB is reasonable") as t:
           influxdb_stats = get_and_print_memory_stats("influxdb.service")
           t.assertLess(influxdb_stats['memory_peak'], MAX_INFLUXDB_PEAK_MEMORY_MB)
 
@@ -270,7 +272,7 @@ pkgs.testers.runNixOSTest {
       with TestPrecondition("Cardinality of data collected by Telegraf matches stress test setup") as t:
           check_cardinalities(t)
 
-      with TestCase(f"Generate {weeks} weeks of data (SLOW_MODE = ${lib.boolToString slowMode})"):
+      with TestCheck(f"Generate {weeks} weeks of data (SLOW_MODE = ${lib.boolToString slowMode})"):
           res = machine.succeed(
           f"""inch \
                   -no-setup \
@@ -292,7 +294,7 @@ pkgs.testers.runNixOSTest {
       # Note: memory limits enforced via MemoryMax, "realistic" memory only
       # checked at the end
 
-      with TestCase("Disk usage after stress test is within limits") as t:
+      with TestCheck("Disk usage after stress test is within limits") as t:
           check_stored_size(t)
 
 
@@ -303,7 +305,7 @@ pkgs.testers.runNixOSTest {
       print("====== STATS AFTER compaction ========")
       get_and_print_memory_stats("influxdb.service")
 
-      with TestCase("Disk usage after compaction is within limits") as t:
+      with TestCheck("Disk usage after compaction is within limits") as t:
           check_stored_size(t)
 
       print("====== STATS AFTER restarting ========")
@@ -312,10 +314,10 @@ pkgs.testers.runNixOSTest {
           time.sleep(10)
       stats = get_and_print_memory_stats("influxdb.service")
 
-      with TestCase("InfluxDB memory usage after restart is within limits") as t:
+      with TestCheck("InfluxDB memory usage after restart is within limits") as t:
           t.assertLess(stats['memory_peak'], MAX_INFLUXDB_PEAK_MEMORY_MB)
 
-      with TestCase("Disk usage after restart is within limits") as t:
+      with TestCheck("Disk usage after restart is within limits") as t:
           check_stored_size(t)
     '';
 }

--- a/testing/integration/network-watchdog-wifi.nix
+++ b/testing/integration/network-watchdog-wifi.nix
@@ -83,13 +83,14 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = {nodes}:
 ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestPrecondition, TestCheck, wait_for_logs, wait_until_passes
 ## == Helpers
 
 def checkpoint_now():
@@ -118,7 +119,7 @@ with TestPrecondition("connman sees the wifi AP"):
 
 ## == Test cases
 
-with TestCase("connman ignores wifi signal strength changes") as t:
+with TestCheck("connman ignores wifi signal strength changes") as t:
     checkpoint = checkpoint_now()
     playos.succeed("iw dev wlan0 set txpower fixed 0")
     connman_scan_wifi()
@@ -126,7 +127,7 @@ with TestCase("connman ignores wifi signal strength changes") as t:
         unit='playos-network-watchdog.service',
         since=checkpoint, timeout=30)
 
-with TestCase("wifi AP temporarily disappearing does not cause watchdog setting updates") as t:
+with TestCheck("wifi AP temporarily disappearing does not cause watchdog setting updates") as t:
     checkpoint = checkpoint_now()
     playos.succeed("iw dev wlan0 ap stop")
     for _ in range(0, ${toString bssExpirationScanCount} - 1):

--- a/testing/integration/network-watchdog.nix
+++ b/testing/integration/network-watchdog.nix
@@ -215,7 +215,6 @@ with TestPrecondition("PlayOS is booted and services are running "):
     playos.wait_for_unit('playos-network-watchdog.service')
     playos.wait_for_unit('tinyproxy.service')
     playos.wait_for_unit('always-ok-http-service.service')
-    playos.wait_for_unit("network-online.target")
 
 with TestPrecondition("PlayOS can reach HTTPStubServer`s"):
     # assert we can reach the stub servers...

--- a/testing/integration/network-watchdog.nix
+++ b/testing/integration/network-watchdog.nix
@@ -70,6 +70,9 @@ pkgs.testers.runNixOSTest {
           };
         };
 
+        # work-around to nixos broken network targets when connman is used
+        systemd.targets.network.wantedBy = [ "multi-user.target" ];
+
         services.connman = {
           enable = pkgs.lib.mkOverride 0 true; # disabled in runNixOSTest by default
         };
@@ -215,11 +218,14 @@ with TestPrecondition("PlayOS is booted and services are running "):
     playos.wait_for_unit('playos-network-watchdog.service')
     playos.wait_for_unit('tinyproxy.service')
     playos.wait_for_unit('always-ok-http-service.service')
+    playos.wait_for_unit('multi-user.target')
 
 with TestPrecondition("PlayOS can reach HTTPStubServer`s"):
     # assert we can reach the stub servers...
-    playos.succeed("curl ${primaryCheckUrl}")
-    playos.succeed("curl ${secondaryCheckUrl}")
+    # wrapping in wait_until_passes, since curl hangs forever if port forwarding
+    # is broken
+    wait_until_passes(lambda: playos.succeed("curl ${primaryCheckUrl}", timeout=1))
+    wait_until_passes(lambda: playos.succeed("curl ${secondaryCheckUrl}", timeout=1))
     # ...but they return an HTTP status code >=400
     playos.fail("curl --fail ${primaryCheckUrl}")
     playos.fail("curl --fail ${secondaryCheckUrl}")

--- a/testing/integration/network-watchdog.nix
+++ b/testing/integration/network-watchdog.nix
@@ -91,6 +91,7 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
@@ -100,7 +101,7 @@ let
     watchdogCfg = nodes.playos.playos.networking.watchdog;
 in
 ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestPrecondition, TestCheck, wait_for_logs, get_first_connman_service_name, HTTPStubServer, wait_until_passes
 import datetime
 
 ## == Config vars
@@ -232,7 +233,7 @@ with TestPrecondition("Proxy and always-ok-http-service works") as t:
 
 ## == Test cases
 
-with TestCase("watchdog reaches ONCE_CONNECTED state") as t:
+with TestCheck("watchdog reaches ONCE_CONNECTED state") as t:
     wait_for_watchdog_state('ONCE_CONNECTED')
     expect_no_new_connman_restarts(t)
 
@@ -241,7 +242,7 @@ with TestCase("watchdog reaches ONCE_CONNECTED state") as t:
 
 stop_all_stubs()
 
-with TestCase("watchdog eventually reaches DISCONNECTED state and triggers restart") as t:
+with TestCheck("watchdog eventually reaches DISCONNECTED state and triggers restart") as t:
     wait_for_watchdog_state('DISCONNECTED')
     wait_for_connman_restart(t)
 
@@ -249,11 +250,11 @@ with TestCase("watchdog eventually reaches DISCONNECTED state and triggers resta
 
 STUB2.start()
 
-with TestCase("watchdog reaches ONCE_CONNECTED state with only secondary URL good"):
+with TestCheck("watchdog reaches ONCE_CONNECTED state with only secondary URL good"):
     wait_for_watchdog_state('ONCE_CONNECTED')
 
 
-with TestCase("watchdog goes into SETTING_CHANGE_DELAY after connman changes") as t:
+with TestCheck("watchdog goes into SETTING_CHANGE_DELAY after connman changes") as t:
     configure_connman("--domains whatever.local")
     wait_for_watchdog_state('SETTING_CHANGE_DELAY')
     wait_for_watchdog_state('ONCE_CONNECTED')
@@ -263,7 +264,7 @@ with TestCase("watchdog goes into SETTING_CHANGE_DELAY after connman changes") a
 # Note: this test case is "here" in the sequence, because by we know connman is
 # done with configuration and there should be no more SETTING_CHANGE_DELAYs that
 # affect the test timing.
-with TestCase("watchdog retries with sleep according to config") as t:
+with TestCheck("watchdog retries with sleep according to config") as t:
     stop_all_stubs()
     # when stubs are stopped, all the requests will time out, therefore the time
     # it takes to transition to DISCONNECTED should be exactly max_state_change_time_without_delay
@@ -278,7 +279,7 @@ with TestCase("watchdog retries with sleep according to config") as t:
 
 # This test case is inspired by a real-world scenario, see:
 # https://www.notion.so/dividat/PlayOS-network-connectivity-debugging-1fc6ed7e60528050a268f84009197715?source=copy_link#1fc6ed7e60528091b282f3dbfaf7db98
-with TestCase("watchdog restarts connman to recover from external ip setting corruption") as t:
+with TestCheck("watchdog restarts connman to recover from external ip setting corruption") as t:
     playos.succeed("ip address flush dev eth0")
     wait_for_watchdog_state('SETTING_CHANGE_DELAY')
     wait_for_watchdog_state('ONCE_CONNECTED')
@@ -287,7 +288,7 @@ with TestCase("watchdog restarts connman to recover from external ip setting cor
     wait_for_watchdog_state('ONCE_CONNECTED')
 
 
-with TestCase("watchdog recovers after ip route flush") as t:
+with TestCheck("watchdog recovers after ip route flush") as t:
     playos.succeed("ip route flush dev eth0")
     wait_for_watchdog_state('SETTING_CHANGE_DELAY')
     wait_for_watchdog_state('ONCE_CONNECTED')
@@ -299,7 +300,7 @@ with TestCase("watchdog recovers after ip route flush") as t:
 
 stop_all_stubs()
 
-with TestCase("watchdog detects configured proxy and uses it") as t:
+with TestCheck("watchdog detects configured proxy and uses it") as t:
     wait_for_watchdog_state('DISCONNECTED')
     wait_for_connman_restart(t)
     wait_for_watchdog_state('NEVER_CONNECTED')
@@ -309,7 +310,7 @@ with TestCase("watchdog detects configured proxy and uses it") as t:
     # proxy redirects check URLs to always-ok-http-service, so it works
     wait_for_watchdog_state('ONCE_CONNECTED')
 
-with TestCase("watchdog responds to proxy removal") as t:
+with TestCheck("watchdog responds to proxy removal") as t:
     configure_connman("--proxy direct")
     wait_for_watchdog_state('SETTING_CHANGE_DELAY')
     # stubs are still stopped, so we get disconnected
@@ -321,7 +322,7 @@ with TestCase("watchdog responds to proxy removal") as t:
 
 
 # test case for false positives - a bit synthetic
-with TestCase("if connman gets misconfigured, watchdog remains disconnected after restarting connman") as t:
+with TestCheck("if connman gets misconfigured, watchdog remains disconnected after restarting connman") as t:
     service = get_first_connman_service_name(playos)
     # invalid static IP config, should make checkServerIP unreachable
     playos.succeed(f"connmanctl config {service} --ipv4 manual 172.33.33.33 255.255.255.0 172.33.33.1")

--- a/testing/integration/playos-diagnostics.nix
+++ b/testing/integration/playos-diagnostics.nix
@@ -19,16 +19,18 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript =
 ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestCheck
 from contextlib import contextmanager
 from pathlib import Path
 import tarfile
+import tempfile
 from datetime import datetime
 import gzip
 import urllib.parse
@@ -91,7 +93,7 @@ def get_file_contents(archive_dir, glob_str, t=None):
 start_all()
 machine.wait_for_unit("multi-user.target")
 
-with TestCase("script outputs a valid gziped tar archive to stdout"):
+with TestCheck("script outputs a valid gziped tar archive to stdout"):
     run_diagnostic_script("> /tmp/diag.tar.gz")
     machine.succeed("mkdir -p /tmp/diag")
     machine.succeed("tar xvf /tmp/diag.tar.gz -C /tmp/")
@@ -99,7 +101,7 @@ with TestCase("script outputs a valid gziped tar archive to stdout"):
 
 ALL_DIAGNOSTIC_TYPES = [ t.lower() for t in run_diagnostic_script("--list-types")[1].split() ]
 
-with TestCase("archive contents contain expected structure") as t:
+with TestCheck("archive contents contain expected structure") as t:
     with diagnostic_output() as (_, tmpdir):
       top_level_items = list(tmpdir.iterdir())
 
@@ -128,7 +130,7 @@ with TestCase("archive contents contain expected structure") as t:
         t.assertGreater(len(list(dir.glob("*"))), 1)
 
 
-with TestCase("logs are collected according to --since limits") as t:
+with TestCheck("logs are collected according to --since limits") as t:
     machine.succeed('echo RECENT_TEST_LOG | systemd-cat -t TEST') # journald
     oldest_expected_date = datetime.fromisoformat(machine.succeed(
       'date --date="12 seconds ago" --rfc-3339=seconds | sed "s/ /T/"').strip())
@@ -144,7 +146,7 @@ with TestCase("logs are collected according to --since limits") as t:
             t.assertGreater(ts, oldest_expected_date,
                f"Logs contain entries with timestamps older than expected, line: {line}")
 
-with TestCase("proxy passwords are masked in connman output") as t:
+with TestCheck("proxy passwords are masked in connman output") as t:
     machine.wait_until_succeeds("connmanctl services | grep ethernet")
 
     ethernet_service_id = machine.succeed("connmanctl services | awk '/ethernet/ {print $NF}' | head -n 1").strip()
@@ -170,7 +172,7 @@ with TestCase("proxy passwords are masked in connman output") as t:
             f"The expected masked string '{expected_mask}' was not found.")
 
 
-with TestCase("--minimal flag excludes logs and metrics") as t:
+with TestCheck("--minimal flag excludes logs and metrics") as t:
     with diagnostic_output('--minimal') as (_, tmpdir):
         match = list(tmpdir.glob("playos-diagnostics-*/data/logs/"))
         t.assertEqual(match, [])
@@ -179,13 +181,13 @@ with TestCase("--minimal flag excludes logs and metrics") as t:
         t.assertEqual(match, [])
 
 
-with TestCase("--exclude excludes custom types") as t:
+with TestCheck("--exclude excludes custom types") as t:
     with diagnostic_output('--exclude NETWORK') as (_, tmpdir):
         match = list(tmpdir.glob("playos-diagnostics-*/data/network/"))
         t.assertEqual(match, [])
 
 
-with TestCase("command error exit codes are propagated up") as t:
+with TestCheck("command error exit codes are propagated up") as t:
     # create a faulty device and bind it to /etc/os-release to ensure all reads error out
     machine.succeed("echo '0 2048 error' | dmsetup create faulty_device")
     machine.succeed("mount --bind /dev/mapper/faulty_device /etc/os-release")
@@ -201,7 +203,7 @@ with TestCase("command error exit codes are propagated up") as t:
     machine.succeed("umount /etc/os-release")
 
 
-with TestCase("commands that hang are timed out") as t:
+with TestCheck("commands that hang are timed out") as t:
     # bind-mount /etc/os-release to an empty pipe to block reads forever
     machine.succeed("mkfifo /tmp/empty-pipe")
     machine.succeed("mount --bind /tmp/empty-pipe /etc/os-release")

--- a/testing/integration/power-button-shutdown.nix
+++ b/testing/integration/power-button-shutdown.nix
@@ -11,13 +11,15 @@ pkgs.testers.runNixOSTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
   ];
 
   testScript = {nodes}:
 ''
-${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import TestPrecondition, TestCheck
+import time
 
 with TestPrecondition("Power Button has been recognized"):
     machine.start()
@@ -26,14 +28,14 @@ with TestPrecondition("Power Button has been recognized"):
 
     print(machine.succeed("cat /proc/bus/input/devices"))
 
-with TestCase("Short press on power and sleep from regular keyboard are ignored"):
+with TestCheck("Short press on power and sleep from regular keyboard are ignored"):
     # https://github.com/qemu/qemu/blob/master/pc-bios/keymaps/en-us
     machine.send_monitor_command("sendkey 0xde") # XF86PowerOff
     machine.send_monitor_command("sendkey 0xdf") # XF86Sleep
     time.sleep(5)
     machine.succeed("echo still alive", timeout=1)
 
-with TestCase("ACPI shutdown command invokes shutdown"):
+with TestCheck("ACPI shutdown command invokes shutdown"):
     machine.send_monitor_command("system_powerdown")
     machine.wait_for_console_text("Stopped target Multi-User System")
 

--- a/testing/manual/kiosk-dual-screen.nix
+++ b/testing/manual/kiosk-dual-screen.nix
@@ -78,6 +78,7 @@ pkgs.nixosTest {
   };
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
     ps.diffimg
@@ -86,7 +87,9 @@ pkgs.nixosTest {
   #enableOCR = true;
 
   testScript = ''
-    ${builtins.readFile ../helpers/nixos-test-script-helpers.py}
+    from playos_test_helpers import TestCheck
+    import tempfile
+    import time
     import diffimg # type: ignore
 
     def xrandr(output, params):
@@ -123,7 +126,7 @@ pkgs.nixosTest {
 
     original_kiosk_pid = get_kiosk_pid()
 
-    with TestCase("kiosk gracefully responds to screen and mode changes") as t,\
+    with TestCheck("kiosk gracefully responds to screen and mode changes") as t,\
             tempfile.TemporaryDirectory() as d:
         xrandr("Virtual-1", "--primary --mode 640x480")
         time.sleep(3) # give controller time to resize

--- a/testing/manual/kiosk-dual-screen.nix
+++ b/testing/manual/kiosk-dual-screen.nix
@@ -16,7 +16,7 @@ let
   sessionName = "kiosk-browser";
   inherit (builtins) toString;
 in
-pkgs.nixosTest {
+pkgs.testers.runNixOSTest {
   name = "Kiosk gracefully switches between output screens and modes";
 
   nodes.machine = { config, ... }: {

--- a/testing/release-validation.nix
+++ b/testing/release-validation.nix
@@ -155,13 +155,12 @@ pkgs.testers.runNixOSTest {
         virtualisation.vlans = [ 1 ];
         networking.firewall.enable = false;
 
-        services.static-web-server.enable = true;
-        services.static-web-server.listen = "[::]:80";
-        services.static-web-server.root = "/tmp/www";
-
-        systemd.tmpfiles.rules = [
-            "d ${config.services.static-web-server.root} 0777 root root -"
-        ];
+        services.darkhttpd.enable = true;
+        services.darkhttpd.address = "::";
+        services.darkhttpd.port = 80;
+        services.darkhttpd.rootDir = "/run/darkhttpd";
+        systemd.services.darkhttpd.serviceConfig.RuntimeDirectory = "darkhttpd";
+        systemd.services.darkhttpd.serviceConfig.RuntimeDirectoryMode = "0777";
 
         services.dnsmasq.enable = true;
         services.dnsmasq.settings = {
@@ -233,7 +232,7 @@ product_name = "${safeProductName}"
 pre_version = "${preSystemVersion}"
 next_version = "${nextSystemVersion}"
 
-http_root = "${nodes.sidekick.services.static-web-server.root}"
+http_root = "${nodes.sidekick.services.darkhttpd.rootDir}"
 http_local_url = "http://127.0.0.1"
 
 ### Test helpers

--- a/testing/release-validation.nix
+++ b/testing/release-validation.nix
@@ -203,6 +203,7 @@ pkgs.testers.runNixOSTest {
   ];
 
   extraPythonPackages = ps: [
+    ps.playos-test-helpers
     ps.colorama
     ps.types-colorama
     ps.requests
@@ -213,8 +214,12 @@ pkgs.testers.runNixOSTest {
   ];
 
   testScript = {nodes}: ''
-${builtins.readFile ./helpers/nixos-test-script-helpers.py}
+from playos_test_helpers import eprint, TestPrecondition, TestCheck, wait_for_logs, wait_until_passes
 ${builtins.readFile ./end-to-end/tests/base/proxy-and-update-helpers.py}
+import atexit
+import subprocess
+import tempfile
+import time
 import tesserocr # type: ignore
 import PIL.Image
 import PIL.ImageEnhance
@@ -472,7 +477,7 @@ with TestPrecondition("Navigate to System Status page") as t:
 ### Helpers re-used in both BASE->PRE and PRE->NEXT
 
 def check_update_is_downloaded_and_installed(stage):
-  with TestCase(f"{stage}: controller starts downloading the bundle") as t:
+  with TestCheck(f"{stage}: controller starts downloading the bundle") as t:
       def t_check():
           playos.send_key("ctrl-r")
           time.sleep(2)
@@ -482,7 +487,7 @@ def check_update_is_downloaded_and_installed(stage):
 
       wait_until_passes(t_check, retries=30, sleep=1)
 
-  with TestCase(f"{stage}: controller has downloaded and installed the bundle") as t:
+  with TestCheck(f"{stage}: controller has downloaded and installed the bundle") as t:
       # controller takes at least 2 minutes for the download
       # (1.2GB @ 10 MB/s), so allow up to 5 minutes for the download+install
       screen_text = wait_until_passes(
@@ -493,7 +498,7 @@ def check_update_is_downloaded_and_installed(stage):
 
 
 def check_system_boots_into_new_version(new_version, stage):
-    with TestCase(f"{stage}: kiosk is open with kiosk URL after reboot") as t:
+    with TestCheck(f"{stage}: kiosk is open with kiosk URL after reboot") as t:
         wait_until_passes(
             lambda: t.assertIn("Hello world", screenshot_and_ocr(playos)),
             retries=60,
@@ -502,7 +507,7 @@ def check_system_boots_into_new_version(new_version, stage):
 
     move_mouse_to_corner()
 
-    with TestCase(f"{stage}: controller GUI with new version is visible") as t:
+    with TestCheck(f"{stage}: controller GUI with new version is visible") as t:
         # switch to controller
         playos.send_key("ctrl-shift-f12")
         wait_until_passes(
@@ -510,7 +515,7 @@ def check_system_boots_into_new_version(new_version, stage):
             retries=10
         )
 
-    with TestCase(f"{stage}: The new booted version reaches a Good state") as t:
+    with TestCheck(f"{stage}: The new booted version reaches a Good state") as t:
         wait_until_passes(
             # UpdateError possible initially, because DHCP has not completed
             lambda: check_for_text_in_status_page("Good", ignore_errors=True),
@@ -539,7 +544,7 @@ reboot_via_tty()
 
 check_system_boots_into_new_version(next_version, "PRE->NEXT")
 
-with TestCase("Update state is UpToDate") as t:
+with TestCheck("Update state is UpToDate") as t:
     wait_until_passes(
         lambda: check_for_text_in_status_page("UpToDate", ignore_errors=True),
         retries=3, sleep=10)

--- a/testing/release-validation.nix
+++ b/testing/release-validation.nix
@@ -37,8 +37,8 @@
 # The system images have a passwordless root account, so you can gain root
 # access from the QEMU GUI:
 #   - switch to QEMU monitor console (using ctrl-alt-2 or the menu)
-#   - execute "sendkey ctrl-shift-f8" (switch to status screen on TTY8)
-#   - execute "sendkey ctrl-shift-f1" (switch to TTY1)
+#   - execute "sendkey ctrl-alt-f8" (switch to status screen on TTY8)
+#   - execute "sendkey ctrl-alt-f3" (switch to TTY3)
 #   - login with "root"
 let
     # Note: we use HTTP instead of HTTPS, because pkgs.fetchurl fails
@@ -389,11 +389,11 @@ def check_for_text_in_status_page(text, ignore_errors=False):
 
     t.assertIn(text, screen_text)
 
-# Note: done via root shell on tty1, since a QEMU system_reset corrupts the
+# Note: done via root shell on tty, since a QEMU system_reset corrupts the
 # /boot/status.ini due to unclean unmount + FAT
 def reboot_via_tty():
-    playos.send_key("ctrl-alt-f8", delay=2) # direct switch to tty1 prevented by limit-vtes.nix
-    playos.send_key("ctrl-alt-f1", delay=2)
+    playos.send_key("ctrl-alt-f8", delay=2) # direct switch to tty prevented by limit-vtes.nix
+    playos.send_key("ctrl-alt-f3", delay=2)
     playos.send_chars("root\n")
     time.sleep(2)
     playos.send_chars("systemctl reboot\n")

--- a/testing/run-in-vm/default.nix
+++ b/testing/run-in-vm/default.nix
@@ -1,9 +1,8 @@
-{ substituteAll
+{ replaceVars
 , version, disk, testingToplevel
 , bindfs, qemu, OVMF, python3
 }:
-substituteAll {
-  src = ./run-in-vm.py;
+replaceVars ./run-in-vm.py {
   inherit version disk testingToplevel;
   inherit bindfs qemu python3;
   ovmf = "${OVMF.fd}/FV/OVMF.fd";


### PR DESCRIPTION
Updated definitions to resolve deprecation warnings, eval errors and build errors.

## Issues

- [x] kiosk segfaults when started locally
- [x] kiosk crashes in `run-in-vm` because QML imports are not found
- [x] tests using `nixos-test-script-helpers` don't run due to mypy errors
- [x] Integration tests pass, currently failing:
  - [x] controller-interface-labeling.nix
  - [x] controller-proxy.nix
  - [x] controller-system-buttons.nix
  - [x] controller-watchdog-controls.nix
  - [x] kiosk-recovery.nix
  - [x] controller-wifi.nix
    - flaky, failing run: https://github.com/dividat/playos/actions/runs/25785981276/job/75739414045
    - historically this test is quite flaky and this could be just another instance which might still be present on `main`
    - possible that some deep wpa_supplicant and/or service ordering changes are triggering a worse path, which cause some backoffs/timeouts. Attempt to harden it further: 3fb4bc0
  - [x] network-watchdog.nix
    - seems to be flaky, need to review
    - details and fix attempt: cd968d8
    - fix insufficient, still flaky: https://github.com/dividat/playos/actions/runs/25717413931/job/75510417749?pr=303
    - seems to no longer flake after cac19ae 
- [x] E2E tests pass
- [x] Release validation tests pass: https://github.com/dividat/playos/actions/runs/25483115066
- [x] Add a message to all TTYs explaining how to return to the graphical session (to ensure the Ctrl+Alt+F7 change does not confuse operators): 1d81d83 

## Checklist

- [ ] Changelog updated
- [x] Code documented
- [x] User manual updated
- [x] Live ISO boot
- [x] Manual install
- [x] Clean up git commits
- [x] Bloat check: compare bundle sizes (`du -BM -sL $(nix-build -A components.unsignedRaucBundle)`)
  - RAUC bundle increased by 400M (+30%) compare to main (from 1323M to 1724M), need to investigate
  - Main 3 bloat contributors:
    1. Skeleton RAUC + deps: adds around ~70MB compressed (~240 MB uncompressed)
    2. linux-firmware increase: adds around ~150MB compressed (~500 MB uncompressed)
    3. gst-plugins-bad (new dep via pyqt6->qtmultimedia->gst-plugins-bad): adds around 50MB compressed, useless plugins (MIDI, TTS..), no way to disable without causing massive Qt rebuild...
  - The rest seem to be package increases.
  - The biggest potential savings are from trimming the linux-firmware image, made a separate issue to track this: https://github.com/dividat/playos/issues/343
- [x] Bloat check: compare installer sizes (`du -BM -sL $(nix-build -A components.installer.isoImage)`)
  - on main: `2252M`
  - here: `3345M`
  - ~49% (~1100MB) increase
  - attributable to the overall +970MB system image increase (see above) + rescueImage is now using different toplevel init due to skeleton split
  - unfortunate situation, but not much we can do here, #343 is still the best remedy
- [x] Read through NixOS 25.05 and 25.11 release notes: https://nixos.org/manual/nixos/stable/release-notes#sec-release-25.11
  - read through manually and also asked Claude to review, nothing beyond what is already changed/fixed.