### PR TITLE
Use standard poweroff with power button

### DIFF
--- a/application/power-management/default.nix
+++ b/application/power-management/default.nix
@@ -49,9 +49,8 @@ in {
       polkit.addRule(function(action, subject) {
         if (subject.user == "${user}" &&
           subject.isInGroup("${group}") &&
-          action.id == "org.freedesktop.systemd1.manage-units" &&
-          action.lookup("unit") == "poweroff.target" &&
-          action.lookup("verb") == "start") {
+          (action.id == "org.freedesktop.login1.power-off" ||
+           action.id == "org.freedesktop.login1.power-off-multiple-sessions")) {
           return polkit.Result.YES;
         }
       })

--- a/application/power-management/power-button-shutdown.py
+++ b/application/power-management/power-button-shutdown.py
@@ -16,7 +16,7 @@ def handle_device(device):
         for event in device.read_loop():
             if event.type == evdev.ecodes.EV_KEY and event.code == evdev.ecodes.KEY_POWER and event.value:
                 logging.info(f'KEY_POWER detected on {device.path}, shutting down')
-                subprocess.run(['systemctl', 'start', 'poweroff.target'], check=True)
+                subprocess.run(['systemctl', 'poweroff'], check=True)
     except Exception as e:
         logging.error(f'Error handling {device.path}: {e}')
 

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -462,7 +462,7 @@ end
 module StatusGui = struct
   open Status_page
 
-  let shutdown () = Util.run_cmd_no_stdout [| "halt"; "--poweroff" |]
+  let shutdown () = Util.run_cmd_no_stdout [| "systemctl"; "poweroff" |]
 
   let reboot () = Util.run_cmd_no_stdout [| "reboot" |]
 

--- a/testing/integration/power-button-shutdown.nix
+++ b/testing/integration/power-button-shutdown.nix
@@ -36,6 +36,7 @@ with TestCase("Short press on power and sleep from regular keyboard are ignored"
 with TestCase("ACPI shutdown command invokes shutdown"):
     machine.send_monitor_command("system_powerdown")
     machine.wait_for_console_text("Stopped target Multi-User System")
+    machine.wait_for_shutdown()
 
 # Test script does not finish on its own after shutdown
 exit(0)


### PR DESCRIPTION
This avoids a serious problem with power-button initiated shutdown surfacing in the context of #303 (but probably not caused by it).

In order to limit the required permissions of the service handling the PC power button, the handler started the systemd `poweroff.target` instead of invoking a poweroff[^1]. This has worked fine so far, but fails badly in the context of a nixpkgs bump[^2], where on attempting to shut down in this way the system gets stuck in a loop, trying to kill the display-manager, which is always restarted, with repeated execution of the destructive kiosk recovery service[^3].
    
The problem seems to be that the job-mode is not set to `replace-irreversibly` as it would when invoking `systemctl poweroff`[^4], so nothing stops new and conflicting service start jobs from being enqueued while the system still attempts to stop everything and shut down.
    
In theory this could have been a problem since the recovery mechanism for the kiosk/display-manager was added[^5], but seems to only surface in practice after the nixpkgs bump.
    
It might be enough to add a `--job-mode=replace-irreversibly` to the existing command, but it seems cleaner to allow the service user to request regular power-off via polkit, switching to `systemctl poweroff`.
    
[^1]: https://github.com/dividat/playos/commit/9578319fbd286ed7c58dba243d35725d15e2f5ca
[^2]: https://github.com/dividat/playos/pull/303
[^3]: https://github.com/dividat/playos/blob/a0c685b8b3e0da598db408ba3e31817419ea58c4/application.nix#L203-L217
[^4]: https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#poweroff
[^5]: https://github.com/dividat/playos/pull/324

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [x] User manual updated
