### PR TITLE
Pin-down external GHA to SHA refs to protect against compromise

### DIFF
--- a/.github/actions/prep-build-env/action.yml
+++ b/.github/actions/prep-build-env/action.yml
@@ -81,14 +81,14 @@ runs:
       cp -r /root/.aws ~/.aws
 
   - name: Install post-run action
-    uses: yfyf/run-and-post-run@main
+    uses: yfyf/run-and-post-run@d4c684a8c8f09138bed7a27adbf1a7f8dae845bf # main, 2025-07-23
     with:
       post: |
         echo "Waiting for cache uploads to finish"
         sudo -i tsp -w || true
         sudo -i tsp -l
 
-  - uses: cachix/install-nix-action@v31.8.4
+  - uses: cachix/install-nix-action@0b0e072294b088b73964f1d72dfdac0951439dbd # v31.8.4
     with:
       nix_path: nixpkgs=channel:nixos-unstable
       extra_nix_config: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -56,7 +56,7 @@ jobs:
         run: ./build release-disk
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3
         with:
           aws-access-key-id:  ${{ secrets.TEST_DISKS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TEST_DISKS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -22,7 +22,7 @@ jobs:
           - "previous" # uses default in release-validation.nix
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - uses: ./.github/actions/prep-build-env
       with:
         NIX_CACHE_ACCOUNT_ID: ${{ secrets.NIX_CACHE_ACCOUNT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       integration_tests: ${{ steps.set-matrix-integration.outputs.integration_tests }}
       manual_tests: ${{ steps.set-matrix-manual.outputs.manual_tests }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - id: set-matrix-integration
       run: |
         FILES=$(find testing/integration -name '*.nix' -printf '"%p",')
@@ -31,7 +31,7 @@ jobs:
       matrix:
         file: ${{fromJson(needs.prepare-matrix.outputs.integration_tests)}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - uses: ./.github/actions/prep-build-env
       with:
         NIX_CACHE_ACCOUNT_ID: ${{ secrets.NIX_CACHE_ACCOUNT_ID }}
@@ -49,7 +49,7 @@ jobs:
       matrix:
         file: ${{fromJson(needs.prepare-matrix.outputs.manual_tests)}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - uses: ./.github/actions/prep-build-env
       with:
         NIX_CACHE_ACCOUNT_ID: ${{ secrets.NIX_CACHE_ACCOUNT_ID }}
@@ -62,7 +62,7 @@ jobs:
   kiosk-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - uses: ./.github/actions/prep-build-env
       with:
         NIX_CACHE_ACCOUNT_ID: ${{ secrets.NIX_CACHE_ACCOUNT_ID }}
@@ -74,7 +74,7 @@ jobs:
   build-vm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - uses: ./.github/actions/prep-build-env
       with:
         NIX_CACHE_ACCOUNT_ID: ${{ secrets.NIX_CACHE_ACCOUNT_ID }}
@@ -86,7 +86,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - uses: ./.github/actions/prep-build-env
       with:
         NIX_CACHE_ACCOUNT_ID: ${{ secrets.NIX_CACHE_ACCOUNT_ID }}
@@ -107,7 +107,7 @@ jobs:
   ocaml-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - uses: ./.github/actions/prep-build-env
       with:
         NIX_CACHE_ACCOUNT_ID: ${{ secrets.NIX_CACHE_ACCOUNT_ID }}


### PR DESCRIPTION
Been meaning to do this, but this was the final trigger: https://socket.dev/blog/bitwarden-cli-compromised

Doing this for e.g. `actions/checkout` might be overkill, but I think it is more hygienic if it is identical for all `uses:`