### PR TITLE
Switch to CloudFlare R2 for release disks

### DIFF
--- a/.github/workflows/gen-release-summary.sh
+++ b/.github/workflows/gen-release-summary.sh
@@ -25,7 +25,7 @@ echo -e "
 
 ## Artifacts
 
-- Test disk: [https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-release-disk-$RELEASE_TAG.img.zst](https://dividat-playos-test-disks.s3.amazonaws.com/by-tag/playos-release-disk-$RELEASE_TAG.img.zst)
+- Test disk: [https://playos-test-disks.dividump.xyz/by-tag/playos-release-disk-$RELEASE_TAG.img.zst](https://playos-test-disks.dividump.xyz/by-tag/playos-release-disk-$RELEASE_TAG.img.zst)
 
 ## Changelog
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -56,14 +56,12 @@ jobs:
       - name: Build release disk
         run: ./build release-disk
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3
-        with:
-          aws-access-key-id:  ${{ secrets.TEST_DISKS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TEST_DISKS_SECRET_ACCESS_KEY }}
-          aws-region: eu-central-1
-
-      - name: Publish to S3
+      - name: Publish to bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_TEST_DISKS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_TEST_DISKS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL: https://${{ secrets.CF_TEST_DISKS_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: ./.github/workflows/upload-test-disk.sh "$PLAYOS_VERSION"
 
       - name: Create Release summary

--- a/testing/release-validation.nix
+++ b/testing/release-validation.nix
@@ -46,7 +46,7 @@ let
     # and also fails when __structuredAttrs is disabled (due to
     # https://github.com/NixOS/nixpkgs/issues/177660).
     # HTTP usage is fine since the output hash is fixed and verifies the download.
-    baseS3URL = "http://dividat-playos-test-disks.s3.amazonaws.com/by-tag";
+    baseS3URL = "http://playos-test-disks.dividump.xyz/by-tag";
     # Generated via ./build release-disk and .github/workflows/release-tag.yml
     # See https://github.com/dividat/playos/releases
     diskImageURLs = {


### PR DESCRIPTION
Test run succeeded: https://github.com/dividat/playos/actions/runs/31599075862/job/94121670599

Checklist:
- [x] Copy disk images to R2
- [x] Delete temp CF migration credentials
- [x] Update all URLs in releases
- [x] Test that the `release-validation` tests work with the new location of disks
    - [https://github.com/dividat/playos/actions/runs/31693229996](https://github.com/dividat/playos/actions/runs/31693229996)
- [x] Delete AWS credentials from GH (post-merge)
- [x] Delete AWS bucket (post-merge)