### PR TITLE
Add pcscd plugin for newer ACS smart card readers

### DIFF
--- a/application.nix
+++ b/application.nix
@@ -326,7 +326,13 @@ rec {
       playos.controller.annotateDiscoveredServices = [ "_sensoControl._tcp" "_sensoUpdate._udp" ];
 
       # Enable pcscd for smart card identification
-      services.pcscd.enable = true;
+      services.pcscd = {
+        enable = true;
+
+        # Support newer ACS readers (ACS-maintained; https://github.com/acshk/acsccid)
+        plugins = [ pkgs.acsccid ];
+      };
+
       # Allow play user to access pcsc
       security.polkit.extraConfig = ''
         polkit.addRule(function(action, subject) {


### PR DESCRIPTION
CCID[^1], used by pcscd out of the box supports various ACS[^2] readers, but some newer readers are not (yet) supported. ACS maintains a fork of CCID at https://github.com/acshk/acsccid [^3] which adds support for more of their readers.

This change will only really have the desired effect after updating Nixpkgs to 25.11 (https://github.com/dividat/playos/pull/303), at which point acsccid v1.1.13 will be brought in, which supports the ACS WalletMate II series (since v1.1.11). This series has identical dimensions to readers regularly used with Play, acts as a regular smart card reader to read out UIDs, but in addition supports Apple and Google wallet protocols. Either reader series may then be used, unblocking experimentation with smartphone "wallets" as alternative identification providers.

[^1]: https://ccid.apdu.fr/
[^2]: https://www.acs.com.hk/
[^3]: Sourceforge link in case GitHub is down: https://acsccid.sourceforge.io/

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
