### PR TITLE
Separate nameservers form

### DIFF
--- a/controller/Changelog.md
+++ b/controller/Changelog.md
@@ -8,6 +8,7 @@
 # Changed
 
 - os: Pin versions of permanent components produced by installer
+- controller: Allow configuring static IP and DNS servers separately
 
 # [2026.3.0] - 2026-04-22
 

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -386,23 +386,29 @@ module NetworkGui = struct
               m "disabling static ip %s" (get_prop "static_ip_address")
           )
         in
-        let%lwt () = Connman.Service.set_dhcp_ipv4 service in
-        let%lwt () = Connman.Service.set_nameservers service [] in
-        return ()
+        Connman.Service.set_dhcp_ipv4 service
     | Some _ ->
         let address = get_prop "static_ip_address" in
         let netmask = get_prop "static_ip_netmask" in
         let gateway = get_prop "static_ip_gateway" in
+        Connman.Service.set_manual_ipv4 service ~address ~netmask ~gateway
+
+  (** Set custom nameservers on a service *)
+  let update_nameservers service form_data =
+    let get_prop s = form_data |> List.assoc s |> List.hd in
+    match form_data |> List.assoc_opt "nameservers_enabled" with
+    | None ->
+        let%lwt () =
+          Logs_lwt.info ~src:log_src (fun m -> m "Clearing custom nameservers")
+        in
+        Connman.Service.set_nameservers service []
+    | Some _ ->
         let nameservers =
-          get_prop "static_ip_nameservers"
+          get_prop "nameservers"
           |> String.split_on_char ','
           |> List.map String.trim
         in
-        let%lwt () =
-          Connman.Service.set_manual_ipv4 service ~address ~netmask ~gateway
-        in
-        let%lwt () = Connman.Service.set_nameservers service nameservers in
-        return ()
+        Connman.Service.set_nameservers service nameservers
 
   (** Connect to a service *)
   let connect ~(connman : Connman.Manager.t) req =
@@ -424,6 +430,8 @@ module NetworkGui = struct
     let%lwt service = with_service ~connman (param req "id") in
     (* Static IP *)
     let%lwt () = update_static_ip service form_data in
+    (* Custom Nameservers *)
+    let%lwt () = update_nameservers service form_data in
     (* Proxy *)
     let%lwt current_proxy = Manager.get_default_proxy connman in
     let%lwt () =

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -382,8 +382,8 @@ module NetworkGui = struct
     match form_data |> List.assoc_opt "static_ip_enabled" with
     | None ->
         let%lwt () =
-          Logs_lwt.err ~src:log_src (fun m ->
-              m "disabling static ip %s" (get_prop "static_ip_address")
+          Logs_lwt.info ~src:log_src (fun m ->
+              m "Disabling static IP, switching to DHCP"
           )
         in
         Connman.Service.set_dhcp_ipv4 service

--- a/controller/server/gui.ml
+++ b/controller/server/gui.ml
@@ -407,6 +407,7 @@ module NetworkGui = struct
           get_prop "nameservers"
           |> String.split_on_char ','
           |> List.map String.trim
+          |> List.filter (fun s -> s <> "")
         in
         Connman.Service.set_nameservers service nameservers
 

--- a/controller/server/view/network_details_page.ml
+++ b/controller/server/view/network_details_page.ml
@@ -177,22 +177,32 @@ let static_ip_form service =
             ~value:
               (ipv4_value (fun ipv4 -> ipv4.gateway |> Option.value ~default:""))
             ~pattern:ip_address_regex_pattern
-        @ ip_input ~name:"static_ip_nameservers" ~labelTxt:"Nameservers"
-            ~value:
-              ( if is_static service then String.concat ", " service.nameservers
-                else ""
-              )
-            ~pattern:multi_ip_address_regex_pattern
-        @ [ p
-              ~a:[ a_class [ "d-Note" ] ]
-              [ txt
-                  "To set multiple nameservers, use a comma separated list of \
-                   addresses."
-              ; br ()
-              ; txt "eg. 1.1.1.1, 9.9.9.9"
-              ]
-          ]
         )
+    ]
+
+let nameservers_form service =
+  let value = String.concat ", " service.nameservers in
+  div
+    [ label
+        ~a:[ a_class [ "d-Label" ] ]
+        [ txt "DNS Servers"
+        ; input
+            ~a:
+              [ a_value value
+              ; a_class [ "d-Input"; "d-Network__Input" ]
+              ; a_name "nameservers"
+              ; a_pattern multi_ip_address_regex_pattern
+              ]
+            ()
+        ]
+    ; p
+        ~a:[ a_class [ "d-Note" ] ]
+        [ txt
+            "To set multiple DNS nameservers, use a comma separated list of \
+             addresses."
+        ; br ()
+        ; txt "eg. 1.1.1.1, 9.9.9.9"
+        ]
     ]
 
 let checked_input cond attrs =
@@ -239,6 +249,10 @@ let connected_form service =
         ; toggle_group ~is_enabled:(is_static service) ~legend_text:"Static IP"
             ~toggle_field:"static_ip_enabled"
             [ static_ip_form service ]
+        ; toggle_group
+            ~is_enabled:(service.nameservers <> [])
+            ~legend_text:"Custom DNS" ~toggle_field:"nameservers_enabled"
+            [ nameservers_form service ]
         ; input
             ~a:
               [ a_input_type `Submit; a_class [ "d-Button" ]; a_value "Update" ]


### PR DESCRIPTION
Triggered by a support call, this separates configuration forms for DNS and static IP.

We introduced the ability to configure nameservers along with configuring static IP, since static IP normally requires configuring nameservers, too. But the converse is not true, it is very sensible to set custom nameservers in combination with obtaining IP via DHCP.

The current bundling forces setting a static IP just to work around some DNS issue, which makes things more challenging for users and introduces unnecessary coupling/brittleness.

We infrequently have customer installations where the DHCP-configured DNS server is causing problems in some way, especially with CloudFront distributions (e.g. issues in working with IPv6/IPv4; improper handling of [truncated DNS UDP packets](https://blog.apnic.net/2024/07/15/revisiting-dns-and-udp-truncation/)). Being able to just set another DNS server, without affecting DHCP would make resolving these much smoother and easier to instruct for local IT departments.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
-   [ ] User manual updated
